### PR TITLE
Correct link to "background_job_file"

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ System Cron:
 * Check the file permissions of the **cron.php** file and if **www-data** (or whatever your httpd user is called like) can read and execute that script
 * Check if you can execute the cron with **sudo -u www-data php -f nextcloud/cron.php** (replace www-data with your httpd user)
 * Check your **data/nextcloud.log** for errors
-* Check if the cronjob is ever executed by placing an **error_log('updating');** in the [background job file](https://github.com/nextcloud/news/blob/master/cron/updater.php#L28). If the cronjob runs, there should be an updating log statement in your httpd log.
+* Check if the cronjob is ever executed by placing an **error_log('updating');** in the [background job file](https://github.com/nextcloud/news/blob/master/lib/Cron/Updater.php#L28). If the cronjob runs, there should be an updating log statement in your httpd log.
 * If there is no **updating** statement in your logs check if your cronjob is executed by executing a different script
 * Check if the **oc_jobs** table has a **reserved_at** entry with a value other than 0. If it does for whatever reason, set it to 0. You can check this by executing:
 


### PR DESCRIPTION
In https://github.com/nextcloud/news/commit/004fcbbcc7609ca83807f2e38967ef54f469bf72#diff-d9c8edc6e6e9557c91d113ede10ef894 the directory layout has been updated, but unfortunately it was forgotten to update the link for the new layout.