### PR TITLE
removes unread-condition to respect all items while purging

### DIFF
--- a/lib/Db/ItemMapper.php
+++ b/lib/Db/ItemMapper.php
@@ -338,16 +338,15 @@ class ItemMapper extends NewsMapper
      *
      * @param int $threshold the number of items that should be deleted
      */
-    public function deleteReadOlderThanThreshold($threshold)
+    public function deleteOlderThanThreshold($threshold)
     {
-        $params = [false, false, $threshold];
+        $params = [false, $threshold];
 
         $sql = 'SELECT (COUNT(*) - `feeds`.`articles_per_update`) AS `size`, ' .
             '`feeds`.`id` AS `feed_id`, `feeds`.`articles_per_update` ' .
             'FROM `*PREFIX*news_items` `items` ' .
             'JOIN `*PREFIX*news_feeds` `feeds` ' .
             'ON `feeds`.`id` = `items`.`feed_id` ' .
-            'AND `items`.`unread` = ? ' .
             'AND `items`.`starred` = ? ' .
             'GROUP BY `feeds`.`id`, `feeds`.`articles_per_update` ' .
             'HAVING COUNT(*) > ?';
@@ -359,13 +358,12 @@ class ItemMapper extends NewsMapper
             $limit = $size - $threshold;
 
             if ($limit > 0) {
-                $params = [false, false, $row['feed_id'], $limit];
+                $params = [false, $row['feed_id'], $limit];
 
                 $sql = 'DELETE FROM `*PREFIX*news_items` ' .
                     'WHERE `id` IN (' .
                     'SELECT `id` FROM `*PREFIX*news_items` ' .
-                    'WHERE `unread` = ? ' .
-                    'AND `starred` = ? ' .
+                    'WHERE `starred` = ? ' .
                     'AND `feed_id` = ? ' .
                     'ORDER BY `id` ASC ' .
                     'LIMIT ?' .

--- a/lib/Db/Mysql/ItemMapper.php
+++ b/lib/Db/Mysql/ItemMapper.php
@@ -26,23 +26,22 @@ class ItemMapper extends \OCA\News\Db\ItemMapper
 
 
     /**
-     * Delete all items for feeds that have over $threshold unread and not
+     * Delete all items for feeds that have over $threshold not
      * starred items
      *
      * @param int $threshold the number of items that should be deleted
      */
-    public function deleteReadOlderThanThreshold($threshold)
+    public function deleteOlderThanThreshold($threshold)
     {
         $sql = 'SELECT (COUNT(*) - `feeds`.`articles_per_update`) AS `size`, ' .
         '`feeds`.`id` AS `feed_id`, `feeds`.`articles_per_update` ' .
             'FROM `*PREFIX*news_items` `items` ' .
             'JOIN `*PREFIX*news_feeds` `feeds` ' .
                 'ON `feeds`.`id` = `items`.`feed_id` ' .
-                'AND `items`.`unread` = ? ' .
                 'AND `items`.`starred` = ? ' .
             'GROUP BY `feeds`.`id`, `feeds`.`articles_per_update` ' .
             'HAVING COUNT(*) > ?';
-        $params = [false, false, $threshold];
+        $params = [false, $threshold];
         $result = $this->execute($sql, $params);
 
         while ($row = $result->fetch()) {
@@ -50,11 +49,10 @@ class ItemMapper extends \OCA\News\Db\ItemMapper
             $limit = $size - $threshold;
 
             if ($limit > 0) {
-                $params = [false, false, $row['feed_id'], $limit];
+                $params = [false, $row['feed_id'], $limit];
 
                 $sql = 'DELETE FROM `*PREFIX*news_items` ' .
-                    'WHERE `unread` = ? ' .
-                    'AND `starred` = ? ' .
+                    'WHERE `starred` = ? ' .
                     'AND `feed_id` = ? ' .
                     'ORDER BY `id` ASC ' .
                     'LIMIT ?';

--- a/lib/Service/ItemService.php
+++ b/lib/Service/ItemService.php
@@ -257,7 +257,7 @@ class ItemService extends Service
     {
         $count = $this->config->getAutoPurgeCount();
         if ($count >= 0) {
-            $this->itemMapper->deleteReadOlderThanThreshold($count);
+            $this->itemMapper->deleteOlderThanThreshold($count);
         }
     }
 

--- a/tests/Integration/Db/ItemMapperTest.php
+++ b/tests/Integration/Db/ItemMapperTest.php
@@ -18,7 +18,7 @@ use OCA\News\Tests\Integration\Fixtures\ItemFixture;
 class ItemMapperTest extends IntegrationTest
 {
 
-    public function testFind() 
+    public function testFind()
     {
         $feed = new FeedFixture();
         $feed = $this->feedMapper->insert($feed);
@@ -38,7 +38,7 @@ class ItemMapperTest extends IntegrationTest
      * @param  $title
      * @return mixed
      */
-    private function whereTitleId($title) 
+    private function whereTitleId($title)
     {
         return $this->findItemByTitle($title)->getId();
     }
@@ -46,7 +46,7 @@ class ItemMapperTest extends IntegrationTest
     /**
      * @expectedException OCP\AppFramework\Db\DoesNotExistException
      */
-    public function testFindNotFoundWhenDeletedFeed() 
+    public function testFindNotFoundWhenDeletedFeed()
     {
         $this->loadFixtures('default');
 
@@ -58,7 +58,7 @@ class ItemMapperTest extends IntegrationTest
     /**
      * @expectedException OCP\AppFramework\Db\DoesNotExistException
      */
-    public function testFindNotFoundWhenDeletedFolder() 
+    public function testFindNotFoundWhenDeletedFolder()
     {
         $this->loadFixtures('default');
 
@@ -68,11 +68,11 @@ class ItemMapperTest extends IntegrationTest
     }
 
 
-    private function deleteReadOlderThanThreshold() 
+    private function deleteOlderThanThreshold()
     {
         $this->loadFixtures('default');
 
-        $this->itemMapper->deleteReadOlderThanThreshold(1);
+        $this->itemMapper->deleteOlderThanThreshold(1);
 
         $this->itemMapper->find($this->whereTitleId('a title1'), $this->user);
         $this->itemMapper->find($this->whereTitleId('a title2'), $this->user);
@@ -84,12 +84,12 @@ class ItemMapperTest extends IntegrationTest
     /**
      * @expectedException OCP\AppFramework\Db\DoesNotExistException
      */
-    public function testDeleteOlderThanThresholdOne() 
+    public function testDeleteOlderThanThresholdOne()
     {
         $this->loadFixtures('default');
         $id = $this->whereTitleId('del1');
 
-        $this->deleteReadOlderThanThreshold();
+        $this->deleteOlderThanThreshold();
 
         $this->itemMapper->find($id, $this->user);
     }
@@ -97,18 +97,18 @@ class ItemMapperTest extends IntegrationTest
     /**
      * @expectedException OCP\AppFramework\Db\DoesNotExistException
      */
-    public function testDeleteOlderThanThresholdTwo() 
+    public function testDeleteOlderThanThresholdTwo()
     {
         $this->loadFixtures('default');
         $id = $this->whereTitleId('del2');
 
-        $this->deleteReadOlderThanThreshold();
+        $this->deleteOlderThanThreshold();
 
         $this->itemMapper->find($id, $this->user);
     }
 
 
-    public function testStarredCount() 
+    public function testStarredCount()
     {
         $this->loadFixtures('default');
 
@@ -117,7 +117,7 @@ class ItemMapperTest extends IntegrationTest
     }
 
 
-    public function testReadAll() 
+    public function testReadAll()
     {
         $this->loadFixtures('default');
 
@@ -146,7 +146,7 @@ class ItemMapperTest extends IntegrationTest
     }
 
 
-    public function testReadFolder() 
+    public function testReadFolder()
     {
         $this->loadFixtures('default');
 
@@ -178,7 +178,7 @@ class ItemMapperTest extends IntegrationTest
     }
 
 
-    public function testReadFeed() 
+    public function testReadFeed()
     {
         $this->loadFixtures('default');
 
@@ -209,7 +209,7 @@ class ItemMapperTest extends IntegrationTest
     }
 
 
-    public function testDeleteUser() 
+    public function testDeleteUser()
     {
         $this->loadFixtures('default');
 
@@ -219,7 +219,7 @@ class ItemMapperTest extends IntegrationTest
         $this->assertEquals(0, $id);
     }
 
-    public function testGetNewestItemId() 
+    public function testGetNewestItemId()
     {
         $this->loadFixtures('default');
 
@@ -229,7 +229,7 @@ class ItemMapperTest extends IntegrationTest
         $this->assertEquals($itemId, $id);
     }
 
-    public function testFindAllUnreadOrStarred() 
+    public function testFindAllUnreadOrStarred()
     {
         $this->loadFixtures('default');
 
@@ -238,7 +238,7 @@ class ItemMapperTest extends IntegrationTest
     }
 
 
-    public function testReadItem() 
+    public function testReadItem()
     {
         $this->loadFixtures('readitem');
         // assert that all items are unread
@@ -277,7 +277,7 @@ class ItemMapperTest extends IntegrationTest
         }
     }
 
-    public function testUnreadItem() 
+    public function testUnreadItem()
     {
         $this->loadFixtures('readitem');
         // unread an item
@@ -304,7 +304,7 @@ class ItemMapperTest extends IntegrationTest
         }
     }
 
-    protected function tearDown() 
+    protected function tearDown()
     {
         parent::tearDown();
         $this->clearUserNewsDatabase('john');

--- a/tests/Unit/Service/ItemServiceTest.php
+++ b/tests/Unit/Service/ItemServiceTest.php
@@ -32,7 +32,7 @@ class ItemServiceTest extends TestCase
 
     private $mapper;
     /**
-     * @var  ItemService 
+     * @var  ItemService
      */
     private $itemService;
     private $user;
@@ -418,7 +418,7 @@ class ItemServiceTest extends TestCase
             ->method('getAutoPurgeCount')
             ->will($this->returnValue(2));
         $this->mapper->expects($this->once())
-            ->method('deleteReadOlderThanThreshold')
+            ->method('deleteOlderThanThreshold')
             ->with($this->equalTo(2));
 
         $this->itemService->autoPurgeOld();
@@ -430,13 +430,13 @@ class ItemServiceTest extends TestCase
             ->method('getAutoPurgeCount')
             ->will($this->returnValue(-1));
         $this->mapper->expects($this->never())
-            ->method('deleteReadOlderThanThreshold');
+            ->method('deleteOlderThanThreshold');
 
         $this->itemService->autoPurgeOld();
     }
 
 
-    public function testGetNewestItemId() 
+    public function testGetNewestItemId()
     {
         $this->mapper->expects($this->once())
             ->method('getNewestItemId')
@@ -448,7 +448,7 @@ class ItemServiceTest extends TestCase
     }
 
 
-    public function testGetNewestItemIdDoesNotExist() 
+    public function testGetNewestItemIdDoesNotExist()
     {
         $this->mapper->expects($this->once())
             ->method('getNewestItemId')
@@ -494,7 +494,7 @@ class ItemServiceTest extends TestCase
     }
 
 
-    public function testDeleteUser() 
+    public function testDeleteUser()
     {
         $this->mapper->expects($this->once())
             ->method('deleteUser')


### PR DESCRIPTION
it makes no sense to keep old items regardless whether they are read or not. If an item is too old its no news anymore and should be removed - as well as read items. Only keep starred items.