### PR TITLE
Remove UTF-8 charset warning from news

### DIFF
--- a/lib/Service/StatusService.php
+++ b/lib/Service/StatusService.php
@@ -13,8 +13,6 @@
 
 namespace OCA\News\Service;
 
-use Doctrine\DBAL\Platforms\MySqlPlatform;
-
 use OCP\IConfig;
 use OCP\IDBConnection;
 
@@ -22,13 +20,13 @@ use OCA\News\Config\Config;
 
 class StatusService
 {
-
+    /** @var IConfig */
     private $settings;
+    /** @var Config */
     private $config;
+    /** @var string */
     private $appName;
-    /**
-     * @var IDBConnection
-     */
+    /** @var IDBConnection */
     private $connection;
 
     public function __construct(

--- a/templates/part.content.warnings.php
+++ b/templates/part.content.warnings.php
@@ -23,20 +23,3 @@
         </ul>
     </news-instant-notification>
 <?php }; ?>
-
-<?php if ($_['warnings']['incorrectDbCharset']) { ?>
-    <news-instant-notification id="cron-warning">
-        <p><?php p($l->t('Non UTF-8 charset for MySQL/MariaDB database detected!')); ?></p>
-        <ul>
-            <li>
-                <a href="https://docs.nextcloud.com/server/latest/admin_manual/configuration_database/mysql_4byte_support.html"
-                   target="_blank"
-                   rel="noreferrer">
-                    <?php
-                    p($l->t('Learn how to convert your database to utf8mb4 (make a backup beforehand)'));
-                    ?>
-                </a>
-            </li>
-        </ul>
-    </news-instant-notification>
-<?php }; ?>


### PR DESCRIPTION
According to #496 first I just removed the notification from the frontend. How are the translations removed - have I to remove them or is Transifex removing unused translations?

We still have an API request returning a flag for this. For BC we are not able to remove this flag, but I'm not sure if we should just keep it or return false in every case and update the documentation?