### PR TITLE
Use trusty and postgresql 9.6 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-dist: precise
+dist: trusty
 language: php
 php:
     - 5.6
@@ -61,7 +61,7 @@ after_failure:
 
 addons:
     firefox: "latest"
-    postgresql: "9.4"
+    postgresql: "9.6"
 
 services:
     - mysql


### PR DESCRIPTION
The issue with mysql on trusty containers has been solved, so we can switch the tests to use trusty and postgresql 9.6