### PR TITLE
Remove 4-Byte Unicode characters from item body

### DIFF
--- a/lib/Db/Item.php
+++ b/lib/Db/Item.php
@@ -245,6 +245,15 @@ class Item extends Entity implements IAPI, \JsonSerializable {
     }
 
     public function setBody($body) {
+        // replace 4-byte unicode characters (e.g. Emoticons) with
+        // replacement character if DB does not explicitly support them.
+        // Don't just strip it for security/XSS reasons, see
+        // http://stackoverflow.com/questions/8491431/
+        // how-to-replace-remove-4-byte-characters-from-a-utf-8-string-in-php
+        //
+        // FIXME: This should only be necessary if OCP\IConfig\getSystemValue('mysql.utf8mb4') is not true
+        $body = preg_replace('/[\x{10000}-\x{10FFFF}]/u', "\xEF\xBF\xBD", $body);
+
         // FIXME: this should not happen if the target="_blank" is already
         // on the link
         parent::setBody(str_replace(


### PR DESCRIPTION
workaround for #53.

I don't have any experience in Owncloud/Nextcloud development, so I don't know how to properly check if Nextcloud is [configured to support 4-Byte-strings](https://github.com/nextcloud/server/pull/1773/commits/cc28f82b369c2e8ebf2d0b4390379b9cda4af40b#diff-2f769bc01ffefdf14eb04404218e7582R1109).