### PR TITLE
info.xml: bump php min-version

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Before you update to a new version, [check the changelog](https://github.com/nex
     <screenshot small-thumbnail="https://raw.githubusercontent.com/nextcloud/news/master/screenshots/2-small.png">https://raw.githubusercontent.com/nextcloud/news/master/screenshots/2.png</screenshot>
     <screenshot small-thumbnail="https://raw.githubusercontent.com/nextcloud/news/master/screenshots/3-small.png">https://raw.githubusercontent.com/nextcloud/news/master/screenshots/3.png</screenshot>
     <dependencies>
-        <php min-version="5.6"/>
+        <php min-version="7.0"/>
         <database min-version="9.4">pgsql</database>
         <database>sqlite</database>
         <database min-version="5.5">mysql</database>

--- a/composer.json
+++ b/composer.json
@@ -41,14 +41,14 @@
     "riimu/kit-pathjoin": "1.2.0",
     "debril/feed-io": "^3.1",
     "arthurhoaro/favicon": "^1.2",
-    "guzzlehttp/guzzle": "^6.3",
     "ext-json": "*",
     "ext-simplexml": "*",
     "ext-libxml": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.5",
-    "squizlabs/php_codesniffer": "^3.3"
+    "squizlabs/php_codesniffer": "^3.3",
+    "guzzlehttp/guzzle": "^6.3"
   },
   "replace": {
     "guzzlehttp/guzzle": "*"


### PR DESCRIPTION
What about the other dependencies?

And i saw that guzzle was added to the dependencies. Do we actually need that or can we move it back to require-dev?