### PR TITLE
Fix the error RSS source overlay

### DIFF
--- a/css/navigation.css
+++ b/css/navigation.css
@@ -135,6 +135,7 @@
     background-color: #DE1212;
     color: #fff;
     position: relative;
+    overflow-y: auto;
 }
 
 #app-navigation .ui-state-disabled {


### PR DESCRIPTION
There is a close icon in error message. Since the close icon is overlaid, it causes users cannot click that.

Screenshots:

**Origin**
![nextcloud_news_overlay](https://user-images.githubusercontent.com/2720857/38183410-bdbfe25a-362f-11e8-9d77-a0a84c4571d0.jpg)

**Fixed**
![nextcloud_news_overflow](https://user-images.githubusercontent.com/2720857/38183481-2f4dd2d8-3630-11e8-971e-acb7d98f80e7.jpg)

