### PR TITLE
Entity setters + getters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "source": "https://github.com/nextcloud/news/"
     },
     "require": {
+        "php": "^7.0",
         "ezyang/htmlpurifier": "4.9.3",
         "miniflux/picofeed": "0.1.34",
         "pear/net_url2": "2.2.1",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "source": "https://github.com/nextcloud/news/"
     },
     "require": {
-        "php": "^7.0",
         "ezyang/htmlpurifier": "4.9.3",
         "miniflux/picofeed": "0.1.34",
         "pear/net_url2": "2.2.1",

--- a/lib/Db/Feed.php
+++ b/lib/Db/Feed.php
@@ -15,105 +15,64 @@ namespace OCA\News\Db;
 
 use \OCP\AppFramework\Db\Entity;
 
-/**
- * @method integer getId()
- * @method void setId(integer $value)
- * @method string getUserId()
- * @method void setUserId(string $value)
- * @method int getOrdering()
- * @method void setOrdering(integer $value)
- * @method string getUrlHash()
- * @method void setUrlHash(string $value)
- * @method string getLocation()
- * @method void setLocation(string $value)
- * @method string getUrl()
- * @method string getTitle()
- * @method void setTitle(string $value)
- * @method string getLastModified()
- * @method void setLastModified(string $value)
- * @method string getHttpLastModified()
- * @method void setHttpLastModified(string $value)
- * @method string getHttpEtag()
- * @method void setHttpEtag(string $value)
- * @method string getFaviconLink()
- * @method void setFaviconLink(string $value)
- * @method integer getAdded()
- * @method void setAdded(integer $value)
- * @method boolean getPinned()
- * @method void setPinned(boolean $value)
- * @method integer getFolderId()
- * @method void setFolderId(integer $value)
- * @method integer getFullTextEnabled()
- * @method void setFullTextEnabled(bool $value)
- * @method integer getUnreadCount()
- * @method void setUnreadCount(integer $value)
- * @method string getLink()
- * @method boolean getPreventUpdate()
- * @method void setPreventUpdate(boolean $value)
- * @method integer getDeletedAt()
- * @method void setDeletedAt(integer $value)
- * @method integer getArticlesPerUpdate()
- * @method void setArticlesPerUpdate(integer $value)
- * @method integer getUpdateErrorCount()
- * @method void setUpdateErrorCount(integer $value)
- * @method string getLastUpdateError()
- * @method void setLastUpdateError(string $value)
- * @method string getBasicAuthUser()
- * @method void setBasicAuthUser(string $value)
- * @method string getBasicAuthPassword()
- * @method void setBasicAuthPassword(string $value)
- */
 class Feed extends Entity implements IAPI, \JsonSerializable
 {
 
     use EntityJSONSerializer;
 
+    /** @var string */
     protected $userId;
+    /** @var string */
     protected $urlHash;
+    /** @var string */
     protected $url;
+    /** @var string */
     protected $title;
+    /** @var string */
     protected $faviconLink;
+    /** @var int */
     protected $added;
+    /** @var int */
     protected $folderId;
+    /** @var int */
     protected $unreadCount;
+    /** @var string */
     protected $link;
+    /** @var bool */
     protected $preventUpdate;
+    /** @var int */
     protected $deletedAt;
+    /** @var int */
     protected $articlesPerUpdate;
+    /** @var string */
     protected $httpLastModified;
+    /** @var string */
     protected $lastModified;
+    /** @var string */
     protected $httpEtag;
+    /** @var string */
     protected $location;
+    /** @var int */
     protected $ordering;
+    /** @var bool */
     protected $fullTextEnabled;
+    /** @var bool */
     protected $pinned;
+    /** @var int */
     protected $updateMode;
+    /** @var int */
     protected $updateErrorCount;
+    /** @var string */
     protected $lastUpdateError;
+    /** @var string */
     protected $basicAuthUser;
+    /** @var string */
     protected $basicAuthPassword;
-
-    public function __construct()
-    {
-        $this->addType('parentId', 'integer');
-        $this->addType('added', 'integer');
-        $this->addType('folderId', 'integer');
-        $this->addType('unreadCount', 'integer');
-        $this->addType('preventUpdate', 'boolean');
-        $this->addType('pinned', 'boolean');
-        $this->addType('deletedAt', 'integer');
-        $this->addType('articlesPerUpdate', 'integer');
-        $this->addType('ordering', 'integer');
-        $this->addType('fullTextEnabled', 'boolean');
-        $this->addType('updateMode', 'integer');
-        $this->addType('updateErrorCount', 'integer');
-    }
-
 
     /**
      * Turns entitie attributes into an array
      */
-    public function jsonSerialize() 
+    public function jsonSerialize()
     {
         $serialized = $this->serializeFields(
             [
@@ -155,7 +114,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     }
 
 
-    public function toAPI() 
+    public function toAPI()
     {
         return $this->serializeFields(
             [
@@ -175,24 +134,481 @@ class Feed extends Entity implements IAPI, \JsonSerializable
         );
     }
 
-
-    public function setUrl($url) 
+    /**
+     * @return int
+     */
+    public function getId()
     {
-        $url = trim($url);
-        if(strpos($url, 'http') === 0) {
-            parent::setUrl($url);
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        if ($this->id !== $id) {
+            $this->id = (int)$id;
+            $this->markFieldUpdated('id');
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getUserId()
+    {
+        return $this->userId;
+    }
+
+    /**
+     * @param string $userId
+     */
+    public function setUserId($userId)
+    {
+        if ($this->userId !== $userId) {
+            $this->userId = (string)$userId;
+            $this->markFieldUpdated('userId');
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrlHash()
+    {
+        return $this->urlHash;
+    }
+
+    /**
+     * @param string $urlHash
+     */
+    public function setUrlHash($urlHash)
+    {
+        if ($this->urlHash !== $urlHash) {
+            $this->urlHash = (string)$urlHash;
+            $this->markFieldUpdated('urlHash');
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param string $url
+     */
+    public function setUrl($url)
+    {
+        $url = trim((string)$url);
+        if(strpos($url, 'http') === 0 && $this->url !== $url) {
+            $this->url = $url;
             $this->setUrlHash(md5($url));
+            $this->markFieldUpdated('url');
         }
     }
 
-
-    public function setLink($url) 
+    /**
+     * @return string
+     */
+    public function getTitle()
     {
-        $url = trim($url);
-        if(strpos($url, 'http') === 0) {
-            parent::setLink($url);
+        return $this->title;
+    }
+
+    /**
+     * @param string $title
+     */
+    public function setTitle($title)
+    {
+        if ($this->title !== $title) {
+            $this->title = (string)$title;
+            $this->markFieldUpdated('title');
         }
     }
 
+    /**
+     * @return string
+     */
+    public function getFaviconLink()
+    {
+        return $this->faviconLink;
+    }
 
+    /**
+     * @param string $faviconLink
+     */
+    public function setFaviconLink($faviconLink)
+    {
+        if ($this->faviconLink !== $faviconLink) {
+            $this->faviconLink = (string)$faviconLink;
+            $this->markFieldUpdated('faviconLink');
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getAdded()
+    {
+        return $this->added;
+    }
+
+    /**
+     * @param int $added
+     */
+    public function setAdded($added)
+    {
+        if ($this->added !== $added) {
+            $this->added = (int)$added;
+            $this->markFieldUpdated('added');
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getFolderId()
+    {
+        return $this->folderId;
+    }
+
+    /**
+     * @param int $folderId
+     */
+    public function setFolderId($folderId)
+    {
+        if ($this->folderId !== $folderId) {
+            $this->folderId = (int)$folderId;
+            $this->markFieldUpdated('folderId');
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getUnreadCount()
+    {
+        return $this->unreadCount;
+    }
+
+    /**
+     * @param int $unreadCount
+     */
+    public function setUnreadCount($unreadCount)
+    {
+        if ($this->unreadCount !== $unreadCount) {
+            $this->unreadCount = (int)$unreadCount;
+            $this->markFieldUpdated('unreadCount');
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getLink()
+    {
+        return $this->link;
+    }
+
+    /**
+     * @param string $link
+     */
+    public function setLink($link)
+    {
+        $link = trim((string)$link);
+        if(strpos($link, 'http') === 0 && $this->link !== $link) {
+            $this->link = (string)$link;
+            $this->markFieldUpdated('link');
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function getPreventUpdate()
+    {
+        return $this->preventUpdate;
+    }
+
+    /**
+     * @param bool $preventUpdate
+     */
+    public function setPreventUpdate($preventUpdate)
+    {
+        if ($this->preventUpdate !== $preventUpdate) {
+            $this->preventUpdate = (bool)$preventUpdate;
+            $this->markFieldUpdated('preventUpdate');
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getDeletedAt()
+    {
+        return $this->deletedAt;
+    }
+
+    /**
+     * @param int $deletedAt
+     */
+    public function setDeletedAt($deletedAt)
+    {
+        if ($this->deletedAt !== $deletedAt) {
+            $this->deletedAt = (int)$deletedAt;
+            $this->markFieldUpdated('deletedAt');
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getArticlesPerUpdate()
+    {
+        return $this->articlesPerUpdate;
+    }
+
+    /**
+     * @param int $articlesPerUpdate
+     */
+    public function setArticlesPerUpdate($articlesPerUpdate)
+    {
+        if ($this->articlesPerUpdate !== $articlesPerUpdate) {
+            $this->articlesPerUpdate = (int)$articlesPerUpdate;
+            $this->markFieldUpdated('articlesPerUpdate');
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getHttpLastModified()
+    {
+        return $this->httpLastModified;
+    }
+
+    /**
+     * @param string $httpLastModified
+     */
+    public function setHttpLastModified($httpLastModified)
+    {
+        if ($this->httpLastModified !== $httpLastModified) {
+            $this->httpLastModified = (string)$httpLastModified;
+            $this->markFieldUpdated('httpLastModified');
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getLastModified()
+    {
+        return $this->lastModified;
+    }
+
+    /**
+     * @param string $lastModified
+     */
+    public function setLastModified($lastModified)
+    {
+        if ($this->lastModified !== $lastModified) {
+            $this->lastModified = (string)$lastModified;
+            $this->markFieldUpdated('lastModified');
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getHttpEtag()
+    {
+        return $this->httpEtag;
+    }
+
+    /**
+     * @param string $httpEtag
+     */
+    public function setHttpEtag($httpEtag)
+    {
+        if ($this->httpEtag !== $httpEtag) {
+            $this->httpEtag = (string)$httpEtag;
+            $this->markFieldUpdated('httpEtag');
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocation()
+    {
+        return $this->location;
+    }
+
+    /**
+     * @param string $location
+     */
+    public function setLocation($location)
+    {
+        if ($this->location !== $location) {
+            $this->location = (string)$location;
+            $this->markFieldUpdated('location');
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getOrdering()
+    {
+        return $this->ordering;
+    }
+
+    /**
+     * @param int $ordering
+     */
+    public function setOrdering($ordering)
+    {
+        if ($this->ordering !== $ordering) {
+            $this->ordering = (int)$ordering;
+            $this->markFieldUpdated('ordering');
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function getFullTextEnabled()
+    {
+        return $this->fullTextEnabled;
+    }
+
+    /**
+     * @param bool $fullTextEnabled
+     */
+    public function setFullTextEnabled($fullTextEnabled)
+    {
+        if ($this->fullTextEnabled !== $fullTextEnabled) {
+            $this->fullTextEnabled = (bool)$fullTextEnabled;
+            $this->markFieldUpdated('fullTextEnabled');
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function getPinned()
+    {
+        return $this->pinned;
+    }
+
+    /**
+     * @param bool $pinned
+     */
+    public function setPinned($pinned)
+    {
+        if ($this->pinned !== $pinned) {
+            $this->pinned = (bool)$pinned;
+            $this->markFieldUpdated('pinned');
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getUpdateMode()
+    {
+        return $this->updateMode;
+    }
+
+    /**
+     * @param int $updateMode
+     */
+    public function setUpdateMode($updateMode)
+    {
+        if ($this->updateMode !== $updateMode) {
+            $this->updateMode = (int)$updateMode;
+            $this->markFieldUpdated('updateMode');
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getUpdateErrorCount()
+    {
+        return $this->updateErrorCount;
+    }
+
+    /**
+     * @param int $updateErrorCount
+     */
+    public function setUpdateErrorCount($updateErrorCount)
+    {
+        if ($this->updateErrorCount !== $updateErrorCount) {
+            $this->updateErrorCount = (int)$updateErrorCount;
+            $this->markFieldUpdated('updateErrorCount');
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getLastUpdateError()
+    {
+        return $this->lastUpdateError;
+    }
+
+    /**
+     * @param string $lastUpdateError
+     */
+    public function setLastUpdateError($lastUpdateError)
+    {
+        if ($this->lastUpdateError !== $lastUpdateError) {
+            $this->lastUpdateError = (string)$lastUpdateError;
+            $this->markFieldUpdated('lastUpdateError');
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getBasicAuthUser()
+    {
+        return $this->basicAuthUser;
+    }
+
+    /**
+     * @param string $basicAuthUser
+     */
+    public function setBasicAuthUser($basicAuthUser)
+    {
+        if ($this->basicAuthUser !== $basicAuthUser) {
+            $this->basicAuthUser = (string)$basicAuthUser;
+            $this->markFieldUpdated('basicAuthUser');
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getBasicAuthPassword()
+    {
+        return $this->basicAuthPassword;
+    }
+
+    /**
+     * @param string $basicAuthPassword
+     */
+    public function setBasicAuthPassword($basicAuthPassword)
+    {
+        if ($this->basicAuthPassword !== $basicAuthPassword) {
+            $this->basicAuthPassword = (string)$basicAuthPassword;
+            $this->markFieldUpdated('basicAuthPassword');
+        }
+    }
 }

--- a/lib/Db/Feed.php
+++ b/lib/Db/Feed.php
@@ -13,7 +13,7 @@
 
 namespace OCA\News\Db;
 
-use \OCP\AppFramework\Db\Entity;
+use OCP\AppFramework\Db\Entity;
 
 class Feed extends Entity implements IAPI, \JsonSerializable
 {
@@ -70,12 +70,211 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     protected $basicAuthPassword = '';
 
     /**
+     * @return int|null
+     */
+    public function getAdded()
+    {
+        return $this->added;
+    }
+
+    /**
+     * @return int
+     */
+    public function getArticlesPerUpdate(): int
+    {
+        return $this->articlesPerUpdate;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getBasicAuthPassword()
+    {
+        return $this->basicAuthPassword;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getBasicAuthUser()
+    {
+        return $this->basicAuthUser;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getDeletedAt()
+    {
+        return $this->deletedAt;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getFaviconLink()
+    {
+        return $this->faviconLink;
+    }
+
+    /**
+     * @return int
+     */
+    public function getFolderId(): int
+    {
+        return $this->folderId;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getFullTextEnabled(): bool
+    {
+        return $this->fullTextEnabled;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getHttpEtag()
+    {
+        return $this->httpEtag;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getHttpLastModified()
+    {
+        return $this->httpLastModified;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getLastModified()
+    {
+        return $this->lastModified;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getLastUpdateError()
+    {
+        return $this->lastUpdateError;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getLink()
+    {
+        return $this->link;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getLocation()
+    {
+        return $this->location;
+    }
+
+    /**
+     * @return int
+     */
+    public function getOrdering(): int
+    {
+        return $this->ordering;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getPinned(): bool
+    {
+        return $this->pinned;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getPreventUpdate(): bool
+    {
+        return $this->preventUpdate;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return int
+     */
+    public function getUnreadCount(): int
+    {
+        return $this->unreadCount;
+    }
+
+    /**
+     * @return int
+     */
+    public function getUpdateErrorCount(): int
+    {
+        return $this->updateErrorCount;
+    }
+
+    /**
+     * @return int
+     */
+    public function getUpdateMode(): int
+    {
+        return $this->updateMode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrlHash(): string
+    {
+        return $this->urlHash;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUserId(): string
+    {
+        return $this->userId;
+    }
+
+    /**
      * Turns entity attributes into an array
      */
     public function jsonSerialize(): array
     {
-        $serialized = $this->serializeFields(
-            [
+        $serialized = $this->serializeFields([
             'id',
             'userId',
             'urlHash',
@@ -98,8 +297,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable
             'lastUpdateError',
             'basicAuthUser',
             'basicAuthPassword'
-            ]
-        );
+        ]);
 
         $url = parse_url($this->link, PHP_URL_HOST);
 
@@ -111,151 +309,6 @@ class Feed extends Entity implements IAPI, \JsonSerializable
         $serialized['cssClass'] = 'custom-' . str_replace('.', '-', $url);
 
         return $serialized;
-    }
-
-
-    public function toAPI(): array
-    {
-        return $this->serializeFields(
-            [
-            'id',
-            'url',
-            'title',
-            'faviconLink',
-            'added',
-            'folderId',
-            'unreadCount',
-            'ordering',
-            'link',
-            'pinned',
-            'updateErrorCount',
-            'lastUpdateError'
-            ]
-        );
-    }
-
-    /**
-     * @return int
-     */
-    public function getId(): int
-    {
-        return $this->id;
-    }
-
-    /**
-     * @param int $id
-     */
-    public function setId(int $id)
-    {
-        if ($this->id !== $id) {
-            $this->id = $id;
-            $this->markFieldUpdated('id');
-        }
-    }
-
-    /**
-     * @return string
-     */
-    public function getUserId(): string
-    {
-        return $this->userId;
-    }
-
-    /**
-     * @param string $userId
-     */
-    public function setUserId(string $userId)
-    {
-        if ($this->userId !== $userId) {
-            $this->userId = $userId;
-            $this->markFieldUpdated('userId');
-        }
-    }
-
-    /**
-     * @return string
-     */
-    public function getUrlHash(): string
-    {
-        return $this->urlHash;
-    }
-
-    /**
-     * @param string $urlHash
-     */
-    public function setUrlHash(string $urlHash)
-    {
-        if ($this->urlHash !== $urlHash) {
-            $this->urlHash = $urlHash;
-            $this->markFieldUpdated('urlHash');
-        }
-    }
-
-    /**
-     * @return string
-     */
-    public function getUrl(): string
-    {
-        return $this->url;
-    }
-
-    /**
-     * @param string $url
-     */
-    public function setUrl(string $url)
-    {
-        $url = trim($url);
-        if(strpos($url, 'http') === 0 && $this->url !== $url) {
-            $this->url = $url;
-            $this->setUrlHash(md5($url));
-            $this->markFieldUpdated('url');
-        }
-    }
-
-    /**
-     * @return string
-     */
-    public function getTitle(): string
-    {
-        return $this->title;
-    }
-
-    /**
-     * @param string $title
-     */
-    public function setTitle(string $title)
-    {
-        if ($this->title !== $title) {
-            $this->title = $title;
-            $this->markFieldUpdated('title');
-        }
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getFaviconLink()
-    {
-        return $this->faviconLink;
-    }
-
-    /**
-     * @param string|null $faviconLink
-     */
-    public function setFaviconLink(string $faviconLink = null)
-    {
-        if ($this->faviconLink !== $faviconLink) {
-            $this->faviconLink = $faviconLink;
-            $this->markFieldUpdated('faviconLink');
-        }
-    }
-
-    /**
-     * @return int|null
-     */
-    public function getAdded()
-    {
-        return $this->added;
     }
 
     /**
@@ -270,110 +323,6 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     }
 
     /**
-     * @return int
-     */
-    public function getFolderId(): int
-    {
-        return $this->folderId;
-    }
-
-    /**
-     * @param int $folderId
-     */
-    public function setFolderId(int $folderId)
-    {
-        if ($this->folderId !== $folderId) {
-            $this->folderId = $folderId;
-            $this->markFieldUpdated('folderId');
-        }
-    }
-
-    /**
-     * @return int
-     */
-    public function getUnreadCount(): int
-    {
-        return $this->unreadCount;
-    }
-
-    /**
-     * @param int $unreadCount
-     */
-    public function setUnreadCount(int $unreadCount)
-    {
-        if ($this->unreadCount !== $unreadCount) {
-            $this->unreadCount = $unreadCount;
-            $this->markFieldUpdated('unreadCount');
-        }
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getLink()
-    {
-        return $this->link;
-    }
-
-    /**
-     * @param string|null $link
-     */
-    public function setLink(string $link = null)
-    {
-        $link = trim($link);
-        if(strpos($link, 'http') === 0 && $this->link !== $link) {
-            $this->link = $link;
-            $this->markFieldUpdated('link');
-        }
-    }
-
-    /**
-     * @return bool
-     */
-    public function getPreventUpdate(): bool
-    {
-        return $this->preventUpdate;
-    }
-
-    /**
-     * @param bool $preventUpdate
-     */
-    public function setPreventUpdate(bool $preventUpdate)
-    {
-        if ($this->preventUpdate !== $preventUpdate) {
-            $this->preventUpdate = $preventUpdate;
-            $this->markFieldUpdated('preventUpdate');
-        }
-    }
-
-    /**
-     * @return int|null
-     */
-    public function getDeletedAt()
-    {
-        return $this->deletedAt;
-    }
-
-    /**
-     * @param int|null $deletedAt
-     */
-    public function setDeletedAt(int $deletedAt = null)
-    {
-        if ($this->deletedAt !== $deletedAt) {
-            $this->deletedAt = $deletedAt;
-            $this->markFieldUpdated('deletedAt');
-        }
-    }
-
-    /**
-     * @return int
-     */
-    public function getArticlesPerUpdate(): int
-    {
-        return $this->articlesPerUpdate;
-    }
-
-    /**
      * @param int $articlesPerUpdate
      */
     public function setArticlesPerUpdate(int $articlesPerUpdate)
@@ -385,201 +334,14 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     }
 
     /**
-     * @return string|null
+     * @param string|null $basicAuthPassword
      */
-    public function getHttpLastModified()
+    public function setBasicAuthPassword(string $basicAuthPassword = null)
     {
-        return $this->httpLastModified;
-    }
-
-    /**
-     * @param string|null $httpLastModified
-     */
-    public function setHttpLastModified(string $httpLastModified = null)
-    {
-        if ($this->httpLastModified !== $httpLastModified) {
-            $this->httpLastModified = $httpLastModified;
-            $this->markFieldUpdated('httpLastModified');
+        if ($this->basicAuthPassword !== $basicAuthPassword) {
+            $this->basicAuthPassword = $basicAuthPassword;
+            $this->markFieldUpdated('basicAuthPassword');
         }
-    }
-
-    /**
-     * @return int|null
-     */
-    public function getLastModified()
-    {
-        return $this->lastModified;
-    }
-
-    /**
-     * @param int|null $lastModified
-     */
-    public function setLastModified(int $lastModified = null)
-    {
-        if ($this->lastModified !== $lastModified) {
-            $this->lastModified = $lastModified;
-            $this->markFieldUpdated('lastModified');
-        }
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getHttpEtag()
-    {
-        return $this->httpEtag;
-    }
-
-    /**
-     * @param string|null $httpEtag
-     */
-    public function setHttpEtag(string $httpEtag = null)
-    {
-        if ($this->httpEtag !== $httpEtag) {
-            $this->httpEtag = $httpEtag;
-            $this->markFieldUpdated('httpEtag');
-        }
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getLocation()
-    {
-        return $this->location;
-    }
-
-    /**
-     * @param string|null $location
-     */
-    public function setLocation(string $location = null)
-    {
-        if ($this->location !== $location) {
-            $this->location = $location;
-            $this->markFieldUpdated('location');
-        }
-    }
-
-    /**
-     * @return int
-     */
-    public function getOrdering(): int
-    {
-        return $this->ordering;
-    }
-
-    /**
-     * @param int $ordering
-     */
-    public function setOrdering(int $ordering)
-    {
-        if ($this->ordering !== $ordering) {
-            $this->ordering = $ordering;
-            $this->markFieldUpdated('ordering');
-        }
-    }
-
-    /**
-     * @return bool
-     */
-    public function getFullTextEnabled(): bool
-    {
-        return $this->fullTextEnabled;
-    }
-
-    /**
-     * @param bool $fullTextEnabled
-     */
-    public function setFullTextEnabled(bool $fullTextEnabled)
-    {
-        if ($this->fullTextEnabled !== $fullTextEnabled) {
-            $this->fullTextEnabled = $fullTextEnabled;
-            $this->markFieldUpdated('fullTextEnabled');
-        }
-    }
-
-    /**
-     * @return bool
-     */
-    public function getPinned(): bool
-    {
-        return $this->pinned;
-    }
-
-    /**
-     * @param bool $pinned
-     */
-    public function setPinned(bool $pinned)
-    {
-        if ($this->pinned !== $pinned) {
-            $this->pinned = $pinned;
-            $this->markFieldUpdated('pinned');
-        }
-    }
-
-    /**
-     * @return int
-     */
-    public function getUpdateMode(): int
-    {
-        return $this->updateMode;
-    }
-
-    /**
-     * @param int $updateMode
-     */
-    public function setUpdateMode(int $updateMode)
-    {
-        if ($this->updateMode !== $updateMode) {
-            $this->updateMode = $updateMode;
-            $this->markFieldUpdated('updateMode');
-        }
-    }
-
-    /**
-     * @return int
-     */
-    public function getUpdateErrorCount(): int
-    {
-        return $this->updateErrorCount;
-    }
-
-    /**
-     * @param int $updateErrorCount
-     */
-    public function setUpdateErrorCount(int $updateErrorCount)
-    {
-        if ($this->updateErrorCount !== $updateErrorCount) {
-            $this->updateErrorCount = $updateErrorCount;
-            $this->markFieldUpdated('updateErrorCount');
-        }
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getLastUpdateError()
-    {
-        return $this->lastUpdateError;
-    }
-
-    /**
-     * @param string|null $lastUpdateError
-     */
-    public function setLastUpdateError(string $lastUpdateError = null)
-    {
-        if ($this->lastUpdateError !== $lastUpdateError) {
-            $this->lastUpdateError = $lastUpdateError;
-            $this->markFieldUpdated('lastUpdateError');
-        }
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getBasicAuthUser()
-    {
-        return $this->basicAuthUser;
     }
 
     /**
@@ -594,21 +356,256 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     }
 
     /**
-     * @return string|null
+     * @param int|null $deletedAt
      */
-    public function getBasicAuthPassword()
+    public function setDeletedAt(int $deletedAt = null)
     {
-        return $this->basicAuthPassword;
+        if ($this->deletedAt !== $deletedAt) {
+            $this->deletedAt = $deletedAt;
+            $this->markFieldUpdated('deletedAt');
+        }
     }
 
     /**
-     * @param string|null $basicAuthPassword
+     * @param string|null $faviconLink
      */
-    public function setBasicAuthPassword(string $basicAuthPassword = null)
+    public function setFaviconLink(string $faviconLink = null)
     {
-        if ($this->basicAuthPassword !== $basicAuthPassword) {
-            $this->basicAuthPassword = $basicAuthPassword;
-            $this->markFieldUpdated('basicAuthPassword');
+        if ($this->faviconLink !== $faviconLink) {
+            $this->faviconLink = $faviconLink;
+            $this->markFieldUpdated('faviconLink');
         }
+    }
+
+    /**
+     * @param int $folderId
+     */
+    public function setFolderId(int $folderId)
+    {
+        if ($this->folderId !== $folderId) {
+            $this->folderId = $folderId;
+            $this->markFieldUpdated('folderId');
+        }
+    }
+
+    /**
+     * @param bool $fullTextEnabled
+     */
+    public function setFullTextEnabled(bool $fullTextEnabled)
+    {
+        if ($this->fullTextEnabled !== $fullTextEnabled) {
+            $this->fullTextEnabled = $fullTextEnabled;
+            $this->markFieldUpdated('fullTextEnabled');
+        }
+    }
+
+    /**
+     * @param string|null $httpEtag
+     */
+    public function setHttpEtag(string $httpEtag = null)
+    {
+        if ($this->httpEtag !== $httpEtag) {
+            $this->httpEtag = $httpEtag;
+            $this->markFieldUpdated('httpEtag');
+        }
+    }
+
+    /**
+     * @param string|null $httpLastModified
+     */
+    public function setHttpLastModified(string $httpLastModified = null)
+    {
+        if ($this->httpLastModified !== $httpLastModified) {
+            $this->httpLastModified = $httpLastModified;
+            $this->markFieldUpdated('httpLastModified');
+        }
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId(int $id)
+    {
+        if ($this->id !== $id) {
+            $this->id = $id;
+            $this->markFieldUpdated('id');
+        }
+    }
+
+    /**
+     * @param int|null $lastModified
+     */
+    public function setLastModified(int $lastModified = null)
+    {
+        if ($this->lastModified !== $lastModified) {
+            $this->lastModified = $lastModified;
+            $this->markFieldUpdated('lastModified');
+        }
+    }
+
+    /**
+     * @param string|null $lastUpdateError
+     */
+    public function setLastUpdateError(string $lastUpdateError = null)
+    {
+        if ($this->lastUpdateError !== $lastUpdateError) {
+            $this->lastUpdateError = $lastUpdateError;
+            $this->markFieldUpdated('lastUpdateError');
+        }
+    }
+
+    /**
+     * @param string|null $link
+     */
+    public function setLink(string $link = null)
+    {
+        $link = trim($link);
+        if (strpos($link, 'http') === 0 && $this->link !== $link) {
+            $this->link = $link;
+            $this->markFieldUpdated('link');
+        }
+    }
+
+    /**
+     * @param string|null $location
+     */
+    public function setLocation(string $location = null)
+    {
+        if ($this->location !== $location) {
+            $this->location = $location;
+            $this->markFieldUpdated('location');
+        }
+    }
+
+    /**
+     * @param int $ordering
+     */
+    public function setOrdering(int $ordering)
+    {
+        if ($this->ordering !== $ordering) {
+            $this->ordering = $ordering;
+            $this->markFieldUpdated('ordering');
+        }
+    }
+
+    /**
+     * @param bool $pinned
+     */
+    public function setPinned(bool $pinned)
+    {
+        if ($this->pinned !== $pinned) {
+            $this->pinned = $pinned;
+            $this->markFieldUpdated('pinned');
+        }
+    }
+
+    /**
+     * @param bool $preventUpdate
+     */
+    public function setPreventUpdate(bool $preventUpdate)
+    {
+        if ($this->preventUpdate !== $preventUpdate) {
+            $this->preventUpdate = $preventUpdate;
+            $this->markFieldUpdated('preventUpdate');
+        }
+    }
+
+    /**
+     * @param string $title
+     */
+    public function setTitle(string $title)
+    {
+        if ($this->title !== $title) {
+            $this->title = $title;
+            $this->markFieldUpdated('title');
+        }
+    }
+
+    /**
+     * @param int $unreadCount
+     */
+    public function setUnreadCount(int $unreadCount)
+    {
+        if ($this->unreadCount !== $unreadCount) {
+            $this->unreadCount = $unreadCount;
+            $this->markFieldUpdated('unreadCount');
+        }
+    }
+
+    /**
+     * @param int $updateErrorCount
+     */
+    public function setUpdateErrorCount(int $updateErrorCount)
+    {
+        if ($this->updateErrorCount !== $updateErrorCount) {
+            $this->updateErrorCount = $updateErrorCount;
+            $this->markFieldUpdated('updateErrorCount');
+        }
+    }
+
+    /**
+     * @param int $updateMode
+     */
+    public function setUpdateMode(int $updateMode)
+    {
+        if ($this->updateMode !== $updateMode) {
+            $this->updateMode = $updateMode;
+            $this->markFieldUpdated('updateMode');
+        }
+    }
+
+    /**
+     * @param string $url
+     */
+    public function setUrl(string $url)
+    {
+        $url = trim($url);
+        if (strpos($url, 'http') === 0 && $this->url !== $url) {
+            $this->url = $url;
+            $this->setUrlHash(md5($url));
+            $this->markFieldUpdated('url');
+        }
+    }
+
+    /**
+     * @param string $urlHash
+     */
+    public function setUrlHash(string $urlHash)
+    {
+        if ($this->urlHash !== $urlHash) {
+            $this->urlHash = $urlHash;
+            $this->markFieldUpdated('urlHash');
+        }
+    }
+
+    /**
+     * @param string $userId
+     */
+    public function setUserId(string $userId)
+    {
+        if ($this->userId !== $userId) {
+            $this->userId = $userId;
+            $this->markFieldUpdated('userId');
+        }
+    }
+
+    public function toAPI(): array
+    {
+        return $this->serializeFields(
+            [
+                'id',
+                'url',
+                'title',
+                'faviconLink',
+                'added',
+                'folderId',
+                'unreadCount',
+                'ordering',
+                'link',
+                'pinned',
+                'updateErrorCount',
+                'lastUpdateError'
+            ]
+        );
     }
 }

--- a/lib/Db/Feed.php
+++ b/lib/Db/Feed.php
@@ -21,58 +21,58 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     use EntityJSONSerializer;
 
     /** @var string */
-    protected $userId;
+    protected $userId = '';
     /** @var string */
     protected $urlHash;
     /** @var string */
     protected $url;
     /** @var string */
     protected $title;
-    /** @var string */
-    protected $faviconLink;
-    /** @var int */
-    protected $added;
+    /** @var string|null */
+    protected $faviconLink = null;
+    /** @var int|null */
+    protected $added = 0;
     /** @var int */
     protected $folderId;
     /** @var int */
     protected $unreadCount;
-    /** @var string */
-    protected $link;
+    /** @var string|null */
+    protected $link = null;
     /** @var bool */
-    protected $preventUpdate;
+    protected $preventUpdate = false;
+    /** @var int|null */
+    protected $deletedAt = 0;
     /** @var int */
-    protected $deletedAt;
+    protected $articlesPerUpdate = 0;
+    /** @var string|null */
+    protected $httpLastModified = null;
+    /** @var int|null */
+    protected $lastModified = 0;
+    /** @var string|null */
+    protected $httpEtag = null;
+    /** @var string|null */
+    protected $location = null;
     /** @var int */
-    protected $articlesPerUpdate;
-    /** @var string */
-    protected $httpLastModified;
-    /** @var string */
-    protected $lastModified;
-    /** @var string */
-    protected $httpEtag;
-    /** @var string */
-    protected $location;
-    /** @var int */
-    protected $ordering;
+    protected $ordering = 0;
     /** @var bool */
-    protected $fullTextEnabled;
+    protected $fullTextEnabled = false;
     /** @var bool */
-    protected $pinned;
+    protected $pinned = false;
     /** @var int */
-    protected $updateMode;
+    protected $updateMode = 0;
     /** @var int */
-    protected $updateErrorCount;
-    /** @var string */
-    protected $lastUpdateError;
-    /** @var string */
-    protected $basicAuthUser;
-    /** @var string */
-    protected $basicAuthPassword;
+    protected $updateErrorCount = 0;
+    /** @var string|null */
+    protected $lastUpdateError = '';
+    /** @var string|null */
+    protected $basicAuthUser = '';
+    /** @var string|null */
+    protected $basicAuthPassword = '';
 
     /**
-     * Turns entitie attributes into an array
+     * Turns entity attributes into an array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $serialized = $this->serializeFields(
             [
@@ -114,7 +114,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     }
 
 
-    public function toAPI()
+    public function toAPI(): array
     {
         return $this->serializeFields(
             [
@@ -137,7 +137,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @return int
      */
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }
@@ -145,10 +145,10 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @param int $id
      */
-    public function setId($id)
+    public function setId(int $id)
     {
         if ($this->id !== $id) {
-            $this->id = (int)$id;
+            $this->id = $id;
             $this->markFieldUpdated('id');
         }
     }
@@ -156,7 +156,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @return string
      */
-    public function getUserId()
+    public function getUserId(): string
     {
         return $this->userId;
     }
@@ -164,10 +164,10 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @param string $userId
      */
-    public function setUserId($userId)
+    public function setUserId(string $userId)
     {
         if ($this->userId !== $userId) {
-            $this->userId = (string)$userId;
+            $this->userId = $userId;
             $this->markFieldUpdated('userId');
         }
     }
@@ -175,7 +175,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @return string
      */
-    public function getUrlHash()
+    public function getUrlHash(): string
     {
         return $this->urlHash;
     }
@@ -183,10 +183,10 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @param string $urlHash
      */
-    public function setUrlHash($urlHash)
+    public function setUrlHash(string $urlHash)
     {
         if ($this->urlHash !== $urlHash) {
-            $this->urlHash = (string)$urlHash;
+            $this->urlHash = $urlHash;
             $this->markFieldUpdated('urlHash');
         }
     }
@@ -194,7 +194,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @return string
      */
-    public function getUrl()
+    public function getUrl(): string
     {
         return $this->url;
     }
@@ -202,9 +202,9 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @param string $url
      */
-    public function setUrl($url)
+    public function setUrl(string $url)
     {
-        $url = trim((string)$url);
+        $url = trim($url);
         if(strpos($url, 'http') === 0 && $this->url !== $url) {
             $this->url = $url;
             $this->setUrlHash(md5($url));
@@ -215,7 +215,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @return string
      */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title;
     }
@@ -223,16 +223,16 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @param string $title
      */
-    public function setTitle($title)
+    public function setTitle(string $title)
     {
         if ($this->title !== $title) {
-            $this->title = (string)$title;
+            $this->title = $title;
             $this->markFieldUpdated('title');
         }
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getFaviconLink()
     {
@@ -240,18 +240,18 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     }
 
     /**
-     * @param string $faviconLink
+     * @param string|null $faviconLink
      */
-    public function setFaviconLink($faviconLink)
+    public function setFaviconLink(string $faviconLink = null)
     {
         if ($this->faviconLink !== $faviconLink) {
-            $this->faviconLink = (string)$faviconLink;
+            $this->faviconLink = $faviconLink;
             $this->markFieldUpdated('faviconLink');
         }
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getAdded()
     {
@@ -259,12 +259,12 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     }
 
     /**
-     * @param int $added
+     * @param int|null $added
      */
-    public function setAdded($added)
+    public function setAdded(int $added = null)
     {
         if ($this->added !== $added) {
-            $this->added = (int)$added;
+            $this->added = $added;
             $this->markFieldUpdated('added');
         }
     }
@@ -272,7 +272,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @return int
      */
-    public function getFolderId()
+    public function getFolderId(): int
     {
         return $this->folderId;
     }
@@ -280,10 +280,10 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @param int $folderId
      */
-    public function setFolderId($folderId)
+    public function setFolderId(int $folderId)
     {
         if ($this->folderId !== $folderId) {
-            $this->folderId = (int)$folderId;
+            $this->folderId = $folderId;
             $this->markFieldUpdated('folderId');
         }
     }
@@ -291,7 +291,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @return int
      */
-    public function getUnreadCount()
+    public function getUnreadCount(): int
     {
         return $this->unreadCount;
     }
@@ -299,16 +299,16 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @param int $unreadCount
      */
-    public function setUnreadCount($unreadCount)
+    public function setUnreadCount(int $unreadCount)
     {
         if ($this->unreadCount !== $unreadCount) {
-            $this->unreadCount = (int)$unreadCount;
+            $this->unreadCount = $unreadCount;
             $this->markFieldUpdated('unreadCount');
         }
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getLink()
     {
@@ -316,13 +316,13 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     }
 
     /**
-     * @param string $link
+     * @param string|null $link
      */
-    public function setLink($link)
+    public function setLink(string $link = null)
     {
-        $link = trim((string)$link);
+        $link = trim($link);
         if(strpos($link, 'http') === 0 && $this->link !== $link) {
-            $this->link = (string)$link;
+            $this->link = $link;
             $this->markFieldUpdated('link');
         }
     }
@@ -330,7 +330,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @return bool
      */
-    public function getPreventUpdate()
+    public function getPreventUpdate(): bool
     {
         return $this->preventUpdate;
     }
@@ -338,16 +338,16 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @param bool $preventUpdate
      */
-    public function setPreventUpdate($preventUpdate)
+    public function setPreventUpdate(bool $preventUpdate)
     {
         if ($this->preventUpdate !== $preventUpdate) {
-            $this->preventUpdate = (bool)$preventUpdate;
+            $this->preventUpdate = $preventUpdate;
             $this->markFieldUpdated('preventUpdate');
         }
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getDeletedAt()
     {
@@ -355,12 +355,12 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     }
 
     /**
-     * @param int $deletedAt
+     * @param int|null $deletedAt
      */
-    public function setDeletedAt($deletedAt)
+    public function setDeletedAt(int $deletedAt = null)
     {
         if ($this->deletedAt !== $deletedAt) {
-            $this->deletedAt = (int)$deletedAt;
+            $this->deletedAt = $deletedAt;
             $this->markFieldUpdated('deletedAt');
         }
     }
@@ -368,7 +368,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @return int
      */
-    public function getArticlesPerUpdate()
+    public function getArticlesPerUpdate(): int
     {
         return $this->articlesPerUpdate;
     }
@@ -376,16 +376,16 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @param int $articlesPerUpdate
      */
-    public function setArticlesPerUpdate($articlesPerUpdate)
+    public function setArticlesPerUpdate(int $articlesPerUpdate)
     {
         if ($this->articlesPerUpdate !== $articlesPerUpdate) {
-            $this->articlesPerUpdate = (int)$articlesPerUpdate;
+            $this->articlesPerUpdate = $articlesPerUpdate;
             $this->markFieldUpdated('articlesPerUpdate');
         }
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getHttpLastModified()
     {
@@ -393,18 +393,18 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     }
 
     /**
-     * @param string $httpLastModified
+     * @param string|null $httpLastModified
      */
-    public function setHttpLastModified($httpLastModified)
+    public function setHttpLastModified(string $httpLastModified = null)
     {
         if ($this->httpLastModified !== $httpLastModified) {
-            $this->httpLastModified = (string)$httpLastModified;
+            $this->httpLastModified = $httpLastModified;
             $this->markFieldUpdated('httpLastModified');
         }
     }
 
     /**
-     * @return string
+     * @return int|null
      */
     public function getLastModified()
     {
@@ -412,18 +412,18 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     }
 
     /**
-     * @param string $lastModified
+     * @param int|null $lastModified
      */
-    public function setLastModified($lastModified)
+    public function setLastModified(int $lastModified = null)
     {
         if ($this->lastModified !== $lastModified) {
-            $this->lastModified = (string)$lastModified;
+            $this->lastModified = $lastModified;
             $this->markFieldUpdated('lastModified');
         }
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getHttpEtag()
     {
@@ -431,18 +431,18 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     }
 
     /**
-     * @param string $httpEtag
+     * @param string|null $httpEtag
      */
-    public function setHttpEtag($httpEtag)
+    public function setHttpEtag(string $httpEtag = null)
     {
         if ($this->httpEtag !== $httpEtag) {
-            $this->httpEtag = (string)$httpEtag;
+            $this->httpEtag = $httpEtag;
             $this->markFieldUpdated('httpEtag');
         }
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getLocation()
     {
@@ -450,12 +450,12 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     }
 
     /**
-     * @param string $location
+     * @param string|null $location
      */
-    public function setLocation($location)
+    public function setLocation(string $location = null)
     {
         if ($this->location !== $location) {
-            $this->location = (string)$location;
+            $this->location = $location;
             $this->markFieldUpdated('location');
         }
     }
@@ -463,7 +463,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @return int
      */
-    public function getOrdering()
+    public function getOrdering(): int
     {
         return $this->ordering;
     }
@@ -471,10 +471,10 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @param int $ordering
      */
-    public function setOrdering($ordering)
+    public function setOrdering(int $ordering)
     {
         if ($this->ordering !== $ordering) {
-            $this->ordering = (int)$ordering;
+            $this->ordering = $ordering;
             $this->markFieldUpdated('ordering');
         }
     }
@@ -482,7 +482,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @return bool
      */
-    public function getFullTextEnabled()
+    public function getFullTextEnabled(): bool
     {
         return $this->fullTextEnabled;
     }
@@ -490,10 +490,10 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @param bool $fullTextEnabled
      */
-    public function setFullTextEnabled($fullTextEnabled)
+    public function setFullTextEnabled(bool $fullTextEnabled)
     {
         if ($this->fullTextEnabled !== $fullTextEnabled) {
-            $this->fullTextEnabled = (bool)$fullTextEnabled;
+            $this->fullTextEnabled = $fullTextEnabled;
             $this->markFieldUpdated('fullTextEnabled');
         }
     }
@@ -501,7 +501,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @return bool
      */
-    public function getPinned()
+    public function getPinned(): bool
     {
         return $this->pinned;
     }
@@ -509,10 +509,10 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @param bool $pinned
      */
-    public function setPinned($pinned)
+    public function setPinned(bool $pinned)
     {
         if ($this->pinned !== $pinned) {
-            $this->pinned = (bool)$pinned;
+            $this->pinned = $pinned;
             $this->markFieldUpdated('pinned');
         }
     }
@@ -520,7 +520,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @return int
      */
-    public function getUpdateMode()
+    public function getUpdateMode(): int
     {
         return $this->updateMode;
     }
@@ -528,10 +528,10 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @param int $updateMode
      */
-    public function setUpdateMode($updateMode)
+    public function setUpdateMode(int $updateMode)
     {
         if ($this->updateMode !== $updateMode) {
-            $this->updateMode = (int)$updateMode;
+            $this->updateMode = $updateMode;
             $this->markFieldUpdated('updateMode');
         }
     }
@@ -539,7 +539,7 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @return int
      */
-    public function getUpdateErrorCount()
+    public function getUpdateErrorCount(): int
     {
         return $this->updateErrorCount;
     }
@@ -547,16 +547,16 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @param int $updateErrorCount
      */
-    public function setUpdateErrorCount($updateErrorCount)
+    public function setUpdateErrorCount(int $updateErrorCount)
     {
         if ($this->updateErrorCount !== $updateErrorCount) {
-            $this->updateErrorCount = (int)$updateErrorCount;
+            $this->updateErrorCount = $updateErrorCount;
             $this->markFieldUpdated('updateErrorCount');
         }
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getLastUpdateError()
     {
@@ -564,18 +564,18 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     }
 
     /**
-     * @param string $lastUpdateError
+     * @param string|null $lastUpdateError
      */
-    public function setLastUpdateError($lastUpdateError)
+    public function setLastUpdateError(string $lastUpdateError = null)
     {
         if ($this->lastUpdateError !== $lastUpdateError) {
-            $this->lastUpdateError = (string)$lastUpdateError;
+            $this->lastUpdateError = $lastUpdateError;
             $this->markFieldUpdated('lastUpdateError');
         }
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getBasicAuthUser()
     {
@@ -583,18 +583,18 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     }
 
     /**
-     * @param string $basicAuthUser
+     * @param string|null $basicAuthUser
      */
-    public function setBasicAuthUser($basicAuthUser)
+    public function setBasicAuthUser(string $basicAuthUser = null)
     {
         if ($this->basicAuthUser !== $basicAuthUser) {
-            $this->basicAuthUser = (string)$basicAuthUser;
+            $this->basicAuthUser = $basicAuthUser;
             $this->markFieldUpdated('basicAuthUser');
         }
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getBasicAuthPassword()
     {
@@ -602,12 +602,12 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     }
 
     /**
-     * @param string $basicAuthPassword
+     * @param string|null $basicAuthPassword
      */
-    public function setBasicAuthPassword($basicAuthPassword)
+    public function setBasicAuthPassword(string $basicAuthPassword = null)
     {
         if ($this->basicAuthPassword !== $basicAuthPassword) {
-            $this->basicAuthPassword = (string)$basicAuthPassword;
+            $this->basicAuthPassword = $basicAuthPassword;
             $this->markFieldUpdated('basicAuthPassword');
         }
     }

--- a/lib/Db/Folder.php
+++ b/lib/Db/Folder.php
@@ -13,66 +13,150 @@
 
 namespace OCA\News\Db;
 
-use \OCP\AppFramework\Db\Entity;
+use OCP\AppFramework\Db\Entity;
 
-/**
- * @method integer getId()
- * @method void setId(integer $value)
- * @method string getUserId()
- * @method void setUserId(string $value)
- * @method string getName()
- * @method void setName(string $value)
- * @method integer getParentId()
- * @method void setParentId(integer $value)
- * @method boolean getOpened()
- * @method void setOpened(boolean $value)
- * @method integer getDeletedAt()
- * @method void setDeletedAt(integer $value)
- * @method string getLastModified()
- * @method void setLastModified(string $value)
- */
 class Folder extends Entity implements IAPI, \JsonSerializable
 {
 
     use EntityJSONSerializer;
 
+    /** @var int|null */
     protected $parentId;
+    /** @var string */
     protected $name;
-    protected $userId;
-    protected $opened;
-    protected $deletedAt;
-    protected $lastModified;
+    /** @var string */
+    protected $userId = '';
+    /** @var bool */
+    protected $opened = true;
+    /** @var int|null */
+    protected $deletedAt = 0;
+    /** @var int|null */
+    protected $lastModified = 0;
 
-    public function __construct()
+    /**
+     * @return int|null
+     */
+    public function getDeletedAt()
     {
-        $this->addType('parentId', 'integer');
-        $this->addType('opened', 'boolean');
-        $this->addType('deletedAt', 'integer');
+        return $this->deletedAt;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
     }
 
     /**
-     * Turns entitie attributes into an array
+     * @return int|null
      */
-    public function jsonSerialize() 
+    public function getLastModified()
+    {
+        return $this->lastModified;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getOpened(): bool
+    {
+        return $this->opened;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getParentId()
+    {
+        return $this->parentId;
+    }
+
+    public function getUserId(): string
+    {
+        return $this->userId;
+    }
+
+    /**
+     * Turns entity attributes into an array
+     */
+    public function jsonSerialize(): array
     {
         return $this->serializeFields(
             [
-            'id',
-            'parentId',
-            'name',
-            'userId',
-            'opened',
-            'deletedAt',
+                'id',
+                'parentId',
+                'name',
+                'userId',
+                'opened',
+                'deletedAt',
             ]
         );
     }
 
-    public function toAPI() 
+    public function setDeletedAt(int $deletedAt = null)
+    {
+        if ($this->deletedAt !== $deletedAt) {
+            $this->deletedAt = $deletedAt;
+            $this->markFieldUpdated('deletedAt');
+        }
+    }
+
+    public function setId(int $id)
+    {
+        if ($this->id !== $id) {
+            $this->id = $id;
+            $this->markFieldUpdated('id');
+        }
+    }
+
+    public function setLastModified(int $lastModified = null)
+    {
+
+        if ($this->lastModified !== $lastModified) {
+            $this->lastModified = $lastModified;
+            $this->markFieldUpdated('lastModified');
+        }
+    }
+
+    public function setName(string $name)
+    {
+        if ($this->name !== $name) {
+            $this->name = $name;
+            $this->markFieldUpdated('name');
+        }
+    }
+
+    public function setOpened(bool $opened)
+    {
+        if ($this->opened !== $opened) {
+            $this->opened = $opened;
+            $this->markFieldUpdated('opened');
+        }
+    }
+
+    public function setParentId(int $parentId = null)
+    {
+        if ($this->parentId !== $parentId) {
+            $this->parentId = $parentId;
+            $this->markFieldUpdated('parentId');
+        }
+    }
+
+    public function setUserId(string $userId)
+    {
+        if ($this->userId !== $userId) {
+            $this->userId = $userId;
+            $this->markFieldUpdated('userId');
+        }
+    }
+
+    public function toAPI(): array
     {
         return $this->serializeFields(
             [
-            'id',
-            'name'
+                'id',
+                'name'
             ]
         );
     }

--- a/lib/Db/Item.php
+++ b/lib/Db/Item.php
@@ -13,88 +13,240 @@
 
 namespace OCA\News\Db;
 
-use \OCP\AppFramework\Db\Entity;
+use OCP\AppFramework\Db\Entity;
 
-/**
- * @method integer getId()
- * @method void setId(integer $value)
- * @method string getGuid()
- * @method void setGuid(string $value)
- * @method string getGuidHash()
- * @method void setGuidHash(string $value)
- * @method string getUrl()
- * @method string getTitle()
- * @method string getAuthor()
- * @method string getRtl()
- * @method string getFingerprint()
- * @method string getContentHash()
- * @method integer getPubDate()
- * @method void setPubDate(integer $value)
- * @method string getBody()
- * @method string getEnclosureMime()
- * @method void setEnclosureMime(string $value)
- * @method string getEnclosureLink()
- * @method void setEnclosureLink(string $value)
- * @method integer getFeedId()
- * @method void setFeedId(integer $value)
- * @method void setRtl(boolean $value)
- * @method string getLastModified()
- * @method void setLastModified(string $value)
- * @method void setFingerprint(string $value)
- * @method void setContentHash(string $value)
- * @method void setSearchIndex(string $value)
- * @method void setUnread(bool $value)
- * @method void setStarred(bool $value)
- */
 class Item extends Entity implements IAPI, \JsonSerializable
 {
 
     use EntityJSONSerializer;
 
+    /** @var string|null */
     protected $contentHash;
+    /** @var string */
     protected $guidHash;
+    /** @var string */
     protected $guid;
+    /** @var string|null */
     protected $url;
+    /** @var string|null */
     protected $title;
+    /** @var string|null */
     protected $author;
+    /** @var int|null */
     protected $pubDate;
+    /** @var int|null */
     protected $updatedDate;
+    /** @var string|null */
     protected $body;
+    /** @var string|null */
     protected $enclosureMime;
+    /** @var string|null */
     protected $enclosureLink;
+    /** @var int */
     protected $feedId;
+    /** @var int */
     protected $status = 0;
-    protected $lastModified;
+    /** @var int|null */
+    protected $lastModified = 0;
+    /** @var string|null */
     protected $searchIndex;
-    protected $rtl;
+    /** @var bool */
+    protected $rtl = false;
+    /** @var string|null */
     protected $fingerprint;
+    /** @var bool */
     protected $unread = false;
+    /** @var bool */
     protected $starred = false;
 
-    public function __construct() 
+    /**
+     * @return int
+     */
+    public function cropApiLastModified(): int
     {
-        $this->addType('pubDate', 'integer');
-        $this->addType('updatedDate', 'integer');
-        $this->addType('feedId', 'integer');
-        $this->addType('rtl', 'boolean');
-        $this->addType('unread', 'boolean');
-        $this->addType('starred', 'boolean');
+        $lastModified = $this->getLastModified();
+        if (strlen((string)$lastModified) > 10) {
+            return (int)substr($lastModified, 0, -6);
+        } else {
+            return (int)$lastModified;
+        }
     }
 
-    public function isUnread() 
+    public static function fromImport($import): Item
     {
-        return $this->unread;
+        $item = new static();
+        $item->setGuid($import['guid']);
+        $item->setGuidHash($import['guid']);
+        $item->setUrl($import['url']);
+        $item->setTitle($import['title']);
+        $item->setAuthor($import['author']);
+        $item->setPubDate($import['pubDate']);
+        $item->setUpdatedDate($import['updatedDate']);
+        $item->setBody($import['body']);
+        $item->setEnclosureMime($import['enclosureMime']);
+        $item->setEnclosureLink($import['enclosureLink']);
+        $item->setRtl($import['rtl']);
+        $item->setUnread($import['unread']);
+        $item->setStarred($import['starred']);
+
+        return $item;
     }
 
-    public function isStarred() 
+    public function generateSearchIndex()
+    {
+        $this->setSearchIndex(
+            mb_strtolower(
+                html_entity_decode(strip_tags($this->getBody())) .
+                html_entity_decode($this->getAuthor()) .
+                html_entity_decode($this->getTitle()) .
+                $this->getUrl(),
+                'UTF-8'
+            )
+        );
+        $this->setFingerprint($this->computeFingerprint());
+        $this->setContentHash($this->computeContentHash());
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getAuthor()
+    {
+        return $this->author;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getContentHash()
+    {
+        return $this->contentHash;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getEnclosureLink()
+    {
+        return $this->enclosureLink;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getEnclosureMime()
+    {
+        return $this->enclosureMime;
+    }
+
+    public function getFeedId(): int
+    {
+        return $this->feedId;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getFingerprint()
+    {
+        return $this->fingerprint;
+    }
+
+    public function getGuid(): string
+    {
+        return $this->guid;
+    }
+
+    public function getGuidHash(): string
+    {
+        return $this->guidHash;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getIntro()
+    {
+        return strip_tags($this->getBody());
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getLastModified()
+    {
+        return $this->lastModified;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getPubDate()
+    {
+        return $this->pubDate;
+    }
+
+    public function getRtl(): bool
+    {
+        return $this->rtl;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getSearchIndex()
+    {
+        return $this->searchIndex;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getUpdatedDate()
+    {
+        return $this->updatedDate;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    public function isStarred()
     {
         return $this->starred;
+    }
+
+    public function isUnread()
+    {
+        return $this->unread;
     }
 
     /**
      * Turns entity attributes into an array
      */
-    public function jsonSerialize() 
+    public function jsonSerialize(): array
     {
         return [
             'id' => $this->getId(),
@@ -118,7 +270,171 @@ class Item extends Entity implements IAPI, \JsonSerializable
         ];
     }
 
-    public function toAPI() 
+    public function setAuthor(string $author = null)
+    {
+        $author = strip_tags($author);
+
+        if ($this->author !== $author) {
+            $this->author = $author;
+            $this->markFieldUpdated('author');
+        }
+    }
+
+    public function setBody(string $body = null)
+    {
+        // FIXME: this should not happen if the target="_blank" is already
+        // on the link
+        $body = str_replace('<a', '<a target="_blank" rel="noreferrer"', $body);
+
+        if ($this->body !== $body) {
+            $this->body = $body;
+            $this->markFieldUpdated('body');
+        }
+    }
+
+    public function setContentHash(string $contentHash = null)
+    {
+        if ($this->contentHash !== $contentHash) {
+            $this->contentHash = $contentHash;
+            $this->markFieldUpdated('contentHash');
+        }
+    }
+
+    public function setEnclosureLink(string $enclosureLink = null)
+    {
+        if ($this->enclosureLink !== $enclosureLink) {
+            $this->enclosureLink = $enclosureLink;
+            $this->markFieldUpdated('enclosureLink');
+        }
+    }
+
+    public function setEnclosureMime(string $enclosureMime = null)
+    {
+        if ($this->enclosureMime !== $enclosureMime) {
+            $this->enclosureMime = $enclosureMime;
+            $this->markFieldUpdated('enclosureMime');
+        }
+    }
+
+    public function setFeedId(int $feedId)
+    {
+        if ($this->feedId !== $feedId) {
+            $this->feedId = $feedId;
+            $this->markFieldUpdated('feedId');
+        }
+    }
+
+    public function setFingerprint(string $fingerprint = null)
+    {
+        if ($this->fingerprint !== $fingerprint) {
+            $this->fingerprint = $fingerprint;
+            $this->markFieldUpdated('fingerprint');
+        }
+    }
+
+    public function setGuid(string $guid)
+    {
+        if ($this->guid !== $guid) {
+            $this->guid = $guid;
+            $this->markFieldUpdated('guid');
+        }
+    }
+
+    public function setGuidHash(string $guidHash)
+    {
+        if ($this->guidHash !== $guidHash) {
+            $this->guidHash = $guidHash;
+            $this->markFieldUpdated('guidHash');
+        }
+    }
+
+    public function setId(int $id)
+    {
+        if ($this->id !== $id) {
+            $this->id = $id;
+            $this->markFieldUpdated('id');
+        }
+    }
+
+    public function setLastModified(int $lastModified = null)
+    {
+        if ($this->lastModified !== $lastModified) {
+            $this->lastModified = $lastModified;
+            $this->markFieldUpdated('lastModified');
+        }
+    }
+
+    public function setPubDate(int $pubDate = null)
+    {
+        if ($this->pubDate !== $pubDate) {
+            $this->pubDate = $pubDate;
+            $this->markFieldUpdated('pubDate');
+        }
+    }
+
+    public function setRtl(bool $rtl)
+    {
+        if ($this->rtl !== $rtl) {
+            $this->rtl = $rtl;
+            $this->markFieldUpdated('rtl');
+        }
+    }
+
+    public function setSearchIndex(string $searchIndex = null)
+    {
+        if ($this->searchIndex !== $searchIndex) {
+            $this->searchIndex = $searchIndex;
+            $this->markFieldUpdated('searchIndex');
+        }
+    }
+
+    public function setStarred(bool $starred)
+    {
+        if ($this->starred !== $starred) {
+            $this->starred = $starred;
+            $this->markFieldUpdated('starred');
+        }
+    }
+
+    public function setTitle(string $title = null)
+    {
+        $title = strip_tags($title);
+
+        if ($this->title !== $title) {
+            $this->title = $title;
+            $this->markFieldUpdated('title');
+        }
+    }
+
+    public function setUnread(bool $unread)
+    {
+        if ($this->unread !== $unread) {
+            $this->unread = $unread;
+            $this->markFieldUpdated('unread');
+        }
+    }
+
+    public function setUpdatedDate(int $updatedDate = null)
+    {
+        if ($this->updatedDate !== $updatedDate) {
+            $this->updatedDate = $updatedDate;
+            $this->markFieldUpdated('updatedDate');
+        }
+    }
+
+    public function setUrl(string $url = null)
+    {
+        $url = trim($url);
+        if (
+            (strpos($url, 'http') === 0 || strpos($url, 'magnet') === 0)
+            && $this->url !== $url
+        ) {
+            $this->url = $url;
+            $this->markFieldUpdated('url');
+        }
+    }
+
+    public function toAPI(): array
     {
         return [
             'id' => $this->getId(),
@@ -142,7 +458,7 @@ class Item extends Entity implements IAPI, \JsonSerializable
         ];
     }
 
-    public function toExport($feeds) 
+    public function toExport($feeds): array
     {
         return [
             'guid' => $this->getGuid(),
@@ -161,57 +477,7 @@ class Item extends Entity implements IAPI, \JsonSerializable
         ];
     }
 
-    public function getIntro() 
-    {
-        return strip_tags($this->getBody());
-    }
-
-    public static function fromImport($import) 
-    {
-        $item = new static();
-        $item->setGuid($import['guid']);
-        $item->setGuidHash($import['guid']);
-        $item->setUrl($import['url']);
-        $item->setTitle($import['title']);
-        $item->setAuthor($import['author']);
-        $item->setPubDate($import['pubDate']);
-        $item->setUpdatedDate($import['updatedDate']);
-        $item->setBody($import['body']);
-        $item->setEnclosureMime($import['enclosureMime']);
-        $item->setEnclosureLink($import['enclosureLink']);
-        $item->setRtl($import['rtl']);
-        $item->setUnread($import['unread']);
-        $item->setStarred($import['starred']);
-
-        return $item;
-    }
-
-    public function setAuthor($name) 
-    {
-        parent::setAuthor(strip_tags($name));
-    }
-
-    public function setTitle($title) 
-    {
-        parent::setTitle(strip_tags($title));
-    }
-
-    public function generateSearchIndex() 
-    {
-        $this->setSearchIndex(
-            mb_strtolower(
-                html_entity_decode(strip_tags($this->getBody())) .
-                html_entity_decode($this->getAuthor()) .
-                html_entity_decode($this->getTitle()) .
-                $this->getUrl(),
-                'UTF-8'
-            )
-        );
-        $this->setFingerprint($this->computeFingerprint());
-        $this->setContentHash($this->computeContentHash());
-    }
-
-    private function computeContentHash() 
+    private function computeContentHash(): string
     {
         return md5(
             $this->getTitle() . $this->getUrl() . $this->getBody() .
@@ -220,44 +486,11 @@ class Item extends Entity implements IAPI, \JsonSerializable
         );
     }
 
-    private function computeFingerprint() 
+    private function computeFingerprint(): string
     {
         return md5(
             $this->getTitle() . $this->getUrl() . $this->getBody() .
             $this->getEnclosureLink()
         );
     }
-
-    public function setUrl($url) 
-    {
-        $url = trim($url);
-        if (strpos($url, 'http') === 0 || strpos($url, 'magnet') === 0) {
-            parent::setUrl($url);
-        }
-    }
-
-    public function setBody($body) 
-    {
-        // FIXME: this should not happen if the target="_blank" is already
-        // on the link
-        parent::setBody(
-            str_replace(
-                '<a', '<a target="_blank" rel="noreferrer"', $body
-            )
-        );
-    }
-
-    /**
-     * @return int
-     */
-    public function cropApiLastModified() 
-    {
-        $lastModified = $this->getLastModified();
-        if (strlen((string)$lastModified) > 10) {
-            return (int)substr($lastModified, 0, -6);
-        } else {
-            return (int)$lastModified;
-        }
-    }
-
 }

--- a/lib/Service/FeedService.php
+++ b/lib/Service/FeedService.php
@@ -108,6 +108,10 @@ class FeedService extends Service
     ) {
         // first try if the feed exists already
         try {
+            /**
+             * @var Feed $feed
+             * @var Item[] $items
+             */
             list($feed, $items) = $this->feedFetcher->fetch(
                 $feedUrl, true,
                 null, null, false, $basicAuthUser,
@@ -203,6 +207,7 @@ class FeedService extends Service
      */
     public function update($feedId, $userId, $forceUpdate=false)
     {
+        /** @var Feed $existingFeed */
         $existingFeed = $this->find($feedId, $userId);
 
         if($existingFeed->getPreventUpdate() === true) {
@@ -354,6 +359,7 @@ class FeedService extends Service
                 $feed->setAdded($this->timeFactory->getTime());
                 $feed->setFolderId(0);
                 $feed->setPreventUpdate(true);
+                /** @var Feed $feed */
                 $feed = $this->feedMapper->insert($feed);
 
                 $item->setFeedId($feed->getId());

--- a/lib/Utility/OPMLExporter.php
+++ b/lib/Utility/OPMLExporter.php
@@ -13,6 +13,8 @@
 
 namespace OCA\News\Utility;
 
+use OCA\News\Db\Feed;
+
 /**
  * Exports the OPML
  */
@@ -77,8 +79,12 @@ class OPMLExporter
         return $document;
     }
 
-
-    protected function createFeedOutline($feed, $document) 
+    /**
+     * @param Feed $feed
+     * @param \DOMDocument $document
+     * @return \DOMElement
+     */
+    protected function createFeedOutline($feed, $document)
     {
         $feedOutline = $document->createElement('outline');
         $feedOutline->setAttribute('title', $feed->getTitle());

--- a/tests/Integration/Fixtures/FeedFixture.php
+++ b/tests/Integration/Fixtures/FeedFixture.php
@@ -20,9 +20,8 @@ class FeedFixture extends Feed
 
     use Fixture;
 
-    public function __construct(array $defaults=[])  
+    public function __construct(array $defaults=[])
     {
-        parent::__construct();
         $defaults = array_merge(
             [
             'userId' => 'test',

--- a/tests/Integration/Fixtures/FolderFixture.php
+++ b/tests/Integration/Fixtures/FolderFixture.php
@@ -21,7 +21,6 @@ class FolderFixture extends Folder
 
     public function __construct(array $defaults=[])  
     {
-        parent::__construct();
         $defaults = array_merge(
             [
             'parentId' => 0,

--- a/tests/Integration/Fixtures/ItemFixture.php
+++ b/tests/Integration/Fixtures/ItemFixture.php
@@ -21,7 +21,6 @@ class ItemFixture extends Item
 
     public function __construct(array $defaults=[])  
     {
-        parent::__construct();
         $defaults = array_merge(
             [
             'url' => 'http://google.de',

--- a/tests/Unit/Controller/EntityApiSerializerTest.php
+++ b/tests/Unit/Controller/EntityApiSerializerTest.php
@@ -33,6 +33,10 @@ class EntityApiSerializerTest extends \PHPUnit_Framework_TestCase
     {
         $item = new Item();
         $item->setUnread(true);
+        $item->setId(3);
+        $item->setGuid('guid');
+        $item->setGuidHash('guidhash');
+        $item->setFeedId(123);
 
         $serializer = new EntityApiSerializer('items');
         $result = $serializer->serialize($item);
@@ -45,9 +49,17 @@ class EntityApiSerializerTest extends \PHPUnit_Framework_TestCase
     {
         $item = new Item();
         $item->setUnread(true);
+        $item->setId(3);
+        $item->setGuid('guid');
+        $item->setGuidHash('guidhash');
+        $item->setFeedId(123);
 
         $item2 = new Item();
         $item2->setUnread(false);
+        $item2->setId(5);
+        $item2->setGuid('guid');
+        $item2->setGuidHash('guidhash');
+        $item2->setFeedId(123);
 
         $serializer = new EntityApiSerializer('items');
 
@@ -73,9 +85,17 @@ class EntityApiSerializerTest extends \PHPUnit_Framework_TestCase
     {
         $item = new Item();
         $item->setUnread(true);
+        $item->setId(3);
+        $item->setGuid('guid');
+        $item->setGuidHash('guidhash');
+        $item->setFeedId(123);
 
         $item2 = new Item();
         $item2->setUnread(false);
+        $item2->setId(5);
+        $item2->setGuid('guid');
+        $item2->setGuidHash('guidhash');
+        $item2->setFeedId(123);
 
         $serializer = new EntityApiSerializer('items');
 

--- a/tests/Unit/Controller/ExportControllerTest.php
+++ b/tests/Unit/Controller/ExportControllerTest.php
@@ -98,8 +98,10 @@ class ExportControllerTest extends \PHPUnit_Framework_TestCase
     {
         $item1 = new Item();
         $item1->setFeedId(3);
+        $item1->setGuid('guid');
         $item2 = new Item();
         $item2->setFeedId(5);
+        $item2->setGuid('guid');
 
         $feed1 = new Feed();
         $feed1->setId(3);
@@ -129,13 +131,13 @@ class ExportControllerTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            '[{"guid":null,"url":null,"title":null,' .
+            '[{"guid":"guid","url":null,"title":null,' .
             '"author":null,"pubDate":null,"updatedDate":null,"body":null,"enclosureMime":null,' .
             '"enclosureLink":null,"unread":false,"starred":false,' .
-            '"feedLink":"http:\/\/goo","rtl":null},{"guid":null,"url":null,' .
+            '"feedLink":"http:\/\/goo","rtl":false},{"guid":"guid","url":null,' .
             '"title":null,"author":null,"pubDate":null,"updatedDate":null,"body":null,' .
             '"enclosureMime":null,"enclosureLink":null,"unread":false,' .
-            '"starred":false,"feedLink":"http:\/\/gee","rtl":null}]',
+            '"starred":false,"feedLink":"http:\/\/gee","rtl":false}]',
             $return->render()
         );
     }

--- a/tests/Unit/Controller/ItemApiControllerTest.php
+++ b/tests/Unit/Controller/ItemApiControllerTest.php
@@ -75,7 +75,11 @@ class ItemApiControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testIndex() 
     {
-        $items = [new Item()];
+        $item = new Item();
+        $item->setId(5);
+        $item->setGuid('guid');
+        $item->setGuidHash('guidhash');
+        $item->setFeedId(123);
 
         $this->itemService->expects($this->once())
             ->method('findAll')
@@ -88,13 +92,13 @@ class ItemApiControllerTest extends \PHPUnit_Framework_TestCase
                 $this->equalTo(true),
                 $this->equalTo($this->user->getUID())
             )
-            ->will($this->returnValue($items));
+            ->will($this->returnValue([$item]));
 
         $response = $this->itemAPI->index(1, 2, true, 30, 20, true);
 
         $this->assertEquals(
             [
-            'items' => [$items[0]->toApi()]
+            'items' => [$item->toApi()]
             ], $response
         );
     }
@@ -102,7 +106,11 @@ class ItemApiControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testIndexDefaultBatchSize() 
     {
-        $items = [new Item()];
+        $item = new Item();
+        $item->setId(5);
+        $item->setGuid('guid');
+        $item->setGuidHash('guidhash');
+        $item->setFeedId(123);
 
         $this->itemService->expects($this->once())
             ->method('findAll')
@@ -115,13 +123,13 @@ class ItemApiControllerTest extends \PHPUnit_Framework_TestCase
                 $this->equalTo(false),
                 $this->equalTo($this->user->getUID())
             )
-            ->will($this->returnValue($items));
+            ->will($this->returnValue([$item]));
 
         $response = $this->itemAPI->index(1, 2, false);
 
         $this->assertEquals(
             [
-            'items' => [$items[0]->toApi()]
+            'items' => [$item->toApi()]
             ], $response
         );
     }
@@ -129,7 +137,11 @@ class ItemApiControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testUpdated() 
     {
-        $items = [new Item()];
+        $item = new Item();
+        $item->setId(5);
+        $item->setGuid('guid');
+        $item->setGuidHash('guidhash');
+        $item->setFeedId(123);
 
         $this->itemService->expects($this->once())
             ->method('findAllNew')
@@ -140,13 +152,13 @@ class ItemApiControllerTest extends \PHPUnit_Framework_TestCase
                 $this->equalTo(true),
                 $this->equalTo($this->user->getUID())
             )
-            ->will($this->returnValue($items));
+            ->will($this->returnValue([$item]));
 
         $response = $this->itemAPI->updated(1, 2, 30);
 
         $this->assertEquals(
             [
-            'items' => [$items[0]->toApi()]
+            'items' => [$item->toApi()]
             ], $response
         );
     }

--- a/tests/Unit/Db/FeedTest.php
+++ b/tests/Unit/Db/FeedTest.php
@@ -104,9 +104,11 @@ class FeedTest extends \PHPUnit_Framework_TestCase
 
     public function testSetXSSUrl() 
     {
+        $this->setExpectedException(\TypeError::class);
+
         $feed = new Feed();
         $feed->setUrl('javascript:alert()');
-        $this->assertEquals('', $feed->getUrl());
+        $feed->getUrl();
     }
 
 

--- a/tests/Unit/Db/FolderMapperTest.php
+++ b/tests/Unit/Db/FolderMapperTest.php
@@ -19,9 +19,11 @@ use OCA\News\Utility\Time;
 
 class FolderMapperTest extends MapperTestUtility
 {
-
+    /** @var FolderMapper */
     private $folderMapper;
+    /** @var Folder[] */
     private $folders;
+    /** @var string */
     private $user;
 
     protected function setUp()
@@ -32,7 +34,11 @@ class FolderMapperTest extends MapperTestUtility
 
         // create mock folders
         $folder1 = new Folder();
+        $folder1->setId(4);
+        $folder1->resetUpdatedFields();
         $folder2 = new Folder();
+        $folder2->setId(5);
+        $folder2->resetUpdatedFields();
 
         $this->folders = [$folder1, $folder2];
         $this->user = 'hh';

--- a/tests/Unit/Service/FeedServiceTest.php
+++ b/tests/Unit/Service/FeedServiceTest.php
@@ -27,6 +27,7 @@ class FeedServiceTest extends \PHPUnit_Framework_TestCase
 {
 
     private $feedMapper;
+    /** @var FeedService */
     private $feedService;
     private $user;
     private $response;
@@ -133,8 +134,10 @@ class FeedServiceTest extends \PHPUnit_Framework_TestCase
         $createdFeed->setBasicAuthUser('user');
         $createdFeed->setBasicAuthPassword('pass');
         $item1 = new Item();
+        $item1->setFeedId(4);
         $item1->setGuidHash('hi');
         $item2 = new Item();
+        $item2->setFeedId(4);
         $item2->setGuidHash('yo');
         $return = [
             $createdFeed,
@@ -155,7 +158,10 @@ class FeedServiceTest extends \PHPUnit_Framework_TestCase
         $this->feedMapper->expects($this->once())
             ->method('insert')
             ->with($this->equalTo($createdFeed))
-            ->will($this->returnValue($createdFeed));
+            ->will($this->returnCallback(function() use ($createdFeed) {
+                $createdFeed->setId(4);
+                return $createdFeed;
+            }));
         $this->itemMapper->expects($this->at(0))
             ->method('findByGuidHash')
             ->with(
@@ -210,8 +216,10 @@ class FeedServiceTest extends \PHPUnit_Framework_TestCase
         $createdFeed->setUrlHash($url);
         $createdFeed->setLink($url);
         $item1 = new Item();
+        $item1->setFeedId(5);
         $item1->setGuidHash('hi');
         $item2 = new Item();
+        $item2->setFeedId(5);
         $item2->setGuidHash('yo');
         $return = [
             $createdFeed,
@@ -232,7 +240,10 @@ class FeedServiceTest extends \PHPUnit_Framework_TestCase
         $this->feedMapper->expects($this->once())
             ->method('insert')
             ->with($this->equalTo($createdFeed))
-            ->will($this->returnValue($createdFeed));
+            ->will($this->returnCallback(function() use ($createdFeed) {
+                $createdFeed->setId(5);
+                return $createdFeed;
+            }));
         $this->itemMapper->expects($this->at(0))
             ->method('findByGuidHash')
             ->with(
@@ -519,9 +530,12 @@ class FeedServiceTest extends \PHPUnit_Framework_TestCase
     {
         $feed = new Feed();
         $feed->setId(3);
+        $feed->setUrl('http://example.com');
         $feed->setUrlHash('yo');
 
         $existingFeed = new Feed();
+        $existingFeed->setId(3);
+        $existingFeed->setUrl('http://example.com');
         $feed->setArticlesPerUpdate(2);
 
         $item = new Item();
@@ -552,11 +566,13 @@ class FeedServiceTest extends \PHPUnit_Framework_TestCase
     {
         $feed = new Feed();
         $feed->setId(3);
+        $feed->setUrl('http://example.com');
         $feed->setUpdateErrorCount(0);
         $feed->setLastUpdateError('');
 
         $exptectedFeed = new Feed();
         $exptectedFeed->setId(3);
+        $exptectedFeed->setUrl('http://example.com');
         $exptectedFeed->setUpdateErrorCount(1);
         $exptectedFeed->setLastUpdateError('hi');
 
@@ -655,6 +671,7 @@ class FeedServiceTest extends \PHPUnit_Framework_TestCase
         $feed = new Feed();
         $feed->setId(3);
         $feed->setArticlesPerUpdate(1);
+        $feed->setUrl('http://example.com');
 
         $item = new Item();
         $item->setGuidHash(md5('hi'));
@@ -733,6 +750,7 @@ class FeedServiceTest extends \PHPUnit_Framework_TestCase
         $feed = new Feed();
         $feed->setFolderId(16);
         $feed->setId($feedId);
+        $feed->setUrl('http://example.com');
 
         $this->feedMapper->expects($this->once())
             ->method('find')
@@ -909,7 +927,10 @@ class FeedServiceTest extends \PHPUnit_Framework_TestCase
         $this->feedMapper->expects($this->once())
             ->method('insert')
             ->with($this->equalTo($insertFeed))
-            ->will($this->returnValue($insertFeed));
+            ->will($this->returnCallback(function() use ($insertFeed) {
+                $insertFeed->setId(3);
+                return $insertFeed;
+            }));
 
 
         $this->itemMapper->expects($this->at(0))

--- a/tests/Unit/Utility/OPMLExporterTest.php
+++ b/tests/Unit/Utility/OPMLExporterTest.php
@@ -20,10 +20,16 @@ use OCA\News\Utility\OPMLExporter;
 
 class OPMLExporterTest extends \PHPUnit_Framework_TestCase
 {
-
+    /** @var OPMLExporter */
     private $exporter;
+    /** @var Feed */
     private $feed1;
+    /** @var Feed */
     private $feed2;
+    /** @var Folder */
+    private $folder1;
+    /** @var Folder */
+    private $folder2;
 
     protected function setUp() 
     {
@@ -37,11 +43,11 @@ class OPMLExporterTest extends \PHPUnit_Framework_TestCase
         $this->folder2->setParentId(3);
         $this->folder2->setName('a ergendwas');
         $this->feed1 = new Feed();
-        $this->feed1->setUrl('url 1');
+        $this->feed1->setUrl('http://url1');
         $this->feed1->setTitle('tötel');
         $this->feed1->setFolderId(0);
         $this->feed2 = new Feed();
-        $this->feed2->setUrl('url');
+        $this->feed2->setUrl('http://url');
         $this->feed2->setTitle('ttel df');
         $this->feed2->setLink('goooooogel');
         $this->feed2->setFolderId(1);


### PR DESCRIPTION
I had a look through some code here looking for some improvements.
So I want to propose to add own setters and getters to our entities to get rid of those magic calls inside the NC Entity. This also gives us the ability to define request and response types once we are switching to PHP7 like the current master of NC does.

I would like to see what others think about this change. If it is about to be accepted I would also add the methods for the remaining entities.