### PR TITLE
Put back old tests for stable nextcloud version and bump dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,21 @@ sudo: false
 dist: trusty
 language: php
 php:
-    - 7
+    - 7.0
     - 7.1
     - 7.2
     - nightly
 
 env:
     global:
-        - CORE_BRANCH=master
+        - CORE_BRANCH=stable14
         - MOZ_HEADLESS=1
     matrix:
         - DB=pgsql
 
 matrix:
     allow_failures:
+        - env: DB=pgsql CORE_BRANCH=master
         - php: nightly
     include:
         - php: 7.1
@@ -26,7 +27,9 @@ matrix:
           env: DB=mysql
         - php: 7.2
           env: DB=mysql
-    fast_finish: true
+        - php: 7.2
+          env: DB=pgsql CORE_BRANCH=master
+fast_finish: true
 
 before_install:
     - make
@@ -60,6 +63,4 @@ after_failure:
 addons:
     firefox: "latest-beta"
     postgresql: "9.6"
-
-services:
-    - mysql
+    mariadb: "10.3"

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,14 @@
         "source": "https://github.com/nextcloud/news/"
     },
     "require": {
-        "ezyang/htmlpurifier": "4.9.3",
+        "php": "^7.0",
+        "ezyang/htmlpurifier": "4.10.0",
         "miniflux/picofeed": "0.1.34",
-        "pear/net_url2": "2.2.1",
-        "riimu/kit-pathjoin": "1.1.2"
+        "pear/net_url2": "2.2.2",
+        "riimu/kit-pathjoin": "1.2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^6.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,23 +1,23 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b969e56c53d7689ef20e4d37aa320376",
+    "content-hash": "e4c50c7dfd750b774992ff7414429af8",
     "packages": [
         {
             "name": "ezyang/htmlpurifier",
-            "version": "v4.9.3",
+            "version": "v4.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ezyang/htmlpurifier.git",
-                "reference": "95e1bae3182efc0f3422896a3236e991049dac69"
+                "reference": "d85d39da4576a6934b72480be6978fb10c860021"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/95e1bae3182efc0f3422896a3236e991049dac69",
-                "reference": "95e1bae3182efc0f3422896a3236e991049dac69",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/d85d39da4576a6934b72480be6978fb10c860021",
+                "reference": "d85d39da4576a6934b72480be6978fb10c860021",
                 "shasum": ""
             },
             "require": {
@@ -51,7 +51,7 @@
             "keywords": [
                 "html"
             ],
-            "time": "2017-06-03T02:28:16+00:00"
+            "time": "2018-02-23T01:58:20+00:00"
         },
         {
             "name": "miniflux/picofeed",
@@ -109,16 +109,16 @@
         },
         {
             "name": "pear/net_url2",
-            "version": "v2.2.1",
+            "version": "v2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/Net_URL2.git",
-                "reference": "43a87606daf52efe6685c92131be083143108e37"
+                "reference": "07fd055820dbf466ee3990abe96d0e40a8791f9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/Net_URL2/zipball/43a87606daf52efe6685c92131be083143108e37",
-                "reference": "43a87606daf52efe6685c92131be083143108e37",
+                "url": "https://api.github.com/repos/pear/Net_URL2/zipball/07fd055820dbf466ee3990abe96d0e40a8791f9d",
+                "reference": "07fd055820dbf466ee3990abe96d0e40a8791f9d",
                 "shasum": ""
             },
             "require": {
@@ -139,6 +139,9 @@
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "./"
+            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -166,24 +169,29 @@
                 "uri",
                 "url"
             ],
-            "time": "2016-04-18T22:24:01+00:00"
+            "time": "2017-08-25T06:16:11+00:00"
         },
         {
             "name": "riimu/kit-pathjoin",
-            "version": "v1.1.2",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Riimu/Kit-PathJoin.git",
-                "reference": "5145afabdff12b5871f4a647e86ab2f05059d742"
+                "reference": "8ad2656c79527dba9f7f20e1229dcd38abfe8cee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Riimu/Kit-PathJoin/zipball/5145afabdff12b5871f4a647e86ab2f05059d742",
-                "reference": "5145afabdff12b5871f4a647e86ab2f05059d742",
+                "url": "https://api.github.com/repos/Riimu/Kit-PathJoin/zipball/8ad2656c79527dba9f7f20e1229dcd38abfe8cee",
+                "reference": "8ad2656c79527dba9f7f20e1229dcd38abfe8cee",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "phpunit/phpunit": "^5.7 || ^6.2",
+                "squizlabs/php_codesniffer": "^3.0"
             },
             "type": "library",
             "autoload": {
@@ -211,38 +219,39 @@
                 "path",
                 "system"
             ],
-            "time": "2015-08-22T11:29:24+00:00"
+            "time": "2017-07-09T14:41:04+00:00"
         },
         {
             "name": "zendframework/zendxml",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/ZendXml.git",
-                "reference": "7b64507bc35d841c9c5802d67f6f87ef8e1a58c9"
+                "reference": "267db6a2c431a08a8f8ff0f1f4c302a5ba6f5b99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/ZendXml/zipball/7b64507bc35d841c9c5802d67f6f87ef8e1a58c9",
-                "reference": "7b64507bc35d841c9c5802d67f6f87ef8e1a58c9",
+                "url": "https://api.github.com/repos/zendframework/ZendXml/zipball/267db6a2c431a08a8f8ff0f1f4c302a5ba6f5b99",
+                "reference": "267db6a2c431a08a8f8ff0f1f4c302a5ba6f5b99",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^3.7 || ^4.0",
-                "squizlabs/php_codesniffer": "^1.5"
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4",
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.1.x-dev",
+                    "dev-develop": "1.2.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "ZendXml\\": "library/"
+                "psr-4": {
+                    "ZendXml\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -250,13 +259,13 @@
                 "BSD-3-Clause"
             ],
             "description": "Utility library for XML usage, best practices, and security in PHP",
-            "homepage": "http://packages.zendframework.com/",
             "keywords": [
+                "ZendFramework",
                 "security",
                 "xml",
-                "zf2"
+                "zf"
             ],
-            "time": "2016-02-04T21:02:08+00:00"
+            "time": "2018-04-30T15:11:04+00:00"
         }
     ],
     "packages-dev": [
@@ -316,25 +325,28 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.7.0",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
+                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^4.1"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
@@ -357,7 +369,109 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19T19:58:43+00:00"
+            "time": "2018-06-11T23:09:50+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2017-03-05T18:14:27+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2017-03-05T17:38:23+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -513,33 +627,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.5",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
-                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -572,44 +686,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-02-19T10:16:54+00:00"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.8",
+            "version": "5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-file-iterator": "^1.3",
-                "phpunit/php-text-template": "^1.2",
-                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0",
-                "sebastian/environment": "^1.3.2 || ^2.0",
-                "sebastian/version": "^1.0 || ^2.0"
+                "php": "^7.0",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^2.0.1",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.1.4",
-                "phpunit/phpunit": "^5.7"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.1"
+                "ext-xdebug": "^2.5.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "5.3.x-dev"
                 }
             },
             "autoload": {
@@ -624,7 +738,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -635,7 +749,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-02T07:44:40+00:00"
+            "time": "2018-04-06T15:36:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -825,16 +939,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.27",
+            "version": "6.5.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c"
+                "reference": "0973426fb012359b2f18d3bd1e90ef1172839693"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
-                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0973426fb012359b2f18d3bd1e90ef1172839693",
+                "reference": "0973426fb012359b2f18d3bd1e90ef1172839693",
                 "shasum": ""
             },
             "require": {
@@ -843,33 +957,35 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "~1.3",
-                "php": "^5.6 || ^7.0",
-                "phpspec/prophecy": "^1.6.2",
-                "phpunit/php-code-coverage": "^4.0.4",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "^1.2.4",
-                "sebastian/diff": "^1.4.3",
-                "sebastian/environment": "^1.3.4 || ^2.0",
-                "sebastian/exporter": "~2.0",
-                "sebastian/global-state": "^1.1",
-                "sebastian/object-enumerator": "~2.0",
-                "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "^1.0.6|^2.0.1",
-                "symfony/yaml": "~2.1|~3.0|~4.0"
+                "myclabs/deep-copy": "^1.6.1",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
+                "php": "^7.0",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^5.3",
+                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^1.0.9",
+                "phpunit/phpunit-mock-objects": "^5.0.9",
+                "sebastian/comparator": "^2.1",
+                "sebastian/diff": "^2.0",
+                "sebastian/environment": "^3.1",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0.1"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2"
+                "phpdocumentor/reflection-docblock": "3.0.2",
+                "phpunit/dbunit": "<3.0"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "~1.1"
+                "phpunit/php-invoker": "^1.1"
             },
             "bin": [
                 "phpunit"
@@ -877,7 +993,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.7.x-dev"
+                    "dev-master": "6.5.x-dev"
                 }
             },
             "autoload": {
@@ -903,33 +1019,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-01T05:50:59+00:00"
+            "time": "2018-09-08T15:10:43+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.4",
+            "version": "5.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2 || ^2.0"
+                "doctrine/instantiator": "^1.0.5",
+                "php": "^7.0",
+                "phpunit/php-text-template": "^1.2.1",
+                "sebastian/exporter": "^3.1"
             },
             "conflict": {
-                "phpunit/phpunit": "<5.4.0"
+                "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.4"
+                "phpunit/phpunit": "^6.5.11"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -937,7 +1053,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -952,7 +1068,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -962,7 +1078,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2017-06-30T09:13:00+00:00"
+            "time": "2018-08-09T05:50:03+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1011,30 +1127,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.4",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
+                "php": "^7.0",
+                "sebastian/diff": "^2.0 || ^3.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -1065,38 +1181,38 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2018-02-01T13:46:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.3",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^6.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1123,32 +1239,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2017-05-22T07:24:03+00:00"
+            "time": "2017-08-03T08:09:46+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "2.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.0"
+                "phpunit/phpunit": "^6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1173,34 +1289,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26T07:53:53+00:00"
+            "time": "2017-07-01T08:51:00+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "2.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1240,27 +1356,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-11-19T08:54:04+00:00"
+            "time": "2017-04-03T13:19:02+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1268,7 +1384,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1291,33 +1407,34 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "2.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1337,32 +1454,77 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-02-18T15:18:39+00:00"
+            "time": "2017-08-03T12:35:26+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "2.0.0",
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1390,7 +1552,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-19T07:33:16+00:00"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -1478,62 +1640,44 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v4.0.6",
+            "name": "theseer/tokenizer",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "de5f125ea39de846b90b313b2cfb031a0152d223"
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/de5f125ea39de846b90b313b2cfb031a0152d223",
-                "reference": "de5f125ea39de846b90b313b2cfb031a0152d223",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
-            },
-            "conflict": {
-                "symfony/console": "<3.4"
-            },
-            "require-dev": {
-                "symfony/console": "~3.4|~4.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 }
             ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2018-02-19T20:08:53+00:00"
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2017-04-07T12:08:54+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1591,6 +1735,8 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": "^7.0"
+    },
     "platform-dev": []
 }

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -12,7 +12,7 @@
 
 namespace OCA\News\Tests\Integration;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 use OCA\News\Db\Feed;
 use OCA\News\Db\Item;

