### PR TITLE
#413 DateTime::createFromFormat()

### DIFF
--- a/lib/Config/LegacyGuzzleResponse.php
+++ b/lib/Config/LegacyGuzzleResponse.php
@@ -81,6 +81,6 @@ class LegacyGuzzleResponse implements ResponseInterface
      */
     public function getHeader($name)
     {
-        return $this->response->getHeader($name);
+        return current($this->response->getHeader($name));
     }
 }


### PR DESCRIPTION
Fix #413 
Works  with feed-io 3 (getHeader() returns an array) and will works with feed-io 4 (getHeader() returns an iterator)