### PR TITLE
Different solution for ONLY_FULL_GROUP_BY (see #406) (Issue #80)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 os: linux
 dist: bionic
+sudo: false
 language: php
 
 php:
@@ -45,6 +46,8 @@ before_script:
     - if [[ "$DB" == 'mysql' ]]; then sudo mysql -u root -e 'CREATE DATABASE oc_autotest;'; fi
     - if [[ "$DB" == 'mysql' ]]; then sudo mysql -u root -e "CREATE USER 'oc_autotest'@'localhost' IDENTIFIED BY 'oc_autotest';"; fi
     - if [[ "$DB" == 'mysql' ]]; then sudo mysql -u root -e "GRANT ALL ON oc_autotest.* TO 'oc_autotest'@'localhost';"; fi
+    - if [[ "$DB" == 'mysql' ]]; then sudo mysql -u root -e "SET GLOBAL sql_mode = 'STRICT_ALL_TABLES,ONLY_FULL_GROUP_BY';"; fi
+
     # fill nextcloud with default configs and enable news
     - cd nextcloud
     - mkdir data

--- a/lib/Db/FeedMapper.php
+++ b/lib/Db/FeedMapper.php
@@ -115,7 +115,7 @@ class FeedMapper extends NewsMapper
         $sql = 'SELECT `feeds`.*, `item_numbers`.`unread_count` ' .
             'FROM `*PREFIX*news_feeds` `feeds` ' .
             'JOIN ( ' .
-                'SELECT `feeds`.*, COUNT(`items`.`id`) AS `unread_count` ' .
+                'SELECT `feeds`.`id`, COUNT(`items`.`id`) AS `unread_count` ' .
                 'FROM `*PREFIX*news_feeds` `feeds` ' .
                 'LEFT JOIN `*PREFIX*news_items` `items` ' .
                     'ON `feeds`.`id` = `items`.`feed_id` ' .

--- a/lib/Db/FeedMapper.php
+++ b/lib/Db/FeedMapper.php
@@ -29,18 +29,23 @@ class FeedMapper extends NewsMapper
 
     public function find($id, $userId)
     {
-        $sql = 'SELECT `feeds`.*, COUNT(`items`.`id`) AS `unread_count` ' .
+        $sql = 'SELECT `feeds`.*, `item_numbers`.`unread_count` ' .
             'FROM `*PREFIX*news_feeds` `feeds` ' .
-            'LEFT JOIN `*PREFIX*news_items` `items` ' .
-                'ON `feeds`.`id` = `items`.`feed_id` ' .
-                // WARNING: this is a desperate attempt at making this query
-                // work because prepared statements dont work. This is a
-                // POSSIBLE SQL INJECTION RISK WHEN MODIFIED WITHOUT THOUGHT.
-                // think twice when changing this
-                'AND unread = ? ' .
-            'WHERE `feeds`.`id` = ? ' .
-                'AND `feeds`.`user_id` = ? ' .
-            'GROUP BY `feeds`.`id`';
+            'JOIN ( ' .
+                'SELECT `feeds`.`id`, COUNT(`items`.`id`) AS `unread_count` ' .
+                'FROM `*PREFIX*news_feeds` `feeds` ' .
+                'LEFT JOIN `*PREFIX*news_items` `items` ' .
+                    'ON `feeds`.`id` = `items`.`feed_id` ' .
+                    // WARNING: this is a desperate attempt at making this query
+                    // work because prepared statements dont work. This is a
+                    // POSSIBLE SQL INJECTION RISK WHEN MODIFIED WITHOUT THOUGHT.
+                    // think twice when changing this
+                    'AND `items`.`unread` = ? ' .
+                'WHERE `feeds`.`id` = ? ' .
+                  'AND `feeds`.`user_id` = ? ' .
+                'GROUP BY `feeds`.`id` ' .
+            ') `item_numbers` ' .
+            'ON `item_numbers`.`id` = `feeds`.`id` ';
         $params = [true, $id, $userId];
 
         return $this->findEntity($sql, $params);
@@ -49,23 +54,28 @@ class FeedMapper extends NewsMapper
 
     public function findAllFromUser($userId)
     {
-        $sql = 'SELECT `feeds`.*, COUNT(`items`.`id`) AS `unread_count` ' .
+        $sql = 'SELECT `feeds`.*, `item_numbers`.`unread_count` ' .
             'FROM `*PREFIX*news_feeds` `feeds` ' .
-            'LEFT OUTER JOIN `*PREFIX*news_folders` `folders` ' .
-                'ON `feeds`.`folder_id` = `folders`.`id` ' .
-            'LEFT JOIN `*PREFIX*news_items` `items` ' .
-                'ON `feeds`.`id` = `items`.`feed_id` ' .
-                // WARNING: this is a desperate attempt at making this query
-                // work because prepared statements dont work. This is a
-                // POSSIBLE SQL INJECTION RISK WHEN MODIFIED WITHOUT THOUGHT.
-                // think twice when changing this
-                'AND unread = ? ' .
-            'WHERE `feeds`.`user_id` = ? ' .
-            'AND (`feeds`.`folder_id` = 0 ' .
-                'OR `folders`.`deleted_at` = 0' .
-            ')' .
-            'AND `feeds`.`deleted_at` = 0 ' .
-            'GROUP BY `feeds`.`id`';
+            'JOIN ( ' .
+                'SELECT `feeds`.`id`, COUNT(`items`.`id`) AS `unread_count` ' .
+                'FROM `*PREFIX*news_feeds` `feeds` ' .
+                'LEFT OUTER JOIN `*PREFIX*news_folders` `folders` ' .
+                    'ON `feeds`.`folder_id` = `folders`.`id` ' .
+                'LEFT JOIN `*PREFIX*news_items` `items` ' .
+                    'ON `feeds`.`id` = `items`.`feed_id` ' .
+                    // WARNING: this is a desperate attempt at making this query
+                    // work because prepared statements dont work. This is a
+                    // POSSIBLE SQL INJECTION RISK WHEN MODIFIED WITHOUT THOUGHT.
+                    // think twice when changing this
+                    'AND `items`.`unread` = ? ' .
+                'WHERE `feeds`.`user_id` = ? ' .
+                  'AND (`feeds`.`folder_id` = 0 ' .
+                   'OR `folders`.`deleted_at` = 0 ' .
+                  ') ' .
+                  'AND `feeds`.`deleted_at` = 0 ' .
+                'GROUP BY `feeds`.`id` ' .
+            ') `item_numbers` ' .
+            'ON `item_numbers`.`id` = `feeds`.`id` ';
         $params = [true, $userId];
 
         return $this->findEntities($sql, $params);
@@ -74,22 +84,27 @@ class FeedMapper extends NewsMapper
 
     public function findAll()
     {
-        $sql = 'SELECT `feeds`.*, COUNT(`items`.`id`) AS `unread_count` ' .
+        $sql = 'SELECT `feeds`.*, `item_numbers`.`unread_count` ' .
             'FROM `*PREFIX*news_feeds` `feeds` ' .
-            'LEFT OUTER JOIN `*PREFIX*news_folders` `folders` ' .
-                'ON `feeds`.`folder_id` = `folders`.`id` ' .
-            'LEFT JOIN `*PREFIX*news_items` `items` ' .
-                'ON `feeds`.`id` = `items`.`feed_id` ' .
-                // WARNING: this is a desperate attempt at making this query
-                // work because prepared statements dont work. This is a
-                // POSSIBLE SQL INJECTION RISK WHEN MODIFIED WITHOUT THOUGHT.
-                // think twice when changing this
-                'AND unread = ? ' .
-            'WHERE (`feeds`.`folder_id` = 0 ' .
-                'OR `folders`.`deleted_at` = 0' .
-            ')' .
-            'AND `feeds`.`deleted_at` = 0 ' .
-            'GROUP BY `feeds`.`id`';
+            'JOIN ( ' .
+                'SELECT `feeds`.`id`, COUNT(`items`.`id`) AS `unread_count` ' .
+                'FROM `*PREFIX*news_feeds` `feeds` ' .
+                'LEFT OUTER JOIN `*PREFIX*news_folders` `folders` ' .
+                    'ON `feeds`.`folder_id` = `folders`.`id` ' .
+                'LEFT JOIN `*PREFIX*news_items` `items` ' .
+                    'ON `feeds`.`id` = `items`.`feed_id` ' .
+                    // WARNING: this is a desperate attempt at making this query
+                    // work because prepared statements dont work. This is a
+                    // POSSIBLE SQL INJECTION RISK WHEN MODIFIED WITHOUT THOUGHT.
+                    // think twice when changing this
+                    'AND `items`.`unread` = ? ' .
+                'WHERE (`feeds`.`folder_id` = 0 ' .
+                   'OR `folders`.`deleted_at` = 0 ' .
+                ') ' .
+                'AND `feeds`.`deleted_at` = 0 ' .
+                'GROUP BY `feeds`.`id` ' .
+            ') `item_numbers` ' .
+            'ON `item_numbers`.`id` = `feeds`.`id` ';
 
         return $this->findEntities($sql, [true]);
     }
@@ -97,18 +112,23 @@ class FeedMapper extends NewsMapper
 
     public function findByUrlHash($hash, $userId)
     {
-        $sql = 'SELECT `feeds`.*, COUNT(`items`.`id`) AS `unread_count` ' .
+        $sql = 'SELECT `feeds`.*, `item_numbers`.`unread_count` ' .
             'FROM `*PREFIX*news_feeds` `feeds` ' .
-            'LEFT JOIN `*PREFIX*news_items` `items` ' .
-                'ON `feeds`.`id` = `items`.`feed_id` ' .
-                // WARNING: this is a desperate attempt at making this query
-                // work because prepared statements dont work. This is a
-                // POSSIBLE SQL INJECTION RISK WHEN MODIFIED WITHOUT THOUGHT.
-                // think twice when changing this
-                'AND unread = ? ' .
-            'WHERE `feeds`.`url_hash` = ? ' .
-                'AND `feeds`.`user_id` = ? ' .
-            'GROUP BY `feeds`.`id`';
+            'JOIN ( ' .
+                'SELECT `feeds`.*, COUNT(`items`.`id`) AS `unread_count` ' .
+                'FROM `*PREFIX*news_feeds` `feeds` ' .
+                'LEFT JOIN `*PREFIX*news_items` `items` ' .
+                    'ON `feeds`.`id` = `items`.`feed_id` ' .
+                    // WARNING: this is a desperate attempt at making this query
+                    // work because prepared statements dont work. This is a
+                    // POSSIBLE SQL INJECTION RISK WHEN MODIFIED WITHOUT THOUGHT.
+                    // think twice when changing this
+                    'AND `items`.`unread` = ? ' .
+                'WHERE `feeds`.`url_hash` = ? ' .
+                  'AND `feeds`.`user_id` = ? ' .
+                'GROUP BY `feeds`.`id` ' .
+            ') `item_numbers` ' .
+            'ON `item_numbers`.`id` = `feeds`.`id` ';
         $params = [true, $hash, $userId];
 
         return $this->findEntity($sql, $params);


### PR DESCRIPTION
This is a different approach to #80 .
Here, we apply the aggregate functions in a subquery and get the defails from the `feeds` table in the outer query. 
This makes it easer to see what we are counting and by what we are grouping by. Also, we don't have to include every column from `feeds` in the `group by`.
This uses subqueries rather than a `with` clause as MySQL only supports that in version 8 upwards.
Also, the table of origin has been added to `unread`, as all other columns are referenced this way.

This PR is meant to be an alternative to #406 in consultation with @Grotax to put both ways up for discussion.