### PR TITLE
Use magic class constant

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -13,6 +13,8 @@
 
 namespace OCA\News\AppInfo;
 
+use OCA\News\Hooks\User;
+
 require_once __DIR__ . '/../vendor/autoload.php';
 
-\OCP\Util::connectHook('OC_User', 'pre_deleteUser', 'OCA\News\Hooks\User', 'deleteUser');
+\OCP\Util::connectHook('OC_User', 'pre_deleteUser', User::class, 'deleteUser');

--- a/tests/Unit/Config/ConfigTest.php
+++ b/tests/Unit/Config/ConfigTest.php
@@ -14,6 +14,9 @@
 namespace OCA\News\Tests\Unit\Config;
 
 use OCA\News\Config\Config;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\ILogger;
 use PHPUnit\Framework\TestCase;
 
 class ConfigTest extends TestCase
@@ -26,12 +29,10 @@ class ConfigTest extends TestCase
 
     public function setUp() 
     {
-        $this->logger = $this->getMockBuilder(
-            'OCP\ILogger'
-        )
+        $this->logger = $this->getMockBuilder(ILogger::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->fileSystem = $this->getMockBuilder('OCP\Files\Folder')->getMock();
+        $this->fileSystem = $this->getMockBuilder(Folder::class)->getMock();
         $this->loggerParams = ['hi'];
         $this->config = new Config(
             $this->fileSystem, $this->logger, $this->loggerParams
@@ -54,7 +55,7 @@ class ConfigTest extends TestCase
 
     public function testRead() 
     {
-        $file = $this->getMockBuilder('OCP\Files\File')->getMock();
+        $file = $this->getMockBuilder(File::class)->getMock();
         $this->fileSystem->expects($this->once())
             ->method('get')
             ->with($this->equalTo($this->configPath))
@@ -77,7 +78,7 @@ class ConfigTest extends TestCase
 
     public function testReadIgnoresVeryLowPurgeInterval() 
     {
-        $file = $this->getMockBuilder('OCP\Files\File')->getMock();
+        $file = $this->getMockBuilder(File::class)->getMock();
         $this->fileSystem->expects($this->once())
             ->method('get')
             ->with($this->equalTo($this->configPath))
@@ -95,7 +96,7 @@ class ConfigTest extends TestCase
 
     public function testReadBool() 
     {
-        $file = $this->getMockBuilder('OCP\Files\File')->getMock();
+        $file = $this->getMockBuilder(File::class)->getMock();
         $this->fileSystem->expects($this->once())
             ->method('get')
             ->with($this->equalTo($this->configPath))
@@ -117,7 +118,7 @@ class ConfigTest extends TestCase
 
     public function testReadLogsInvalidValue() 
     {
-        $file = $this->getMockBuilder('OCP\Files\File')->getMock();
+        $file = $this->getMockBuilder(File::class)->getMock();
         $this->fileSystem->expects($this->once())
             ->method('get')
             ->with($this->equalTo($this->configPath))
@@ -141,7 +142,7 @@ class ConfigTest extends TestCase
 
     public function testReadLogsInvalidINI() 
     {
-        $file = $this->getMockBuilder('OCP\Files\File')->getMock();
+        $file = $this->getMockBuilder(File::class)->getMock();
         $this->fileSystem->expects($this->once())
             ->method('get')
             ->with($this->equalTo($this->configPath))
@@ -173,7 +174,7 @@ class ConfigTest extends TestCase
         $this->config->setMaxSize(399);
         $this->config->setExploreUrl('http://google.de');
 
-        $file = $this->getMockBuilder('OCP\Files\File')->getMock();
+        $file = $this->getMockBuilder(File::class)->getMock();
         $this->fileSystem->expects($this->once())
             ->method('get')
             ->with($this->equalTo($this->configPath))
@@ -207,7 +208,7 @@ class ConfigTest extends TestCase
         $this->fileSystem->expects($this->once())
             ->method('newFile')
             ->with($this->equalTo($this->configPath));
-        $file = $this->getMockBuilder('OCP\Files\File')->getMock();
+        $file = $this->getMockBuilder(File::class)->getMock();
         $this->fileSystem->expects($this->once())
             ->method('get')
             ->with($this->equalTo($this->configPath))

--- a/tests/Unit/Controller/AdminControllerTest.php
+++ b/tests/Unit/Controller/AdminControllerTest.php
@@ -13,7 +13,10 @@
 
 namespace OCA\News\Tests\Unit\Controller;
 
+use OCA\News\Config\Config;
 use OCA\News\Controller\AdminController;
+use OCA\News\Service\ItemService;
+use OCP\IRequest;
 use PHPUnit\Framework\TestCase;
 
 class AdminControllerTest extends TestCase
@@ -32,19 +35,13 @@ class AdminControllerTest extends TestCase
     public function setUp()
     {
         $this->appName = 'news';
-        $this->request = $this->getMockBuilder(
-            '\OCP\IRequest'
-        )
+        $this->request = $this->getMockBuilder(IRequest::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->config = $this->getMockBuilder(
-            '\OCA\News\Config\Config'
-        )
+        $this->config = $this->getMockBuilder(Config::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->itemService = $this->getMockBuilder(
-            '\OCA\News\Service\ItemService'
-        )
+        $this->itemService = $this->getMockBuilder(ItemService::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/Unit/Controller/ExportControllerTest.php
+++ b/tests/Unit/Controller/ExportControllerTest.php
@@ -14,12 +14,15 @@
 namespace OCA\News\Tests\Unit\Controller;
 
 use OCA\News\Controller\ExportController;
-use \OCP\AppFramework\Http;
+use OCA\News\Service\FeedService;
+use OCA\News\Service\FolderService;
+use OCA\News\Service\ItemService;
 
 use \OCA\News\Http\TextDownloadResponse;
 use \OCA\News\Utility\OPMLExporter;
 use \OCA\News\Db\Item;
 use \OCA\News\Db\Feed;
+use OCP\IRequest;
 
 use PHPUnit\Framework\TestCase;
 
@@ -42,22 +45,16 @@ class ExportControllerTest extends TestCase
     {
         $this->appName = 'news';
         $this->user = 'john';
-        $this->itemService = $this->getMockBuilder(
-            '\OCA\News\Service\ItemService'
-        )
+        $this->itemService = $this->getMockBuilder(ItemService::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->feedService = $this->getMockBuilder(
-            '\OCA\News\Service\FeedService'
-        )
+        $this->feedService = $this->getMockBuilder(FeedService::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->folderService = $this->getMockBuilder(
-            '\OCA\News\Service\FolderService'
-        )
+        $this->folderService = $this->getMockBuilder(FolderService::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->request = $this->getMockBuilder('\OCP\IRequest')
+        $this->request = $this->getMockBuilder(IRequest::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->opmlExporter = new OPMLExporter();

--- a/tests/Unit/Controller/FeedApiControllerTest.php
+++ b/tests/Unit/Controller/FeedApiControllerTest.php
@@ -16,13 +16,17 @@
 namespace OCA\News\Tests\Unit\Controller;
 
 use OCA\News\Controller\FeedApiController;
+use OCA\News\Service\FeedService;
+use OCA\News\Service\ItemService;
 use \OCP\AppFramework\Http;
 
 use \OCA\News\Service\ServiceNotFoundException;
 use \OCA\News\Service\ServiceConflictException;
-use \OCA\News\Db\Folder;
 use \OCA\News\Db\Feed;
-use \OCA\News\Db\Item;
+use OCP\ILogger;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 
 use PHPUnit\Framework\TestCase;
 
@@ -43,25 +47,17 @@ class FeedApiControllerTest extends TestCase
     protected function setUp() 
     {
         $this->loggerParams = ['hi'];
-        $this->logger = $this->getMockBuilder(
-            '\OCP\ILogger'
-        )
+        $this->logger = $this->getMockBuilder(ILogger::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->appName = 'news';
-        $this->request = $this->getMockBuilder(
-            '\OCP\IRequest'
-        )
+        $this->request = $this->getMockBuilder(IRequest::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->userSession = $this->getMockBuilder(
-            '\OCP\IUserSession'
-        )
+        $this->userSession = $this->getMockBuilder(IUserSession::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->user = $this->getMockBuilder(
-            '\OCP\IUser'
-        )
+        $this->user = $this->getMockBuilder(IUser::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->userSession->expects($this->any())
@@ -70,14 +66,10 @@ class FeedApiControllerTest extends TestCase
         $this->user->expects($this->any())
             ->method('getUID')
             ->will($this->returnValue('123'));
-        $this->feedService = $this->getMockBuilder(
-            '\OCA\News\Service\FeedService'
-        )
+        $this->feedService = $this->getMockBuilder(FeedService::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->itemService = $this->getMockBuilder(
-            '\OCA\News\Service\ItemService'
-        )
+        $this->itemService = $this->getMockBuilder(ItemService::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->feedAPI = new FeedApiController(

--- a/tests/Unit/Controller/FeedControllerTest.php
+++ b/tests/Unit/Controller/FeedControllerTest.php
@@ -14,12 +14,17 @@
 namespace OCA\News\Tests\Unit\Controller;
 
 use OCA\News\Controller\FeedController;
+use OCA\News\Service\FeedService;
+use OCA\News\Service\FolderService;
+use OCA\News\Service\ItemService;
 use OCP\AppFramework\Http;
 
 use OCA\News\Db\Feed;
 use OCA\News\Db\FeedType;
 use OCA\News\Service\ServiceNotFoundException;
 use OCA\News\Service\ServiceConflictException;
+use OCP\IConfig;
+use OCP\IRequest;
 
 use PHPUnit\Framework\TestCase;
 
@@ -44,26 +49,22 @@ class FeedControllerTest extends TestCase
     {
         $this->appName = 'news';
         $this->user = 'jack';
-        $this->settings = $this->getMockBuilder(
-            '\OCP\IConfig'
-        )
+        $this->settings = $this->getMockBuilder(IConfig::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->itemService = $this
-            ->getMockBuilder('\OCA\News\Service\ItemService')
+            ->getMockBuilder(ItemService::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->feedService = $this
-            ->getMockBuilder('\OCA\News\Service\FeedService')
+            ->getMockBuilder(FeedService::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->folderService = $this
-            ->getMockBuilder('\OCA\News\Service\FolderService')
+            ->getMockBuilder(FolderService::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->request = $this->getMockBuilder(
-            '\OCP\IRequest'
-        )
+        $this->request = $this->getMockBuilder(IRequest::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->controller = new FeedController(

--- a/tests/Unit/Controller/FolderApiControllerTest.php
+++ b/tests/Unit/Controller/FolderApiControllerTest.php
@@ -16,16 +16,18 @@
 namespace OCA\News\Tests\Unit\Controller;
 
 use OCA\News\Controller\FolderApiController;
+use OCA\News\Service\FolderService;
+use OCA\News\Service\ItemService;
 use \OCP\AppFramework\Http;
-use \OCP\AppFramework\Http\JSONResponse;
 
 use \OCA\News\Service\ServiceNotFoundException;
 use \OCA\News\Service\ServiceConflictException;
 use \OCA\News\Service\ServiceValidationException;
 
 use \OCA\News\Db\Folder;
-use \OCA\News\Db\Feed;
-use \OCA\News\Db\Item;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 
 use PHPUnit\Framework\TestCase;
 
@@ -45,19 +47,13 @@ class FolderApiControllerTest extends TestCase
     protected function setUp() 
     {
         $this->appName = 'news';
-        $this->request = $this->getMockBuilder(
-            '\OCP\IRequest'
-        )
+        $this->request = $this->getMockBuilder(IRequest::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->userSession = $this->getMockBuilder(
-            '\OCP\IUserSession'
-        )
+        $this->userSession = $this->getMockBuilder(IUserSession::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->user = $this->getMockBuilder(
-            '\OCP\IUser'
-        )
+        $this->user = $this->getMockBuilder(IUser::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->userSession->expects($this->any())
@@ -66,14 +62,10 @@ class FolderApiControllerTest extends TestCase
         $this->user->expects($this->any())
             ->method('getUID')
             ->will($this->returnValue('123'));
-        $this->folderService = $this->getMockBuilder(
-            '\OCA\News\Service\FolderService'
-        )
+        $this->folderService = $this->getMockBuilder(FolderService::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->itemService = $this->getMockBuilder(
-            '\OCA\News\Service\ItemService'
-        )
+        $this->itemService = $this->getMockBuilder(ItemService::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->folderAPI = new FolderApiController(

--- a/tests/Unit/Controller/FolderControllerTest.php
+++ b/tests/Unit/Controller/FolderControllerTest.php
@@ -14,6 +14,9 @@
 namespace OCA\News\Tests\Unit\Controller;
 
 use OCA\News\Controller\FolderController;
+use OCA\News\Service\FeedService;
+use OCA\News\Service\FolderService;
+use OCA\News\Service\ItemService;
 use \OCP\AppFramework\Http;
 
 use \OCA\News\Db\Folder;
@@ -21,6 +24,7 @@ use \OCA\News\Db\Feed;
 use \OCA\News\Service\ServiceNotFoundException;
 use \OCA\News\Service\ServiceConflictException;
 use \OCA\News\Service\ServiceValidationException;
+use OCP\IRequest;
 
 use PHPUnit\Framework\TestCase;
 
@@ -44,24 +48,16 @@ class FolderControllerTest extends TestCase
     {
         $this->appName = 'news';
         $this->user = 'jack';
-        $this->folderService = $this->getMockBuilder(
-            '\OCA\News\Service\FolderService'
-        )
+        $this->folderService = $this->getMockBuilder(FolderService::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->feedService = $this->getMockBuilder(
-            '\OCA\News\Service\FeedService'
-        )
+        $this->feedService = $this->getMockBuilder(FeedService::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->itemService = $this->getMockBuilder(
-            '\OCA\News\Service\ItemService'
-        )
+        $this->itemService = $this->getMockBuilder(ItemService::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->request = $this->getMockBuilder(
-            '\OCP\IRequest'
-        )
+        $this->request = $this->getMockBuilder(IRequest::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->controller = new FolderController(

--- a/tests/Unit/Controller/ItemApiControllerTest.php
+++ b/tests/Unit/Controller/ItemApiControllerTest.php
@@ -16,10 +16,14 @@
 namespace OCA\News\Tests\Unit\Controller;
 
 use OCA\News\Controller\ItemApiController;
+use OCA\News\Service\ItemService;
 use \OCP\AppFramework\Http;
 
 use \OCA\News\Service\ServiceNotFoundException;
 use \OCA\News\Db\Item;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 
 use PHPUnit\Framework\TestCase;
 
@@ -39,19 +43,13 @@ class ItemApiControllerTest extends TestCase
     {
         $this->user = 'tom';
         $this->appName = 'news';
-        $this->request = $this->getMockBuilder(
-            '\OCP\IRequest'
-        )
+        $this->request = $this->getMockBuilder(IRequest::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->userSession = $this->getMockBuilder(
-            '\OCP\IUserSession'
-        )
+        $this->userSession = $this->getMockBuilder(IUserSession::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->user = $this->getMockBuilder(
-            '\OCP\IUser'
-        )
+        $this->user = $this->getMockBuilder(IUser::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->userSession->expects($this->any())
@@ -60,9 +58,7 @@ class ItemApiControllerTest extends TestCase
         $this->user->expects($this->any())
             ->method('getUID')
             ->will($this->returnValue('123'));
-        $this->itemService = $this->getMockBuilder(
-            '\OCA\News\Service\ItemService'
-        )
+        $this->itemService = $this->getMockBuilder(ItemService::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->itemAPI = new ItemApiController(

--- a/tests/Unit/Controller/ItemControllerTest.php
+++ b/tests/Unit/Controller/ItemControllerTest.php
@@ -14,12 +14,16 @@
 namespace OCA\News\Tests\Unit\Controller;
 
 use OCA\News\Controller\ItemController;
+use OCA\News\Service\FeedService;
+use OCA\News\Service\ItemService;
 use \OCP\AppFramework\Http;
 
 use \OCA\News\Db\Item;
 use \OCA\News\Db\Feed;
 use \OCA\News\Db\FeedType;
 use \OCA\News\Service\ServiceNotFoundException;
+use OCP\IConfig;
+use OCP\IRequest;
 
 use PHPUnit\Framework\TestCase;
 
@@ -43,22 +47,18 @@ class ItemControllerTest extends TestCase
     {
         $this->appName = 'news';
         $this->user = 'jackob';
-        $this->settings = $this->getMockBuilder(
-            '\OCP\IConfig'
-        )
+        $this->settings = $this->getMockBuilder(IConfig::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->itemService =
-        $this->getMockBuilder('\OCA\News\Service\ItemService')
+        $this->getMockBuilder(ItemService::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->feedService =
-        $this->getMockBuilder('\OCA\News\Service\FeedService')
+        $this->getMockBuilder(FeedService::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->request = $this->getMockBuilder(
-            '\OCP\IRequest'
-        )
+        $this->request = $this->getMockBuilder(IRequest::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->controller = new ItemController(

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -13,8 +13,15 @@
 
 namespace OCA\News\Tests\Unit\Controller;
 
+use OCA\News\Config\Config;
 use OCA\News\Controller\PageController;
 use \OCA\News\Db\FeedType;
+use OCA\News\Explore\RecommendedSites;
+use OCA\News\Service\StatusService;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IURLGenerator;
 use PHPUnit\Framework\TestCase;
 
 
@@ -51,44 +58,28 @@ class PageControllerTest extends TestCase
             'description' => 'This is a test app',
             'homepage' => 'https://github.com/owncloud/test'
         ];
-        $this->l10n = $this->request = $this->getMockBuilder(
-            '\OCP\IL10n'
-        )
+        $this->l10n = $this->request = $this->getMockBuilder(IL10N::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->settings = $this->getMockBuilder(
-            '\OCP\IConfig'
-        )
+        $this->settings = $this->getMockBuilder(IConfig::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->request = $this->getMockBuilder(
-            '\OCP\IRequest'
-        )
+        $this->request = $this->getMockBuilder(IRequest::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->urlGenerator = $this->getMockBuilder(
-            '\OCP\IURLGenerator'
-        )
+        $this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->appConfig = $this->getMockBuilder(
-            '\OCA\News\Config\Config'
-        )
+        $this->appConfig = $this->getMockBuilder(Config::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->config = $this->getMockBuilder(
-            '\OCA\News\Config\Config'
-        )
+        $this->config = $this->getMockBuilder(Config::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->recommended = $this->getMockBuilder(
-            '\OCA\News\Explore\RecommendedSites'
-        )
+        $this->recommended = $this->getMockBuilder(RecommendedSites::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->status = $this->getMockBuilder(
-            '\OCA\News\Service\StatusService'
-        )
+        $this->status = $this->getMockBuilder(StatusService::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->controller = new PageController(

--- a/tests/Unit/Controller/UserApiControllerTest.php
+++ b/tests/Unit/Controller/UserApiControllerTest.php
@@ -14,6 +14,11 @@
 namespace OCA\News\Tests\Unit\Controller;
 
 use OCA\News\Controller\UserApiController;
+use OCP\Files\File;
+use OCP\Files\IRootFolder;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 
 use PHPUnit\Framework\TestCase;
 
@@ -31,29 +36,19 @@ class UserApiControllerTest extends TestCase
     protected function setUp() 
     {
         $this->appName = 'news';
-        $this->request = $this->getMockBuilder(
-            '\OCP\IRequest'
-        )
+        $this->request = $this->getMockBuilder(IRequest::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->rootFolder = $this->getMockBuilder(
-            '\OCP\Files\IRootFolder'
-        )
+        $this->rootFolder = $this->getMockBuilder(IRootFolder::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->file = $this->getMockBuilder(
-            '\OCP\Files\File'
-        )
+        $this->file = $this->getMockBuilder(File::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->userSession = $this->getMockBuilder(
-            '\OCP\IUserSession'
-        )
+        $this->userSession = $this->getMockBuilder(IUserSession::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->user = $this->getMockBuilder(
-            '\OCP\IUser'
-        )
+        $this->user = $this->getMockBuilder(IUser::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->controller = new UserApiController(

--- a/tests/Unit/Controller/UtilityApiControllerTest.php
+++ b/tests/Unit/Controller/UtilityApiControllerTest.php
@@ -16,6 +16,12 @@
 namespace OCA\News\Tests\Unit\Controller;
 
 use OCA\News\Controller\UtilityApiController;
+use OCA\News\Service\StatusService;
+use OCA\News\Utility\Updater;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 
 use PHPUnit\Framework\TestCase;
 
@@ -34,37 +40,25 @@ class UtilityApiControllerTest extends TestCase
     protected function setUp() 
     {
         $this->appName = 'news';
-        $this->settings = $this->getMockBuilder(
-            '\OCP\IConfig'
-        )
+        $this->settings = $this->getMockBuilder(IConfig::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->request = $this->getMockBuilder(
-            '\OCP\IRequest'
-        )
+        $this->request = $this->getMockBuilder(IRequest::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->userSession = $this->getMockBuilder(
-            '\OCP\IUserSession'
-        )
+        $this->userSession = $this->getMockBuilder(IUserSession::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->user = $this->getMockBuilder(
-            '\OCP\IUser'
-        )
+        $this->user = $this->getMockBuilder(IUser::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->userSession->expects($this->any())
             ->method('getUser')
             ->will($this->returnValue($this->user));
-        $this->updater = $this->getMockBuilder(
-            '\OCA\News\Utility\Updater'
-        )
+        $this->updater = $this->getMockBuilder(Updater::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->status = $this->getMockBuilder(
-            '\OCA\News\Service\StatusService'
-        )
+        $this->status = $this->getMockBuilder(StatusService::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->newsAPI = new UtilityApiController(

--- a/tests/Unit/Db/FolderMapperTest.php
+++ b/tests/Unit/Db/FolderMapperTest.php
@@ -16,6 +16,8 @@ namespace OCA\News\Tests\Unit\Db;
 use OCA\News\Db\Folder;
 use OCA\News\Db\FolderMapper;
 use OCA\News\Utility\Time;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 
 class FolderMapperTest extends MapperTestUtility
 {
@@ -76,9 +78,7 @@ class FolderMapperTest extends MapperTestUtility
 
         $this->setMapperResult($sql, [$id, $userId]);
 
-        $this->expectException(
-            '\OCP\AppFramework\Db\DoesNotExistException'
-        );
+        $this->expectException(DoesNotExistException::class);
         $this->folderMapper->find($id, $userId);
     }
 
@@ -94,9 +94,7 @@ class FolderMapperTest extends MapperTestUtility
 
         $this->setMapperResult($sql, [$id, $userId], $rows);
 
-        $this->expectException(
-            '\OCP\AppFramework\Db\MultipleObjectsReturnedException'
-        );
+        $this->expectException(MultipleObjectsReturnedException::class);
         $this->folderMapper->find($id, $userId);
     }
 

--- a/tests/Unit/Db/MapperTestUtility.php
+++ b/tests/Unit/Db/MapperTestUtility.php
@@ -23,6 +23,8 @@
 
 namespace OCA\News\Tests\Unit\Db;
 
+use OCP\IDBConnection;
+
 use PHPUnit\Framework\TestCase;
 /**
  * Simple utility class for testing mappers
@@ -45,13 +47,11 @@ abstract class MapperTestUtility extends TestCase
     {
         parent::setUp();
 
-        $this->db = $this->getMockBuilder(
-            '\OCP\IDBConnection'
-        )
+        $this->db = $this->getMockBuilder(IDBConnection::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->query = $this->createMock('\PDOStatement');
+        $this->query = $this->createMock(\PDOStatement::class);
         $this->queryAt = 0;
         $this->prepareAt = 0;
         $this->iterators = [];

--- a/tests/Unit/Fetcher/FeedFetcherTest.php
+++ b/tests/Unit/Fetcher/FeedFetcherTest.php
@@ -16,9 +16,16 @@ namespace OCA\News\Tests\Unit\Fetcher;
 use \OCA\News\Db\Item;
 use \OCA\News\Db\Feed;
 use OCA\News\Fetcher\FeedFetcher;
+use OCA\News\Utility\PicoFeedFaviconFactory;
+use OCA\News\Utility\Time;
 use OCP\Http\Client\IClientService;
-use PicoFeed\Processor\ItemPostProcessor;
+use OCP\IL10N;
 use PHPUnit\Framework\TestCase;
+use PicoFeed\Client\Client;
+use PicoFeed\Parser\Parser;
+use PicoFeed\Processor\ItemPostProcessor;
+use PicoFeed\Reader\Favicon;
+use PicoFeed\Reader\Reader;
 
 
 class FeedFetcherTest extends TestCase
@@ -62,51 +69,33 @@ class FeedFetcherTest extends TestCase
 
     protected function setUp()
     {
-        $this->l10n = $this->getMockBuilder(
-            '\OCP\IL10N'
-        )
+        $this->l10n = $this->getMockBuilder(IL10N::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->reader = $this->getMockBuilder(
-            '\PicoFeed\Reader\Reader'
-        )
+        $this->reader = $this->getMockBuilder(Reader::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->parser = $this->getMockBuilder(
-            '\PicoFeed\Parser\Parser'
-        )
+        $this->parser = $this->getMockBuilder(Parser::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->client = $this->getMockBuilder(
-            '\PicoFeed\Client\Client'
-        )
+        $this->client = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->parsedFeed = $this->getMockBuilder(
-            '\PicoFeed\Parser\Feed'
-        )
+        $this->parsedFeed = $this->getMockBuilder(\PicoFeed\Parser\Feed::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->item = $this->getMockBuilder(
-            '\PicoFeed\Parser\Item'
-        )
+        $this->item = $this->getMockBuilder(\PicoFeed\Parser\Item::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->faviconFetcher = $this->getMockBuilder(
-            '\PicoFeed\Reader\Favicon'
-        )
+        $this->faviconFetcher = $this->getMockBuilder(Favicon::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->faviconFactory = $this->getMockBuilder(
-            '\OCA\News\Utility\PicoFeedFaviconFactory'
-        )
+        $this->faviconFactory = $this->getMockBuilder(PicoFeedFaviconFactory::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $this->time = 2323;
-        $timeFactory = $this->getMockBuilder(
-            '\OCA\News\Utility\Time'
-        )
+        $timeFactory = $this->getMockBuilder(Time::class)
             ->disableOriginalConstructor()
             ->getMock();
         $timeFactory->expects($this->any())

--- a/tests/Unit/Fetcher/FetcherTest.php
+++ b/tests/Unit/Fetcher/FetcherTest.php
@@ -26,6 +26,7 @@ namespace OCA\News\Tests\Unit\Fetcher;
 
 
 use OCA\News\Fetcher\Fetcher;
+use OCA\News\Fetcher\IFeedFetcher;
 use PHPUnit\Framework\TestCase;
 
 class FetcherTest extends TestCase
@@ -42,7 +43,7 @@ class FetcherTest extends TestCase
     public function testFetch()
     {
         $url = 'hi';
-        $mockFetcher = $this->getMockBuilder('\OCA\News\Fetcher\IFeedFetcher')
+        $mockFetcher = $this->getMockBuilder(IFeedFetcher::class)
             ->disableOriginalConstructor()
             ->getMock();
         $mockFetcher->expects($this->once())
@@ -67,14 +68,14 @@ class FetcherTest extends TestCase
     public function testNoFetchers()
     {
         $url = 'hi';
-        $mockFetcher = $this->getMockBuilder('\OCA\News\Fetcher\IFeedFetcher')
+        $mockFetcher = $this->getMockBuilder(IFeedFetcher::class)
             ->disableOriginalConstructor()
             ->getMock();
         $mockFetcher->expects($this->once())
             ->method('canHandle')
             ->with($this->equalTo($url))
             ->will($this->returnValue(false));
-        $mockFetcher2 = $this->getMockBuilder('\OCA\News\Fetcher\IFeedFetcher')
+        $mockFetcher2 = $this->getMockBuilder(IFeedFetcher::class)
             ->disableOriginalConstructor()
             ->getMock();
         $mockFetcher2->expects($this->once())
@@ -92,14 +93,14 @@ class FetcherTest extends TestCase
     public function testMultipleFetchers()
     {
         $url = 'hi';
-        $mockFetcher = $this->getMockBuilder('\OCA\News\Fetcher\IFeedFetcher')
+        $mockFetcher = $this->getMockBuilder(IFeedFetcher::class)
             ->disableOriginalConstructor()
             ->getMock();
         $mockFetcher->expects($this->once())
             ->method('canHandle')
             ->with($this->equalTo($url))
             ->will($this->returnValue(false));
-        $mockFetcher2 = $this->getMockBuilder('\OCA\News\Fetcher\IFeedFetcher')
+        $mockFetcher2 = $this->getMockBuilder(IFeedFetcher::class)
             ->disableOriginalConstructor()
             ->getMock();
         $mockFetcher2->expects($this->once())
@@ -118,7 +119,7 @@ class FetcherTest extends TestCase
     {
         $url = 'hi';
         $return = 'zeas';
-        $mockFetcher = $this->getMockBuilder('\OCA\News\Fetcher\IFeedFetcher')
+        $mockFetcher = $this->getMockBuilder(IFeedFetcher::class)
             ->disableOriginalConstructor()
             ->getMock();
         $mockFetcher->expects($this->once())
@@ -129,7 +130,7 @@ class FetcherTest extends TestCase
             ->method('fetch')
             ->with($this->equalTo($url))
             ->will($this->returnValue($return));
-        $mockFetcher2 = $this->getMockBuilder('\OCA\News\Fetcher\IFeedFetcher')
+        $mockFetcher2 = $this->getMockBuilder(IFeedFetcher::class)
             ->disableOriginalConstructor()
             ->getMock();
         $mockFetcher2->expects($this->never())

--- a/tests/Unit/Fetcher/YoutubeFetcherTest.php
+++ b/tests/Unit/Fetcher/YoutubeFetcherTest.php
@@ -12,6 +12,7 @@
 namespace OCA\News\Tests\Unit\Fetcher;
 
 use \OCA\News\Db\Feed;
+use OCA\News\Fetcher\FeedFetcher;
 use OCA\News\Fetcher\YoutubeFetcher;
 
 use PHPUnit\Framework\TestCase;
@@ -24,9 +25,7 @@ class YoutubeFetcherTest extends TestCase
 
     public function setUp() 
     {
-        $this->feedFetcher = $this->getMockBuilder(
-            '\OCA\News\Fetcher\FeedFetcher'
-        )
+        $this->feedFetcher = $this->getMockBuilder(FeedFetcher::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->fetcher = new YoutubeFetcher($this->feedFetcher);

--- a/tests/Unit/Service/FeedServiceTest.php
+++ b/tests/Unit/Service/FeedServiceTest.php
@@ -14,13 +14,20 @@
 
 namespace OCA\News\Tests\Unit\Service;
 
+use OCA\News\Config\Config;
+use OCA\News\Db\FeedMapper;
+use OCA\News\Db\ItemMapper;
 use OCA\News\Service\FeedService;
+use OCA\News\Service\ServiceNotFoundException;
+use OCA\News\Utility\Time;
 use OCP\AppFramework\Db\DoesNotExistException;
 
 use OCA\News\Db\Feed;
 use OCA\News\Db\Item;
 use OCA\News\Fetcher\Fetcher;
 use OCA\News\Fetcher\FetcherException;
+use OCP\IL10N;
+use OCP\ILogger;
 
 use PHPUnit\Framework\TestCase;
 
@@ -46,42 +53,38 @@ class FeedServiceTest extends TestCase
 
     protected function setUp()
     {
-        $this->logger = $this->getMockBuilder(
-            '\OCP\ILogger'
-        )
+        $this->logger = $this->getMockBuilder(ILogger::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->loggerParams = ['hi'];
         $this->time = 222;
         $this->autoPurgeMinimumInterval = 10;
-        $timeFactory = $this->getMockBuilder('\OCA\News\Utility\Time')
+        $timeFactory = $this->getMockBuilder(Time::class)
             ->disableOriginalConstructor()
             ->getMock();
         $timeFactory->expects($this->any())
             ->method('getTime')
             ->will($this->returnValue($this->time));
-        $this->l10n = $this->getMockBuilder('\OCP\IL10N')
+        $this->l10n = $this->getMockBuilder(IL10N::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->feedMapper = $this
-            ->getMockBuilder('\OCA\News\Db\FeedMapper')
+            ->getMockBuilder(FeedMapper::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->fetcher = $this
-            ->getMockBuilder('\OCA\News\Fetcher\Fetcher')
+            ->getMockBuilder(Fetcher::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->itemMapper = $this
-            ->getMockBuilder('\OCA\News\Db\ItemMapper')
+            ->getMockBuilder(ItemMapper::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->purifier = $this
-            ->getMockBuilder('\HTMLPurifier')
+            ->getMockBuilder(\HTMLPurifier::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $config = $this->getMockBuilder(
-            '\OCA\News\Config\Config'
-        )
+        $config = $this->getMockBuilder(Config::class)
             ->disableOriginalConstructor()
             ->getMock();
         $config->expects($this->any())
@@ -117,9 +120,7 @@ class FeedServiceTest extends TestCase
             ->method('fetch')
             ->with($this->equalTo($url))
             ->will($this->throwException($ex));
-        $this->expectException(
-            '\OCA\News\Service\ServiceNotFoundException'
-        );
+        $this->expectException(ServiceNotFoundException::class);
         $this->feedService->create($url, 1, $this->user);
     }
 
@@ -624,9 +625,7 @@ class FeedServiceTest extends TestCase
             )
             ->will($this->throwException($ex));
 
-        $this->expectException(
-            '\OCA\News\Service\ServiceNotFoundException'
-        );
+        $this->expectException(ServiceNotFoundException::class);
         $this->feedService->update($feed->getId(), $this->user);
     }
 
@@ -661,9 +660,7 @@ class FeedServiceTest extends TestCase
             )
             ->will($this->throwException($ex));
 
-        $this->expectException(
-            'OCP\AppFramework\Db\DoesNotExistException'
-        );
+        $this->expectException(DoesNotExistException::class);
         $this->feedService->update($feed->getId(), $this->user);
     }
 
@@ -717,9 +714,7 @@ class FeedServiceTest extends TestCase
             )
             ->will($this->throwException($ex));
 
-        $this->expectException(
-            '\OCA\News\Service\ServiceNotFoundException'
-        );
+        $this->expectException(ServiceNotFoundException::class);
         $this->feedService->update($feed->getId(), $this->user);
     }
 
@@ -1123,9 +1118,7 @@ class FeedServiceTest extends TestCase
             )
             ->will($this->throwException(new DoesNotExistException('')));
 
-        $this->expectException(
-            '\OCA\News\Service\ServiceNotFoundException'
-        );
+        $this->expectException(ServiceNotFoundException::class);
 
         $this->feedService->patch(3, $this->user, ['fullTextEnabled' => true]);
     }

--- a/tests/Unit/Service/FolderServiceTest.php
+++ b/tests/Unit/Service/FolderServiceTest.php
@@ -13,8 +13,14 @@
 
 namespace OCA\News\Tests\Unit\Service;
 
+use OCA\News\Config\Config;
 use \OCA\News\Db\Folder;
+use OCA\News\Db\FolderMapper;
 use OCA\News\Service\FolderService;
+use OCA\News\Service\ServiceConflictException;
+use OCA\News\Service\ServiceValidationException;
+use OCA\News\Utility\Time;
+use OCP\IL10N;
 
 use PHPUnit\Framework\TestCase;
 
@@ -31,25 +37,21 @@ class FolderServiceTest extends TestCase
 
     protected function setUp()
     {
-        $this->l10n = $this->getMockBuilder('\OCP\IL10N')
+        $this->l10n = $this->getMockBuilder(IL10N::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->time = 222;
-        $timeFactory = $this->getMockBuilder('\OCA\News\Utility\Time')
+        $timeFactory = $this->getMockBuilder(Time::class)
             ->disableOriginalConstructor()
             ->getMock();
         $timeFactory->expects($this->any())
             ->method('getTime')
             ->will($this->returnValue($this->time));
-        $this->folderMapper = $this->getMockBuilder(
-            '\OCA\News\Db\FolderMapper'
-        )
+        $this->folderMapper = $this->getMockBuilder(FolderMapper::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->autoPurgeMinimumInterval = 10;
-        $config = $this->getMockBuilder(
-            '\OCA\News\Config\Config'
-        )
+        $config = $this->getMockBuilder(Config::class)
             ->disableOriginalConstructor()
             ->getMock();
         $config->expects($this->any())
@@ -113,9 +115,7 @@ class FolderServiceTest extends TestCase
             ->with($this->equalTo($folderName))
             ->will($this->returnValue($rows));
 
-        $this->expectException(
-            '\OCA\News\Service\ServiceConflictException'
-        );
+        $this->expectException(ServiceConflictException::class);
         $this->folderService->create($folderName, 'john', 3);
     }
 
@@ -192,9 +192,7 @@ class FolderServiceTest extends TestCase
             ->with($this->equalTo($folderName))
             ->will($this->returnValue($rows));
 
-        $this->expectException(
-            '\OCA\News\Service\ServiceConflictException'
-        );
+        $this->expectException(ServiceConflictException::class);
         $this->folderService->rename(3, $folderName, 'john');
     }
 
@@ -208,9 +206,7 @@ class FolderServiceTest extends TestCase
             ->with($this->equalTo($folderName))
             ->will($this->returnValue([]));
 
-        $this->expectException(
-            '\OCA\News\Service\ServiceValidationException'
-        );
+        $this->expectException(ServiceValidationException::class);
         $this->folderService->rename(3, $folderName, 'john');
     }
 

--- a/tests/Unit/Service/ItemServiceTest.php
+++ b/tests/Unit/Service/ItemServiceTest.php
@@ -13,11 +13,16 @@
 
 namespace OCA\News\Tests\Unit\Service;
 
+use OCA\News\Config\Config;
+use OCA\News\Db\ItemMapper;
 use OCA\News\Service\ItemService;
+use OCA\News\Service\ServiceNotFoundException;
+use OCA\News\Utility\Time;
 use \OCP\AppFramework\Db\DoesNotExistException;
 
 use \OCA\News\Db\Item;
 use \OCA\News\Db\FeedType;
+use OCP\IConfig;
 
 use PHPUnit\Framework\TestCase;
 
@@ -41,7 +46,7 @@ class ItemServiceTest extends TestCase
     protected function setUp()
     {
         $this->time = 222;
-        $this->timeFactory = $this->getMockBuilder('\OCA\News\Utility\Time')
+        $this->timeFactory = $this->getMockBuilder(Time::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->timeFactory->expects($this->any())
@@ -50,17 +55,13 @@ class ItemServiceTest extends TestCase
         $this->timeFactory->expects($this->any())
             ->method('getMicroTime')
             ->will($this->returnValue($this->time));
-        $this->mapper = $this->getMockBuilder('\OCA\News\Db\ItemMapper')
+        $this->mapper = $this->getMockBuilder(ItemMapper::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->config = $this->getMockBuilder(
-            '\OCA\News\Config\Config'
-        )
+        $this->config = $this->getMockBuilder(Config::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->systemConfig = $this->getMockBuilder(
-            'OCP\IConfig'
-        )
+        $this->systemConfig = $this->getMockBuilder(IConfig::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->itemService = new ItemService(
@@ -339,9 +340,7 @@ class ItemServiceTest extends TestCase
     public function testReadDoesNotExist()
     {
 
-        $this->expectException(
-            '\OCA\News\Service\ServiceNotFoundException'
-        );
+        $this->expectException(ServiceNotFoundException::class);
         $this->mapper->expects($this->once())
             ->method('readItem')
             ->will($this->throwException(new DoesNotExistException('')));
@@ -352,9 +351,7 @@ class ItemServiceTest extends TestCase
     public function testStarDoesNotExist()
     {
 
-        $this->expectException(
-            '\OCA\News\Service\ServiceNotFoundException'
-        );
+        $this->expectException(ServiceNotFoundException::class);
         $this->mapper->expects($this->once())
             ->method('findByGuidHash')
             ->will($this->throwException(new DoesNotExistException('')));
@@ -462,9 +459,7 @@ class ItemServiceTest extends TestCase
                 )
             );
 
-        $this->expectException(
-            '\OCA\News\Service\ServiceNotFoundException'
-        );
+        $this->expectException(ServiceNotFoundException::class);
         $this->itemService->getNewestItemId($this->user);
     }
 

--- a/tests/Unit/Service/ServiceTest.php
+++ b/tests/Unit/Service/ServiceTest.php
@@ -13,7 +13,9 @@
 
 namespace OCA\News\Tests\Unit\Service;
 
+use OCA\News\Db\ItemMapper;
 use OCA\News\Service\Service;
+use OCA\News\Service\ServiceNotFoundException;
 use \OCP\AppFramework\Db\DoesNotExistException;
 use \OCP\AppFramework\Db\MultipleObjectsReturnedException;
 
@@ -37,7 +39,7 @@ class ServiceTest extends TestCase
 
     protected function setUp()
     {
-        $this->mapper = $this->getMockBuilder('\OCA\News\Db\ItemMapper')
+        $this->mapper = $this->getMockBuilder(ItemMapper::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->newsService = new TestService($this->mapper);
@@ -84,9 +86,7 @@ class ServiceTest extends TestCase
             ->method('find')
             ->will($this->throwException($ex));
 
-        $this->expectException(
-            '\OCA\News\Service\ServiceNotFoundException'
-        );
+        $this->expectException(ServiceNotFoundException::class);
         $this->newsService->find(1, '');
     }
 
@@ -99,9 +99,7 @@ class ServiceTest extends TestCase
             ->method('find')
             ->will($this->throwException($ex));
 
-        $this->expectException(
-            '\OCA\News\Service\ServiceNotFoundException'
-        );
+        $this->expectException(ServiceNotFoundException::class);
         $this->newsService->find(1, '');
     }
 

--- a/tests/Unit/Service/StatusServiceTest.php
+++ b/tests/Unit/Service/StatusServiceTest.php
@@ -13,8 +13,11 @@
 
 namespace OCA\News\Tests\Unit\Service;
 
+use OCA\News\Config\Config;
 use \OCA\News\Db\FeedType;
 use OCA\News\Service\StatusService;
+use OCP\IConfig;
+use OCP\IDBConnection;
 use PHPUnit\Framework\TestCase;
 
 
@@ -29,17 +32,13 @@ class StatusServiceTest extends TestCase
     public function setUp()
     {
         $this->appName = 'news';
-        $this->settings = $this->getMockBuilder(
-            '\OCP\IConfig'
-        )
+        $this->settings = $this->getMockBuilder(IConfig::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->config = $this->getMockBuilder(
-            '\OCA\News\Config\Config'
-        )
+        $this->config = $this->getMockBuilder(Config::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->db = $this->getMockBuilder("\OCP\IDBConnection")
+        $this->db = $this->getMockBuilder(IDBConnection::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->service = new StatusService(

--- a/tests/Unit/Utility/ProxyConfigParserTest.php
+++ b/tests/Unit/Utility/ProxyConfigParserTest.php
@@ -15,6 +15,7 @@ namespace OCA\News\Tests\Unit\Utility;
 
 
 use OCA\News\Utility\ProxyConfigParser;
+use OCP\IConfig;
 use PHPUnit\Framework\TestCase;
 
 class ProxyConfigParserTest extends TestCase
@@ -27,9 +28,7 @@ class ProxyConfigParserTest extends TestCase
 
     protected function setUp() 
     {
-        $this->config = $this->getMockBuilder(
-            '\OCP\IConfig'
-        )
+        $this->config = $this->getMockBuilder(IConfig::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->parser = new ProxyConfigParser($this->config);

--- a/tests/Unit/Utility/UpdaterTest.php
+++ b/tests/Unit/Utility/UpdaterTest.php
@@ -13,6 +13,10 @@
 
 namespace OCA\News\Tests\Unit\Utility;
 
+
+use OCA\News\Service\FeedService;
+use OCA\News\Service\FolderService;
+use OCA\News\Service\ItemService;
 use OCA\News\Utility\Updater;
 use PHPUnit\Framework\TestCase;
 
@@ -26,19 +30,13 @@ class UpdaterTest extends TestCase
 
     protected function setUp() 
     {
-        $this->folderService = $this->getMockBuilder(
-            '\OCA\News\Service\FolderService'
-        )
+        $this->folderService = $this->getMockBuilder(FolderService::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->feedService = $this->getMockBuilder(
-            '\OCA\News\Service\FeedService'
-        )
+        $this->feedService = $this->getMockBuilder(FeedService::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->itemService = $this->getMockBuilder(
-            '\OCA\News\Service\ItemService'
-        )
+        $this->itemService = $this->getMockBuilder(ItemService::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->updater = new Updater(


### PR DESCRIPTION
I just searched for some cases where we are still using classname strings and replaced those with magic class constants to improve code style a bit, even if those are basically just test files :grinning: 