### PR TITLE
Have dist also reinstall dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ distclean: clean
 # Builds the source and appstore package
 .PHONY: dist
 dist:
-    make distclean
+	make distclean
 	make build
 	make source
 	make appstore

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,8 @@ distclean: clean
 # Builds the source and appstore package
 .PHONY: dist
 dist:
+    make distclean
+	make build
 	make source
 	make appstore
 


### PR DESCRIPTION
Suspecting an outdated dependency got shipped in 13.1.1, this should prevent that from happening in the future.