### PR TITLE
Fix #163, use IDBConnection->supports4ByteText()

### DIFF
--- a/lib/Service/StatusService.php
+++ b/lib/Service/StatusService.php
@@ -59,15 +59,9 @@ class StatusService {
             'version' => $version,
             'warnings' => [
                 'improperlyConfiguredCron' => !$this->isProperlyConfigured(),
-                'incorrectDbCharset' => $this->hasIncorrectCharset()
+                'incorrectDbCharset' => !$this->connection->supports4ByteText()
             ]
         ];
-    }
-
-    public function hasIncorrectCharset() {
-        $charset = $this->connection->getParams()['charset'];
-        $platform = $this->connection->getDatabasePlatform();
-        return $platform instanceof MySqlPlatform && $charset !== 'utf8mb4';
     }
 
 }


### PR DESCRIPTION
Instead of the buggy StatusService->hasIncorrectCharset, use
the already available IDBConnection->supports4ByteText() to
determine if 4byte unicode is supported.

Haven't ran unit tests on this one yet, because 'make test' bombs on me (PHP Fatal error:  Trait 'OCA\News\Controller\JSONHttpError' not found in /home/gmc/src/3rdparty/nextcloud/nextcloud-git/apps/news/tests/Unit/Controller/JSONHttpErrorTest.php on line 18).