### PR TITLE
Fix include of “warning” template

### DIFF
--- a/templates/part.content.explore.php
+++ b/templates/part.content.explore.php
@@ -1,4 +1,4 @@
-<?php print_unescaped($this->inc('part.content.cronwarning')) ?>
+<?php print_unescaped($this->inc('part.content.warnings')) ?>
 
 <div id="explore">
     <!--<div class="explore-filter">

--- a/templates/part.content.shortcuts.php
+++ b/templates/part.content.shortcuts.php
@@ -1,4 +1,4 @@
-<?php print_unescaped($this->inc('part.content.cronwarning')) ?>
+<?php print_unescaped($this->inc('part.content.warnings')) ?>
 
 <div id="app-shortcuts">
     <div>


### PR DESCRIPTION
Fix include statement in some templates from `part.content.cronwarning.php` to `part.content.warning.php` (see #166 ).