### PR TITLE
[APIv2] Add batchSize route parameter to /sync route

### DIFF
--- a/docs/externalapi/External-Api.md
+++ b/docs/externalapi/External-Api.md
@@ -177,6 +177,8 @@ The intial sync happens when a user adds an ownCloud account in your app. In tha
 
 * **Method**: GET
 * **Route**: /sync
+* **Route Parameters**:
+  * **{batchSize}**: limit number of returned items to `batchSize`
 * **Authentication**: [required](#authentication)
 * **HTTP headers**:
   * **Accept: "application/json"**


### PR DESCRIPTION
Some users have several thousands unread articles, fetching them all at once can lead to timeouts or memory issues.

So I propose adding a `batchSize` parameter to the `/sync` route to limit the number of items being fetched in one call.