--- a/tests/Unit/Config/ConfigTest.php
+++ b/tests/Unit/Config/ConfigTest.php
@@ -14,10 +14,9 @@
 namespace OCA\News\Tests\Unit\Config;
 
 use OCA\News\Config\Config;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-
-class ConfigTest extends PHPUnit_Framework_TestCase
+class ConfigTest extends TestCase
 {
 
     private $fileSystem;

--- a/tests/Unit/Controller/AdminControllerTest.php
+++ b/tests/Unit/Controller/AdminControllerTest.php
@@ -14,8 +14,9 @@
 namespace OCA\News\Tests\Unit\Controller;
 
 use OCA\News\Controller\AdminController;
+use PHPUnit\Framework\TestCase;
 
-class AdminControllerTest extends \PHPUnit_Framework_TestCase
+class AdminControllerTest extends TestCase
 {
 
     private $appName;

--- a/tests/Unit/Controller/EntityApiSerializerTest.php
+++ b/tests/Unit/Controller/EntityApiSerializerTest.php
@@ -18,14 +18,14 @@ use \OCP\AppFramework\Http\Response;
 use \OCP\AppFramework\Db\Entity;
 
 use \OCA\News\Db\Item;
+use PHPUnit\Framework\TestCase;
 
 class TestEntity extends Entity
 {
 
 }
 
-
-class EntityApiSerializerTest extends \PHPUnit_Framework_TestCase
+class EntityApiSerializerTest extends TestCase
 {
 
 

--- a/tests/Unit/Controller/ExportControllerTest.php
+++ b/tests/Unit/Controller/ExportControllerTest.php
@@ -21,8 +21,9 @@ use \OCA\News\Utility\OPMLExporter;
 use \OCA\News\Db\Item;
 use \OCA\News\Db\Feed;
 
+use PHPUnit\Framework\TestCase;
 
-class ExportControllerTest extends \PHPUnit_Framework_TestCase
+class ExportControllerTest extends TestCase
 {
 
     private $appName;

--- a/tests/Unit/Controller/FeedApiControllerTest.php
+++ b/tests/Unit/Controller/FeedApiControllerTest.php
@@ -24,8 +24,9 @@ use \OCA\News\Db\Folder;
 use \OCA\News\Db\Feed;
 use \OCA\News\Db\Item;
 
+use PHPUnit\Framework\TestCase;
 
-class FeedApiControllerTest extends \PHPUnit_Framework_TestCase
+class FeedApiControllerTest extends TestCase
 {
 
     private $feedService;

--- a/tests/Unit/Controller/FeedControllerTest.php
+++ b/tests/Unit/Controller/FeedControllerTest.php
@@ -21,8 +21,9 @@ use OCA\News\Db\FeedType;
 use OCA\News\Service\ServiceNotFoundException;
 use OCA\News\Service\ServiceConflictException;
 
+use PHPUnit\Framework\TestCase;
 
-class FeedControllerTest extends \PHPUnit_Framework_TestCase
+class FeedControllerTest extends TestCase
 {
 
     private $appName;

--- a/tests/Unit/Controller/FolderApiControllerTest.php
+++ b/tests/Unit/Controller/FolderApiControllerTest.php
@@ -27,8 +27,10 @@ use \OCA\News\Db\Folder;
 use \OCA\News\Db\Feed;
 use \OCA\News\Db\Item;
 
+use PHPUnit\Framework\TestCase;
 
-class FolderApiControllerTest extends \PHPUnit_Framework_TestCase
+
+class FolderApiControllerTest extends TestCase
 {
 
     private $folderService;

--- a/tests/Unit/Controller/FolderControllerTest.php
+++ b/tests/Unit/Controller/FolderControllerTest.php
@@ -22,8 +22,10 @@ use \OCA\News\Service\ServiceNotFoundException;
 use \OCA\News\Service\ServiceConflictException;
 use \OCA\News\Service\ServiceValidationException;
 
+use PHPUnit\Framework\TestCase;
 
-class FolderControllerTest extends \PHPUnit_Framework_TestCase
+
+class FolderControllerTest extends TestCase
 {
 
     private $appName;

--- a/tests/Unit/Controller/ItemApiControllerTest.php
+++ b/tests/Unit/Controller/ItemApiControllerTest.php
@@ -21,8 +21,10 @@ use \OCP\AppFramework\Http;
 use \OCA\News\Service\ServiceNotFoundException;
 use \OCA\News\Db\Item;
 
+use PHPUnit\Framework\TestCase;
 
-class ItemApiControllerTest extends \PHPUnit_Framework_TestCase
+
+class ItemApiControllerTest extends TestCase
 {
 
     private $itemService;

--- a/tests/Unit/Controller/ItemControllerTest.php
+++ b/tests/Unit/Controller/ItemControllerTest.php
@@ -21,8 +21,10 @@ use \OCA\News\Db\Feed;
 use \OCA\News\Db\FeedType;
 use \OCA\News\Service\ServiceNotFoundException;
 
+use PHPUnit\Framework\TestCase;
 
-class ItemControllerTest extends \PHPUnit_Framework_TestCase
+
+class ItemControllerTest extends TestCase
 {
 
     private $appName;

--- a/tests/Unit/Controller/JSONHttpErrorTest.php
+++ b/tests/Unit/Controller/JSONHttpErrorTest.php
@@ -15,12 +15,14 @@ namespace OCA\News\Tests\Unit\Controller;
 
 use OCA\News\Controller\JSONHttpError;
 
+use PHPUnit\Framework\TestCase;
+
 class Test
 {
     use JSONHttpError;
 }
 
-class JSONHttpErrorTest extends \PHPUnit_Framework_TestCase
+class JSONHttpErrorTest extends TestCase
 {
 
 

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -15,9 +15,10 @@ namespace OCA\News\Tests\Unit\Controller;
 
 use OCA\News\Controller\PageController;
 use \OCA\News\Db\FeedType;
+use PHPUnit\Framework\TestCase;
 
 
-class PageControllerTest extends \PHPUnit_Framework_TestCase
+class PageControllerTest extends TestCase
 {
 
     private $settings;

--- a/tests/Unit/Controller/UserApiControllerTest.php
+++ b/tests/Unit/Controller/UserApiControllerTest.php
@@ -15,7 +15,9 @@ namespace OCA\News\Tests\Unit\Controller;
 
 use OCA\News\Controller\UserApiController;
 
-class UserApiControllerTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class UserApiControllerTest extends TestCase
 {
 
     private $request;

--- a/tests/Unit/Controller/UtilityApiControllerTest.php
+++ b/tests/Unit/Controller/UtilityApiControllerTest.php
@@ -17,7 +17,9 @@ namespace OCA\News\Tests\Unit\Controller;
 
 use OCA\News\Controller\UtilityApiController;
 
-class UtilityApiControllerTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class UtilityApiControllerTest extends TestCase
 {
 
     private $settings;

--- a/tests/Unit/Db/FeedTest.php
+++ b/tests/Unit/Db/FeedTest.php
@@ -13,10 +13,10 @@
 
 namespace OCA\News\Tests\Unit\Db;
 
-
+use PHPUnit\Framework\TestCase;
 use OCA\News\Db\Feed;
 
-class FeedTest extends \PHPUnit_Framework_TestCase
+class FeedTest extends TestCase
 {
 
 

--- a/tests/Unit/Db/FolderMapperTest.php
+++ b/tests/Unit/Db/FolderMapperTest.php
@@ -70,7 +70,7 @@ class FolderMapperTest extends MapperTestUtility
 
         $this->setMapperResult($sql, [$id, $userId]);
 
-        $this->setExpectedException(
+        $this->expectException(
             '\OCP\AppFramework\Db\DoesNotExistException'
         );
         $this->folderMapper->find($id, $userId);
@@ -88,7 +88,7 @@ class FolderMapperTest extends MapperTestUtility
 
         $this->setMapperResult($sql, [$id, $userId], $rows);
 
-        $this->setExpectedException(
+        $this->expectException(
             '\OCP\AppFramework\Db\MultipleObjectsReturnedException'
         );
         $this->folderMapper->find($id, $userId);

--- a/tests/Unit/Db/FolderTest.php
+++ b/tests/Unit/Db/FolderTest.php
@@ -14,8 +14,9 @@
 namespace OCA\News\Tests\Unit\Db;
 
 use OCA\News\Db\Folder;
+use PHPUnit\Framework\TestCase;
 
-class FolderTest extends \PHPUnit_Framework_TestCase
+class FolderTest extends TestCase
 {
 
 

--- a/tests/Unit/Db/ItemTest.php
+++ b/tests/Unit/Db/ItemTest.php
@@ -16,7 +16,9 @@ namespace OCA\News\Tests\Unit\Db;
 use OCA\News\Db\Feed;
 use OCA\News\Db\Item;
 
-class ItemTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ItemTest extends TestCase
 {
 
     /**

--- a/tests/Unit/Db/MapperFactoryTest.php
+++ b/tests/Unit/Db/MapperFactoryTest.php
@@ -16,14 +16,14 @@ namespace OCA\News\Tests\Unit\Db;
 use OCA\News\Db\ItemMapper;
 use OCA\News\Db\MapperFactory;
 use OCA\News\Utility\Time;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 use OCP\IDBConnection;
 
 use OCA\News\Db\Mysql\ItemMapper as MysqlMapper;
 
 
-class MapperFactoryTest extends PHPUnit_Framework_TestCase
+class MapperFactoryTest extends TestCase
 {
 
     private $db;

--- a/tests/Unit/Db/MapperTestUtility.php
+++ b/tests/Unit/Db/MapperTestUtility.php
@@ -23,10 +23,11 @@
 
 namespace OCA\News\Tests\Unit\Db;
 
+use PHPUnit\Framework\TestCase;
 /**
  * Simple utility class for testing mappers
  */
-abstract class MapperTestUtility extends \PHPUnit_Framework_TestCase
+abstract class MapperTestUtility extends TestCase
 {
     protected $db;
     private $query;

--- a/tests/Unit/Fetcher/FeedFetcherTest.php
+++ b/tests/Unit/Fetcher/FeedFetcherTest.php
@@ -18,9 +18,10 @@ use \OCA\News\Db\Feed;
 use OCA\News\Fetcher\FeedFetcher;
 use OCP\Http\Client\IClientService;
 use PicoFeed\Processor\ItemPostProcessor;
+use PHPUnit\Framework\TestCase;
 
 
-class FeedFetcherTest extends \PHPUnit_Framework_TestCase
+class FeedFetcherTest extends TestCase
 {
 
     private $fetcher;

--- a/tests/Unit/Fetcher/FetcherTest.php
+++ b/tests/Unit/Fetcher/FetcherTest.php
@@ -26,8 +26,9 @@ namespace OCA\News\Tests\Unit\Fetcher;
 
 
 use OCA\News\Fetcher\Fetcher;
+use PHPUnit\Framework\TestCase;
 
-class FetcherTest extends \PHPUnit_Framework_TestCase
+class FetcherTest extends TestCase
 {
 
     private $fetcher;

--- a/tests/Unit/Fetcher/YoutubeFetcherTest.php
+++ b/tests/Unit/Fetcher/YoutubeFetcherTest.php
@@ -14,8 +14,9 @@ namespace OCA\News\Tests\Unit\Fetcher;
 use \OCA\News\Db\Feed;
 use OCA\News\Fetcher\YoutubeFetcher;
 
+use PHPUnit\Framework\TestCase;
 
-class YoutubeFetcherTest extends \PHPUnit_Framework_TestCase
+class YoutubeFetcherTest extends TestCase
 {
 
     private $fetcher;

--- a/tests/Unit/Http/TextDownloadResponseTest.php
+++ b/tests/Unit/Http/TextDownloadResponseTest.php
@@ -16,8 +16,9 @@ namespace OCA\News\Tests\Unit\Http;
 
 
 use OCA\News\Http\TextDownloadResponse;
+use PHPUnit\Framework\TestCase;
 
-class TextDownloadResponseTest extends \PHPUnit_Framework_TestCase
+class TextDownloadResponseTest extends TestCase
 {
 
 

--- a/tests/Unit/Http/TextResponseTest.php
+++ b/tests/Unit/Http/TextResponseTest.php
@@ -14,10 +14,10 @@
 
 namespace OCA\News\Tests\Unit\Http;
 
-
+use PHPUnit\Framework\TestCase;
 use OCA\News\Http\TextResponse;
 
-class TextResponseTest extends \PHPUnit_Framework_TestCase
+class TextResponseTest extends TestCase
 {
 
 

--- a/tests/Unit/Service/FeedServiceTest.php
+++ b/tests/Unit/Service/FeedServiceTest.php
@@ -22,8 +22,10 @@ use OCA\News\Db\Item;
 use OCA\News\Fetcher\Fetcher;
 use OCA\News\Fetcher\FetcherException;
 
+use PHPUnit\Framework\TestCase;
 
-class FeedServiceTest extends \PHPUnit_Framework_TestCase
+
+class FeedServiceTest extends TestCase
 {
 
     private $feedMapper;
@@ -114,7 +116,7 @@ class FeedServiceTest extends \PHPUnit_Framework_TestCase
             ->method('fetch')
             ->with($this->equalTo($url))
             ->will($this->throwException($ex));
-        $this->setExpectedException(
+        $this->expectException(
             '\OCA\News\Service\ServiceNotFoundException'
         );
         $this->feedService->create($url, 1, $this->user);
@@ -606,7 +608,7 @@ class FeedServiceTest extends \PHPUnit_Framework_TestCase
             )
             ->will($this->throwException($ex));
 
-        $this->setExpectedException(
+        $this->expectException(
             '\OCA\News\Service\ServiceNotFoundException'
         );
         $this->feedService->update($feed->getId(), $this->user);
@@ -643,7 +645,7 @@ class FeedServiceTest extends \PHPUnit_Framework_TestCase
             )
             ->will($this->throwException($ex));
 
-        $this->setExpectedException(
+        $this->expectException(
             'OCP\AppFramework\Db\DoesNotExistException'
         );
         $this->feedService->update($feed->getId(), $this->user);
@@ -698,7 +700,7 @@ class FeedServiceTest extends \PHPUnit_Framework_TestCase
             )
             ->will($this->throwException($ex));
 
-        $this->setExpectedException(
+        $this->expectException(
             '\OCA\News\Service\ServiceNotFoundException'
         );
         $this->feedService->update($feed->getId(), $this->user);
@@ -1100,7 +1102,7 @@ class FeedServiceTest extends \PHPUnit_Framework_TestCase
             )
             ->will($this->throwException(new DoesNotExistException('')));
 
-        $this->setExpectedException(
+        $this->expectException(
             '\OCA\News\Service\ServiceNotFoundException'
         );
 

--- a/tests/Unit/Service/FolderServiceTest.php
+++ b/tests/Unit/Service/FolderServiceTest.php
@@ -16,8 +16,10 @@ namespace OCA\News\Tests\Unit\Service;
 use \OCA\News\Db\Folder;
 use OCA\News\Service\FolderService;
 
+use PHPUnit\Framework\TestCase;
 
-class FolderServiceTest extends \PHPUnit_Framework_TestCase
+
+class FolderServiceTest extends TestCase
 {
 
     private $folderMapper;
@@ -111,7 +113,7 @@ class FolderServiceTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo($folderName))
             ->will($this->returnValue($rows));
 
-        $this->setExpectedException(
+        $this->expectException(
             '\OCA\News\Service\ServiceConflictException'
         );
         $this->folderService->create($folderName, 'john', 3);
@@ -190,7 +192,7 @@ class FolderServiceTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo($folderName))
             ->will($this->returnValue($rows));
 
-        $this->setExpectedException(
+        $this->expectException(
             '\OCA\News\Service\ServiceConflictException'
         );
         $this->folderService->rename(3, $folderName, 'john');
@@ -206,7 +208,7 @@ class FolderServiceTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo($folderName))
             ->will($this->returnValue([]));
 
-        $this->setExpectedException(
+        $this->expectException(
             '\OCA\News\Service\ServiceValidationException'
         );
         $this->folderService->rename(3, $folderName, 'john');

--- a/tests/Unit/Service/ItemServiceTest.php
+++ b/tests/Unit/Service/ItemServiceTest.php
@@ -19,8 +19,10 @@ use \OCP\AppFramework\Db\DoesNotExistException;
 use \OCA\News\Db\Item;
 use \OCA\News\Db\FeedType;
 
+use PHPUnit\Framework\TestCase;
 
-class ItemServiceTest extends \PHPUnit_Framework_TestCase
+
+class ItemServiceTest extends TestCase
 {
 
     private $mapper;
@@ -337,7 +339,7 @@ class ItemServiceTest extends \PHPUnit_Framework_TestCase
     public function testReadDoesNotExist()
     {
 
-        $this->setExpectedException(
+        $this->expectException(
             '\OCA\News\Service\ServiceNotFoundException'
         );
         $this->mapper->expects($this->once())
@@ -350,7 +352,7 @@ class ItemServiceTest extends \PHPUnit_Framework_TestCase
     public function testStarDoesNotExist()
     {
 
-        $this->setExpectedException(
+        $this->expectException(
             '\OCA\News\Service\ServiceNotFoundException'
         );
         $this->mapper->expects($this->once())
@@ -460,7 +462,7 @@ class ItemServiceTest extends \PHPUnit_Framework_TestCase
                 )
             );
 
-        $this->setExpectedException(
+        $this->expectException(
             '\OCA\News\Service\ServiceNotFoundException'
         );
         $this->itemService->getNewestItemId($this->user);

--- a/tests/Unit/Service/ServiceTest.php
+++ b/tests/Unit/Service/ServiceTest.php
@@ -18,6 +18,7 @@ use \OCP\AppFramework\Db\DoesNotExistException;
 use \OCP\AppFramework\Db\MultipleObjectsReturnedException;
 
 use \OCA\News\Db\Folder;
+use PHPUnit\Framework\TestCase;
 
 
 class TestService extends Service
@@ -28,7 +29,7 @@ class TestService extends Service
     }
 }
 
-class ServiceTest extends \PHPUnit_Framework_TestCase
+class ServiceTest extends TestCase
 {
 
     protected $mapper;
@@ -83,7 +84,7 @@ class ServiceTest extends \PHPUnit_Framework_TestCase
             ->method('find')
             ->will($this->throwException($ex));
 
-        $this->setExpectedException(
+        $this->expectException(
             '\OCA\News\Service\ServiceNotFoundException'
         );
         $this->newsService->find(1, '');
@@ -98,7 +99,7 @@ class ServiceTest extends \PHPUnit_Framework_TestCase
             ->method('find')
             ->will($this->throwException($ex));
 
-        $this->setExpectedException(
+        $this->expectException(
             '\OCA\News\Service\ServiceNotFoundException'
         );
         $this->newsService->find(1, '');

--- a/tests/Unit/Service/StatusServiceTest.php
+++ b/tests/Unit/Service/StatusServiceTest.php
@@ -15,9 +15,10 @@ namespace OCA\News\Tests\Unit\Service;
 
 use \OCA\News\Db\FeedType;
 use OCA\News\Service\StatusService;
+use PHPUnit\Framework\TestCase;
 
 
-class StatusServiceTest extends \PHPUnit_Framework_TestCase
+class StatusServiceTest extends TestCase
 {
 
     private $settings;

--- a/tests/Unit/Utility/OPMLExporterTest.php
+++ b/tests/Unit/Utility/OPMLExporterTest.php
@@ -16,9 +16,10 @@ namespace OCA\News\Tests\Unit\Utility;
 use \OCA\News\Db\Folder;
 use \OCA\News\Db\Feed;
 use OCA\News\Utility\OPMLExporter;
+use PHPUnit\Framework\TestCase;
 
 
-class OPMLExporterTest extends \PHPUnit_Framework_TestCase
+class OPMLExporterTest extends TestCase
 {
 
     private $exporter;

--- a/tests/Unit/Utility/ProxyConfigParserTest.php
+++ b/tests/Unit/Utility/ProxyConfigParserTest.php
@@ -15,8 +15,9 @@ namespace OCA\News\Tests\Unit\Utility;
 
 
 use OCA\News\Utility\ProxyConfigParser;
+use PHPUnit\Framework\TestCase;
 
-class ProxyConfigParserTest extends \PHPUnit_Framework_TestCase
+class ProxyConfigParserTest extends TestCase
 {
 
     private $config;

--- a/tests/Unit/Utility/UpdaterTest.php
+++ b/tests/Unit/Utility/UpdaterTest.php
@@ -13,10 +13,10 @@
 
 namespace OCA\News\Tests\Unit\Utility;
 
-
 use OCA\News\Utility\Updater;
+use PHPUnit\Framework\TestCase;
 
-class UpdaterTest extends \PHPUnit_Framework_TestCase
+class UpdaterTest extends TestCase
 {
 
     private $folderService;


### PR DESCRIPTION
This review makes tests work against the stable nextcloud by default again. There's still a test against master for future compatibility. It also bumps composer requirements and the used postgres version