### PR TITLE
use non deprecated public api to register background job

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -16,6 +16,7 @@ namespace OCA\News\AppInfo;
 use HTMLPurifier;
 use HTMLPurifier_Config;
 
+use OCP\BackgroundJob\IJobList;
 use PicoFeed\Config\Config as PicoFeedConfig;
 use PicoFeed\Reader\Reader as PicoFeedReader;
 
@@ -63,7 +64,8 @@ class Application extends App {
         $this->registerService(AppConfig::class, function($c) {
             $config = new AppConfig(
                 $c->query(INavigationManager::class),
-                $c->query(IURLGenerator::class)
+                $c->query(IURLGenerator::class),
+                $c->query(IJobList::class)
             );
 
             $config->loadConfig($c->query('info'));

--- a/lib/Config/AppConfig.php
+++ b/lib/Config/AppConfig.php
@@ -13,6 +13,7 @@
 
 namespace OCA\News\Config;
 
+use OCP\BackgroundJob\IJobList;
 use SimpleXMLElement;
 
 use OCP\INavigationManager;
@@ -26,6 +27,7 @@ class AppConfig {
     private $config;
     private $navigationManager;
     private $urlGenerator;
+	private $jobList;
 
     /**
      * TODO: External deps that are needed:
@@ -33,10 +35,12 @@ class AppConfig {
      * - connect to hooks
      */
     public function __construct(INavigationManager $navigationManager,
-                                IURLGenerator $urlGenerator) {
+                                IURLGenerator $urlGenerator,
+                                IJobList $jobList) {
         $this->navigationManager = $navigationManager;
         $this->urlGenerator = $urlGenerator;
         $this->config = [];
+        $this->jobList = $jobList;
     }
 
 
@@ -83,9 +87,7 @@ class AppConfig {
     public function registerAll() {
         $this->registerNavigation();
         $this->registerHooks();
-        // IJob API is fucked up, so silence the code checker
-        $class = '\OCP\BackgroundJob';
-        $class::addRegularTask($this->config['cron']['job'], 'run');
+        $this->jobList->add('OC\BackgroundJob\Legacy\RegularJob', [$this->config['cron']['job'], 'run']);
         App::registerAdmin($this->config['id'], $this->config['admin']);
     }
 


### PR DESCRIPTION
nc11 finally removed the 3 year+ deprecated api

cc @BernhardPosselt 