### PR TITLE
add "mark read" floating button mobile. Fixes #469

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -44,6 +44,13 @@
     display: block !important;
 }
 
+#mark-all-read-button {
+    position: fixed;
+    z-index: 1;
+    bottom: 0.5em;
+    right: 0.5em;
+}
+
 /* Override hidden before angular is loaded */
 [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak, .ng-hide:not(.ng-hide-animate) {
     display: none !important;

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -11,6 +11,9 @@
         width: 100%;
     }
 
+    #mark-all-read-button {
+        display: block;
+    }
 }
 
 @media only screen and (max-width: 600px) {

--- a/js/controller/NavigationController.js
+++ b/js/controller/NavigationController.js
@@ -36,6 +36,19 @@ app.controller('NavigationController', function ($route, FEED_TYPE, FeedResource
         return FolderResource.getAll();
     };
 
+    this.markCurrentRead = function () {
+      var id = getRouteId();
+      var type = $route.current.$$route.type;
+
+      if(isNaN(id)) {
+        this.markRead();
+      } else if(type === FEED_TYPE.FOLDER) {
+        this.markFolderRead(id);
+      } else if(type === FEED_TYPE.FEED) {
+        this.markFeedRead(id);
+      }
+    };
+
     this.markFolderRead = function (folderId) {
         FeedResource.markFolderRead(folderId);
 

--- a/lib/Controller/FeedController.php
+++ b/lib/Controller/FeedController.php
@@ -207,7 +207,7 @@ class FeedController extends Controller
 
             return [
                 'feeds' => [
-                    // only pass unread count to not accidentally readd
+                    // only pass unread count to not accidentally read
                     // the feed again
                     [
                         'id' => $feed->getId(),

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -12,6 +12,10 @@
         <p ng-show="Content.isShowAll()"><?php p($l->t('No articles available')) ?></p>
         <p ng-show="!Content.isShowAll()"><?php p($l->t('No unread articles available')) ?></p>
     </div>
+    <button ng-controller="NavigationController as Navigation" id="mark-all-read-button" ng-click="Navigation.markCurrentRead()" class="hidden">
+        <span title="Mark Read" class="icon-checkmark"></span>
+    </button>
+
     <ul>
         <li class="item {{ ::Content.getFeed(item.feedId).cssClass }}"
             ng-repeat="item in Content.getItems() |


### PR DESCRIPTION
Fixes https://github.com/nextcloud/news/issues/469

![news-mobile-mark-read-button](https://user-images.githubusercontent.com/21343324/57182789-05ea4d80-6e93-11e9-8cc0-215d4079bcbc.png)

Added a floating button that only shows in "mobile mode". This button will mark the items in the current feed or folder view as read.

Probably will want to make the button itself prettier.

Signed-off-by: nachoparker <nacho@ownyourbits.com>