### PR TITLE
Add the 'Accept' header to the request

### DIFF
--- a/lib/Config/FetcherConfig.php
+++ b/lib/Config/FetcherConfig.php
@@ -61,7 +61,7 @@ class FetcherConfig
      * Acccept header for the client.
      * @var string
      */
-    const DEFAULT_ACCEPT = '*/*';
+    const DEFAULT_ACCEPT = 'application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4, */*;q=0.2';
 
     /**
      * Configure a guzzle client

--- a/lib/Config/FetcherConfig.php
+++ b/lib/Config/FetcherConfig.php
@@ -58,6 +58,12 @@ class FetcherConfig
     const DEFAULT_USER_AGENT = 'NextCloud-News/1.0';
 
     /**
+     * Acccept header for the client.
+     * @var string
+     */
+    const DEFAULT_ACCEPT = '*/*';
+
+    /**
      * Configure a guzzle client
      *
      * @return ClientInterface Legacy client to guzzle.
@@ -78,7 +84,7 @@ class FetcherConfig
     {
         $config = [
             'timeout' => $this->client_timeout,
-            'headers' =>  ['User-Agent' => static::DEFAULT_USER_AGENT],
+            'headers' =>  ['User-Agent' => static::DEFAULT_USER_AGENT, 'Accept' => static::DEFAULT_ACCEPT],
         ];
 
         if (!empty($this->proxy)) {

--- a/lib/Config/FetcherConfig.php
+++ b/lib/Config/FetcherConfig.php
@@ -61,7 +61,9 @@ class FetcherConfig
      * Acccept header for the client.
      * @var string
      */
-    const DEFAULT_ACCEPT = 'application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4, */*;q=0.2';
+    const DEFAULT_ACCEPT = 'application/rss+xml, application/rdf+xml;q=0.8, ' .
+                           'application/atom+xml;q=0.6, application/xml;q=0.4, ' .
+                           'text/xml;q=0.4, */*;q=0.2';
 
     /**
      * Configure a guzzle client


### PR DESCRIPTION
Some firewalls block requests without the Accept header on the HTTP(s) request as seen on issue #517,
so, just add the header to all requests and say we accept anything.