### PR TITLE
Add updatedDate to item model

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -329,6 +329,13 @@
                 <notnull>false</notnull>
             </field>
             <field>
+                <name>updated_date</name>
+                <type>integer</type>
+                <length>8</length>
+                <unsigned>true</unsigned>
+                <notnull>false</notnull>
+            </field>
+            <field>
                 <name>body</name>
                 <type>clob</type>
                 <notnull>false</notnull>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 Before you update to a new version, [check the changelog](https://github.com/nextcloud/news/blob/master/CHANGELOG.md) to avoid surprises.
 
 **Important**: To enable feed updates you will need to enable either [Nextcloud system cron](https://docs.nextcloud.com/server/10/admin_manual/configuration_server/background_jobs_configuration.html#cron) or use [an updater](https://github.com/owncloud/news-updater) which uses the built in update API and disable cron updates. More information can be found [in the README](https://github.com/nextcloud/news).]]></description>
-    <version>10.1.0</version>
+    <version>10.1.1</version>
     <licence>agpl</licence>
     <author>Bernhard Posselt</author>
     <author>Alessandro Cosentino</author>

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require": {
         "ezyang/htmlpurifier": "4.8",
-        "fguillot/picofeed": "dev-master#58a94dcefd12401cdb5a40017dfbbb960756e22a",
+        "fguillot/picofeed": "0.1.28",
         "pear/net_url2": "2.2.1",
         "riimu/kit-pathjoin": "1.1.2"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "7d53c930874a1103e790167b8d0e0d0c",
-    "content-hash": "2bd56b0f3d648651eb3470b5d003ef46",
+    "hash": "2aeb3a6a1ab336d16bf352f4e88f6825",
+    "content-hash": "ef2350b58d0ee66262400727956c9786",
     "packages": [
         {
             "name": "ezyang/htmlpurifier",
@@ -53,16 +53,16 @@
         },
         {
             "name": "fguillot/picofeed",
-            "version": "dev-master",
+            "version": "v0.1.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fguillot/picoFeed.git",
-                "reference": "58a94dcefd12401cdb5a40017dfbbb960756e22a"
+                "reference": "9da506c308bcb40b6fc630f9123466028c03170b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fguillot/picoFeed/zipball/58a94dcefd12401cdb5a40017dfbbb960756e22a",
-                "reference": "58a94dcefd12401cdb5a40017dfbbb960756e22a",
+                "url": "https://api.github.com/repos/fguillot/picoFeed/zipball/9da506c308bcb40b6fc630f9123466028c03170b",
+                "reference": "9da506c308bcb40b6fc630f9123466028c03170b",
                 "shasum": ""
             },
             "require": {
@@ -73,6 +73,11 @@
                 "ext-xml": "*",
                 "php": ">=5.3.0",
                 "zendframework/zendxml": "^1.0"
+            },
+            "require-dev": {
+                "phpdocumentor/reflection-docblock": "2.0.4",
+                "phpunit/phpunit": "4.8.26",
+                "symfony/yaml": "2.8.7"
             },
             "suggest": {
                 "ext-curl": "PicoFeed will use cURL if present"
@@ -97,7 +102,7 @@
             ],
             "description": "Modern library to handle RSS/Atom feeds",
             "homepage": "https://github.com/fguillot/picoFeed",
-            "time": "2016-12-09 00:31:15"
+            "time": "2016-12-29 00:06:41"
         },
         {
             "name": "pear/net_url2",
@@ -254,9 +259,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "fguillot/picofeed": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/lib/Db/Item.php
+++ b/lib/Db/Item.php
@@ -57,6 +57,7 @@ class Item extends Entity implements IAPI, \JsonSerializable {
     protected $title;
     protected $author;
     protected $pubDate;
+    protected $updatedDate;
     protected $body;
     protected $enclosureMime;
     protected $enclosureLink;
@@ -69,6 +70,7 @@ class Item extends Entity implements IAPI, \JsonSerializable {
 
     public function __construct() {
         $this->addType('pubDate', 'integer');
+        $this->addType('updatedDate', 'integer');
         $this->addType('feedId', 'integer');
         $this->addType('status', 'integer');
         $this->addType('rtl', 'boolean');
@@ -122,6 +124,7 @@ class Item extends Entity implements IAPI, \JsonSerializable {
             'title' => $this->getTitle(),
             'author' => $this->getAuthor(),
             'pubDate' => $this->getPubDate(),
+            'updatedDate' => $this->getUpdatedDate(),
             'body' => $this->getBody(),
             'enclosureMime' => $this->getEnclosureMime(),
             'enclosureLink' => $this->getEnclosureLink(),
@@ -144,6 +147,7 @@ class Item extends Entity implements IAPI, \JsonSerializable {
             'title' => $this->getTitle(),
             'author' => $this->getAuthor(),
             'pubDate' => $this->getPubDate(),
+            'updatedDate' => $this->getUpdatedDate(),
             'body' => $this->getBody(),
             'enclosureMime' => $this->getEnclosureMime(),
             'enclosureLink' => $this->getEnclosureLink(),
@@ -164,6 +168,7 @@ class Item extends Entity implements IAPI, \JsonSerializable {
             'title' => $this->getTitle(),
             'author' => $this->getAuthor(),
             'pubDate' => $this->getPubDate(),
+            'updatedDate' => $this->getUpdatedDate(),
             'body' => $this->getBody(),
             'enclosureMime' => $this->getEnclosureMime(),
             'enclosureLink' => $this->getEnclosureLink(),
@@ -186,6 +191,7 @@ class Item extends Entity implements IAPI, \JsonSerializable {
         $item->setTitle($import['title']);
         $item->setAuthor($import['author']);
         $item->setPubDate($import['pubDate']);
+        $item->setUpdatedDate($import['updatedDate']);
         $item->setBody($import['body']);
         $item->setEnclosureMime($import['enclosureMime']);
         $item->setEnclosureLink($import['enclosureLink']);

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -240,7 +240,8 @@ class FeedFetcher implements IFeedFetcher {
         $item->setUrl($parsedItem->getUrl());
         $item->setGuid($parsedItem->getId());
         $item->setGuidHash($item->getGuid());
-        $item->setPubDate($parsedItem->getDate()->getTimestamp());
+        $item->setPubDate($parsedItem->getPublishedDate()->getTimestamp());
+        $item->setUpdatedDate($parsedItem->getUpdatedDate()->getTimestamp());
         $item->setRtl($this->determineRtl($parsedItem, $parsedFeed));
 
         // unescape content because angularjs helps against XSS

--- a/lib/Service/FeedService.php
+++ b/lib/Service/FeedService.php
@@ -246,7 +246,7 @@ class FeedService extends Service {
 
                     // in case of update
                     if ($forceUpdate ||
-                        $item->getPubDate() > $dbItem->getPubDate()) {
+                        $item->getUpdatedDate() > $dbItem->getUpdatedDate()) {
 
                         $dbItem->setTitle($item->getTitle());
                         $dbItem->setUrl($item->getUrl());
@@ -255,6 +255,7 @@ class FeedService extends Service {
                         $dbItem->setRtl($item->getRtl());
                         $dbItem->setLastModified($item->getLastModified());
                         $dbItem->setPubDate($item->getPubDate());
+                        $dbItem->setUpdatedDate($item->getUpdatedDate());
                         $dbItem->setEnclosureMime($item->getEnclosureMime());
                         $dbItem->setEnclosureLink($item->getEnclosureLink());
                         $dbItem->setBody(

--- a/tests/Unit/Controller/ExportControllerTest.php
+++ b/tests/Unit/Controller/ExportControllerTest.php
@@ -119,10 +119,10 @@ class ExportControllerTest extends \PHPUnit_Framework_TestCase {
         );
 
         $this->assertEquals('[{"guid":null,"url":null,"title":null,' .
-            '"author":null,"pubDate":null,"body":null,"enclosureMime":null,' .
+            '"author":null,"pubDate":null,"updatedDate":null,"body":null,"enclosureMime":null,' .
             '"enclosureLink":null,"unread":false,"starred":false,' .
             '"feedLink":"http:\/\/goo","rtl":null},{"guid":null,"url":null,' .
-            '"title":null,"author":null,"pubDate":null,"body":null,' .
+            '"title":null,"author":null,"pubDate":null,"updatedDate":null,"body":null,' .
             '"enclosureMime":null,"enclosureLink":null,"unread":false,' .
             '"starred":false,"feedLink":"http:\/\/gee","rtl":null}]',
             $return->render());

--- a/tests/Unit/Db/ItemTest.php
+++ b/tests/Unit/Db/ItemTest.php
@@ -61,6 +61,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase {
         $item->setTitle('title');
         $item->setAuthor('author');
         $item->setPubDate(123);
+        $item->setUpdatedDate(234);
         $item->setBody('body');
         $item->setEnclosureMime('audio/ogg');
         $item->setEnclosureLink('enclink');
@@ -81,6 +82,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase {
             'title' => 'title',
             'author' => 'author',
             'pubDate' => 123,
+            'updatedDate' => 234,
             'body' => 'body',
             'enclosureMime' => 'audio/ogg',
             'enclosureLink' => 'enclink',
@@ -104,6 +106,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase {
         $item->setTitle('title');
         $item->setAuthor('author');
         $item->setPubDate(123);
+        $item->setUpdatedDate(234);
         $item->setBody('<body><div>this is a test</body>');
         $item->setEnclosureMime('audio/ogg');
         $item->setEnclosureLink('enclink');
@@ -123,6 +126,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase {
             'title' => 'title',
             'author' => 'author',
             'pubDate' => 123,
+            'updatedDate' => 234,
             'body' => '<body><div>this is a test</body>',
             'enclosureMime' => 'audio/ogg',
             'enclosureLink' => 'enclink',
@@ -145,6 +149,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase {
         $item->setTitle('title');
         $item->setAuthor('author');
         $item->setPubDate(123);
+        $item->setUpdatedDate(234);
         $item->setBody('body');
         $item->setEnclosureMime('audio/ogg');
         $item->setEnclosureLink('enclink');
@@ -165,6 +170,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase {
             'title' => 'title',
             'author' => 'author',
             'pubDate' => 123,
+            'updatedDate' => 234,
             'body' => 'body',
             'enclosureMime' => 'audio/ogg',
             'enclosureLink' => 'enclink',
@@ -184,6 +190,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase {
         $item->setTitle('title');
         $item->setAuthor('author');
         $item->setPubDate(123);
+        $item->setUpdatedDate(234);
         $item->setBody('body');
         $item->setEnclosureMime('audio/ogg');
         $item->setEnclosureLink('enclink');
@@ -221,6 +228,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase {
             'title' => $item->getTitle(),
             'author' => $item->getAuthor(),
             'pubDate' => $item->getPubDate(),
+            'updatedDate' => $item->getUpdatedDate(),
             'body' => $item->getBody(),
             'enclosureMime' => $item->getEnclosureMime(),
             'enclosureLink' => $item->getEnclosureLink(),
@@ -244,6 +252,7 @@ class ItemTest extends \PHPUnit_Framework_TestCase {
             'title' => $item->getTitle(),
             'author' => $item->getAuthor(),
             'pubDate' => $item->getPubDate(),
+            'updatedDate' => $item->getUpdatedDate(),
             'body' => $item->getBody(),
             'enclosureMime' => $item->getEnclosureMime(),
             'enclosureLink' => $item->getEnclosureLink(),

--- a/tests/Unit/Fetcher/FeedFetcherTest.php
+++ b/tests/Unit/Fetcher/FeedFetcherTest.php
@@ -38,6 +38,7 @@ class FeedFetcherTest extends \PHPUnit_Framework_TestCase {
     private $title;
     private $guid;
     private $pub;
+    private $updated;
     private $body;
     private $author;
     private $enclosureLink;
@@ -110,6 +111,7 @@ class FeedFetcherTest extends \PHPUnit_Framework_TestCase {
         $this->body2 = 'let the bodies hit the floor ' .
             '<a target="_blank" href="test">test</a>';
         $this->pub = 23111;
+        $this->updated = 23444;
         $this->author = '&lt;boogieman';
         $this->enclosureLink = 'http://enclosure.you';
 
@@ -209,10 +211,14 @@ class FeedFetcherTest extends \PHPUnit_Framework_TestCase {
         $item = new Item();
 
         date_default_timezone_set('America/Los_Angeles');
-        $date = new \DateTime();
-        $date->setTimestamp($this->pub);
-        $this->expectItem('getDate', $date);
+
+        $pubdate = \Datetime::createFromFormat('U',$this->pub);
+        $this->expectItem('getPublishedDate', $pubdate);
         $item->setPubDate($this->pub);
+
+        $update = \Datetime::createFromFormat('U',$this->updated);
+        $this->expectItem('getUpdatedDate', $update);
+        $item->setUpdatedDate($this->updated);
 
         $item->setStatus(0);
         $item->setUnread();

--- a/tests/Unit/Service/FeedServiceTest.php
+++ b/tests/Unit/Service/FeedServiceTest.php
@@ -384,6 +384,7 @@ class FeedServiceTest extends \PHPUnit_Framework_TestCase {
         $item->setGuidHash(md5('hi'));
         $item->setFeedId(3);
         $item->setPubDate(2);
+        $item->setUpdatedDate(2);
         $item->setTitle('hey');
         $item->setAuthor('aut');
         $item->setBody('new');
@@ -396,6 +397,7 @@ class FeedServiceTest extends \PHPUnit_Framework_TestCase {
         $item->setGuidHash(md5('hi'));
         $item->setFeedId(3);
         $item->setPubDate(1);
+        $item->setUpdatedDate(1);
         $item->setTitle('ho');
         $item->setAuthor('auto');
         $item->setBody('old');
@@ -403,7 +405,7 @@ class FeedServiceTest extends \PHPUnit_Framework_TestCase {
         return $item;
     }
 
-    public function testUpdateUpdatesWhenPubdateIsNewer() {
+    public function testUpdateUpdatesWhenUpdateddateIsNewer() {
         $feed = $this->createUpdateFeed();
         $item = $this->createUpdateItem();
         $item2 = $this->createUpdateItem2();


### PR DESCRIPTION
This is an updated version of #43, now that picoFeed has fallback values for pubDate (fguillot/picoFeed#293):

Implement your suggestions from https://github.com/owncloud/news/issues/982#issuecomment-213811774:

* update picoFeed to 0.1.28
* add updated_date to the database and bump version to 10.1.1
* use the new getPublishedDate and getUpdatedDate from picoFeed to set the corresponding item values
* adjust the unit tests