### PR TITLE
Feature: make compact mode headers sticky

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -227,7 +227,13 @@
 
 #app-content .compact .utils {
     cursor: pointer;
-    padding-top: 0;
+    padding: 0;
+    -webkit-position: sticky;
+    position: sticky;
+    top: 50px;
+    background-color: #fff;
+    height: 41px;
+    opacity: 0.9;
 }
 
 #app-content .utils ul {


### PR DESCRIPTION
Hello, this PR is an attempt to address [this issue](https://github.com/nextcloud/news/issues/115).

For compact view it makes the header of opened articles 'sticky' so that as you scroll down, the title bar for expanded articles remains in view for easy access to the action buttons (favorite/keep unread/etc).

It will work in Chrome and FF and should also work in Safari and Edge, but it won't work in IE.

There are a couple of other front-end issues labelled as help wanted that I would like to tackle, I picked this as an easy one to get my feet wet.