### PR TITLE
Throw ServiceNotFoundException when marking non-existent item as read

### DIFF
--- a/lib/Service/ItemService.php
+++ b/lib/Service/ItemService.php
@@ -147,8 +147,12 @@ class ItemService extends Service {
      * @throws ServiceNotFoundException if the item does not exist
      */
     public function read($itemId, $isRead, $userId){
-        $lastModified = $this->timeFactory->getMicroTime();
-        $this->itemMapper->readItem($itemId, $isRead, $lastModified, $userId);
+        try {
+            $lastModified = $this->timeFactory->getMicroTime();
+            $this->itemMapper->readItem($itemId, $isRead, $lastModified, $userId);
+        } catch(DoesNotExistException $ex) {
+            throw new ServiceNotFoundException($ex->getMessage());
+        }
     }
 
 

--- a/tests/Unit/Service/ItemServiceTest.php
+++ b/tests/Unit/Service/ItemServiceTest.php
@@ -298,6 +298,18 @@ class ItemServiceTest extends \PHPUnit_Framework_TestCase {
     }
 
 
+    public function testReadDoesNotExist(){
+
+        $this->setExpectedException(
+            '\OCA\News\Service\ServiceNotFoundException'
+        );
+        $this->mapper->expects($this->once())
+            ->method('readItem')
+            ->will($this->throwException(new DoesNotExistException('')));
+
+        $this->itemService->read(1, true, $this->user);
+    }
+
     public function testStarDoesNotExist(){
 
         $this->setExpectedException(


### PR DESCRIPTION
Fix for #58 
Also add a test case for this