### PR TITLE
Make headline title configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Replaced url of utf8mb4 instructions to stack exchange with nextcloud-specific page, #181
+- Created user setting for populating title of news headlines 
 
 ## 11.0.5
 

--- a/js/controller/ContentController.js
+++ b/js/controller/ContentController.js
@@ -130,6 +130,11 @@ app.controller('ContentController',
             return !SettingsResource.get('preventReadOnScroll');
         };
 
+        this.showHeadlineAsTitle = function () {
+            return SettingsResource.get('showHeadlineAsTitle');
+        };
+
+
         this.scrollRead = function (itemIds) {
             var ids = [];
             var feedIds = [];

--- a/js/service/SettingsResource.js
+++ b/js/service/SettingsResource.js
@@ -19,7 +19,8 @@ app.service('SettingsResource', function ($http, BASE_URL) {
         oldestFirst: null,
         preventReadOnScroll: false,
         compactExpand: false,
-        exploreUrl: ''
+        exploreUrl: '',
+        showHeadlineAsTitle: false
     };
     this.defaultLanguageCode = 'en';
     this.supportedLanguageCodes = [
@@ -63,7 +64,8 @@ app.service('SettingsResource', function ($http, BASE_URL) {
                 compact: this.settings.compact,
                 oldestFirst: this.settings.oldestFirst,
                 compactExpand: this.settings.compactExpand,
-                preventReadOnScroll: this.settings.preventReadOnScroll
+                preventReadOnScroll: this.settings.preventReadOnScroll,
+                showHeadlineAsTitle: this.settings.showHeadlineAsTitle
             }
         });
     };

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -97,7 +97,8 @@ class PageController extends Controller {
             'compact',
             'preventReadOnScroll',
             'oldestFirst',
-            'compactExpand'
+            'compactExpand',
+            'showHeadlineAsTitle'
         ];
 
         $exploreUrl = $this->config->getExploreUrl();
@@ -130,14 +131,16 @@ class PageController extends Controller {
      * @param bool $compact
      * @param bool $preventReadOnScroll
      * @param bool $oldestFirst
+     * @param bool $showHeadlineAsTitle
      */
     public function updateSettings($showAll, $compact, $preventReadOnScroll,
-                                   $oldestFirst, $compactExpand) {
+                                   $oldestFirst, $compactExpand, $showHeadlineAsTitle) {
         $settings = ['showAll',
             'compact',
             'preventReadOnScroll',
             'oldestFirst',
-            'compactExpand'
+            'compactExpand',
+            'showHeadlineAsTitle'
         ];
 
         foreach ($settings as $setting) {

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -35,6 +35,7 @@
                         </a>
                     </li>
                     <li class="title only-in-compact"
+                    title="{{ (Content.showHeadlineAsTitle() ? item.title : '') }}"
                         ng-class="{
                             'icon-rss':
                                 !Content.getFeed(item.feedId).faviconLink

--- a/templates/part.settings.php
+++ b/templates/part.settings.php
@@ -56,6 +56,15 @@
                        id="settings-oldestFirst">
                 <label for="settings-oldestFirst"><?php p($l->t('Reverse ordering (oldest on top)')); ?></label>
             </li>
+            <li class="settings-fieldset-interior-item">
+                <input type="checkbox"
+                       class="checkbox"
+                       ng-click="Settings.toggleSetting('showHeadlineAsTitle')"
+                       ng-checked="Settings.getSetting('showHeadlineAsTitle')"
+                       name="oldestFirst"
+                       id="settings-showHeadlineAsTitle">
+                <label for="settings-showHeadlineAsTitle"><?php p($l->t('Show the headline in mouseover')); ?></label>
+            </li>
         </ul>
     </fieldset>
 


### PR DESCRIPTION
#151 - I found this functionality useful if you have a feed with a lot of long headlines and are using compact mode. Added a setting to control this behavior.