### PR TITLE
UI: Make BasicAuth Credentials less important in subscription form (but also visible)

### DIFF
--- a/css/navigation.css
+++ b/css/navigation.css
@@ -67,7 +67,6 @@
 }
 
 #app-navigation .add-new-popup .add-new-folder-primary {
-    float: right;
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
     width: 36px;
@@ -76,17 +75,13 @@
     margin-right: 0;
 }
 
-#app-navigation .add-new-popup .add-feed-advanced {
+#app-navigation .add-new-popup .add-new-basicauth-toggle {
+    padding: 5px 0;
+}
+
+#app-navigation .add-new-popup .add-feed-basicauth {
     width: 100%;
-}
-
-#app-navigation .add-new-popup .add-feed-advanced-area {
-    padding: 10px 0;
-}
-
-#app-navigation .add-new-popup .add-feed-advanced-area h2 {
-    font-size: 11pt;
-    font-weight: bold;
+    padding: 0 0 10px;
 }
 
 #app-navigation .add-new-popup .error {

--- a/templates/part.navigation.addfeed.php
+++ b/templates/part.navigation.addfeed.php
@@ -76,11 +76,15 @@
                 </p>
 
                 <!-- basic auth -->
-                <button type="button" class="add-feed-advanced" ng-click="Navigation.showAddFeedAdvanced=!Navigation.showAddFeedAdvanced">
-                    <?php p($l->t('Advanced settings')); ?>
-                </button>
-                <div ng-if="Navigation.showAddFeedAdvanced" class="add-feed-advanced-area">
-                    <h2><?php p($l->t('Credentials')); ?></h2>
+                <div class="add-new-basicauth-toggle">
+                    <input type="checkbox"
+                           class="checkbox"
+                           ng-model="Navigation.addFeedBasicauth"
+                           id="add-feed-basicauth">
+                    <label for="add-feed-basicauth"><?php p($l->t('Credentials')); ?></label>
+                </div>
+
+                <div ng-show="Navigation.addFeedBasicauth" class="add-feed-basicauth">
                     <p class="warning"><?php p($l->t('HTTP Basic Auth credentials must be stored unencrypted! Everyone with access to the server or database will be able to access them!')); ?></p>
                     <input type="text"
                         ng-model="Navigation.feed.user"


### PR DESCRIPTION
Since the BasicAuth credentials were the only "Advanced settings", i removed the `Advanced settings` Button and added a `credentials` Checkbox instead.

This change makes the interface clearer.

![Screen Shot 2019-04-07 at 16 13 39](https://user-images.githubusercontent.com/1266260/55691176-3c927e00-5950-11e9-8251-1141bf34e9af.png)
![Screen Shot 2019-04-07 at 16 13 57](https://user-images.githubusercontent.com/1266260/55691179-3f8d6e80-5950-11e9-8071-f58879183442.png)

Technically, the `Advanced settings` string is not used anymore. I didn't delete the transaltions yet. 
Should I?