### PR TITLE
Fix multi-line news titles

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -228,7 +228,7 @@
     position: sticky;
     top: 50px;
     background-color: var(--color-main-background);
-    height: 41px;
+    min-height: 41px;
     opacity: 0.9;
 }
 


### PR DESCRIPTION
Change CSS "height" for a "min-height" so that it can expand if necessary

Fixes #359