### PR TITLE
Return also folderId with "news:updater:all-feeds"

### DIFF
--- a/lib/Command/Updater/AllFeeds.php
+++ b/lib/Command/Updater/AllFeeds.php
@@ -49,7 +49,8 @@ class AllFeeds extends Command
         foreach ($feeds as $feed) {
             $result['feeds'][] = [
                 'id' => $feed->getId(),
-                'userId' => $feed->getUserId()
+                'userId' => $feed->getUserId(),
+                'folderId' => $feed->getFolderId(),
             ];
         }
 


### PR DESCRIPTION
I wish to implement in https://github.com/nextcloud/news-updater a folder based update time, since I have a large number of feeds but only a few of them requires to be updated very often.
Hence in order to be able to do that I need that "news:updater:all-feeds" returns also the folderId.
Of course this is not only for personal usage and if this patch will be accepted I planned to create a pull request also to the news-updater.
I think this is very simple patch that shouln't cause any issue, but if it does please let me know what they are, and if I can fix them.