### PR TITLE
reset modified since filter when updating feeds

### DIFF
--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -72,6 +72,7 @@ class FeedFetcher implements IFeedFetcher
             $url2->setUserinfo(urlencode($user), urlencode($password));
         }
         $url = $url2->getNormalizedURL();
+        $this->reader->resetFilters();
         if (is_null($lastModified) || !is_string($lastModified)) {
             $resource = $this->reader->read($url);
         } else {


### PR DESCRIPTION
When updating feeds the modified since date is added as a filter. This needs to be reset when looping over the feeds. Fixes #444.