### PR TITLE
prevent menu actions from collapsing sidebar

### DIFF
--- a/templates/part.navigation.feed.php
+++ b/templates/part.navigation.feed.php
@@ -87,7 +87,7 @@
         </ul>
     </div>
 
-    <div class="app-navigation-entry-menu">
+    <div class="app-navigation-entry-menu" ng-click="$event.stopPropagation()">
         <ul>
             <li ng-show="Navigation.isFeedUnread(feed.id)" class="mark-read">
                 <button ng-click="Navigation.markFeedRead(feed.id)">


### PR DESCRIPTION
It makes the menu hard to use to unusable on mobile / tablet

Before

![news-collapse-before-fix](https://user-images.githubusercontent.com/21343324/57264713-13563200-7063-11e9-9a8b-0c7776eaa3d4.gif)

After

![news-collapse-after-fix](https://user-images.githubusercontent.com/21343324/57264718-16e9b900-7063-11e9-995c-e152769f5d3c.gif)
