### PR TITLE
Implementation for issue https://github.com/nextcloud/news/issues/38

### DIFF
--- a/lib/Db/Feed.php
+++ b/lib/Db/Feed.php
@@ -137,7 +137,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable {
             'basicAuthPassword'
         ]);
 
-        $url = parse_url($this->link)['host'];
+        $url = parse_url($this->link, PHP_URL_HOST);
 
         // strip leading www. to avoid css class confusion
         if (strpos($url, 'www.') === 0) {


### PR DESCRIPTION
Instead of the array return type use component parameter PHP_URL_HOST
to get the host part from the URL as string. This avoids an undefined
index warning if host part could not be found.