### PR TITLE
Add "mark read" floating button for mobile. Fixes #469

### DIFF
--- a/templates/part.navigation.feed.php
+++ b/templates/part.navigation.feed.php
@@ -87,7 +87,7 @@
         </ul>
     </div>
 
-    <div class="app-navigation-entry-menu">
+    <div class="app-navigation-entry-menu" ng-click="$event.stopPropagation()">
         <ul>
             <li ng-show="Navigation.isFeedUnread(feed.id)" class="mark-read">
                 <button ng-click="Navigation.markFeedRead(feed.id)">


### PR DESCRIPTION
Fixes https://github.com/nextcloud/news/issues/469

![news-mobile-mark-read-button](https://user-images.githubusercontent.com/21343324/57182789-05ea4d80-6e93-11e9-8cc0-215d4079bcbc.png)

Added a floating button that only shows in "mobile mode". This button will mark the items in the current feed or folder view as read.

Probably will want to make the button itself prettier.

