### PR TITLE
Put background back on news title

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -225,6 +225,7 @@
     -webkit-position: sticky;
     position: sticky;
     top: 50px;
+    background-color: var(--color-main-background);
     min-height: 41px;
     opacity: 0.9;
 }


### PR DESCRIPTION
Fixes the lack of background on the news item title when scrolling, which makes the content unreadable and defeats the idea of the sticky title (#450), by putting the colour back that was removed in e4da0957.