### PR TITLE
prevent raw angluar templates from flashing on page load

### DIFF
--- a/templates/index.php
+++ b/templates/index.php
@@ -27,6 +27,7 @@ foreach (Plugin::getScripts() as $appName => $fileName) {
 
     <div id="global-loading"
         class="icon-loading"
+        ngCloak
         ng-show="App.loading.isLoading('global')"></div>
 
     <!-- content -->


### PR DESCRIPTION
- when opening news app on lower end computer, the angular templates
flash on the screen for about 1 second
- angular directive doc: https://docs.angularjs.org/api/ng/directive/ngCloak

![Screenshot 2019-03-13 at 21 33 37](https://user-images.githubusercontent.com/3188890/54331584-d24c1f00-45d7-11e9-83c4-d3a9bc0e59e3.png)
