### PR TITLE
Update httpLastModified from the feed response

### DIFF
--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -206,7 +206,7 @@ class FeedFetcher implements IFeedFetcher
         $item->setGuid($parsedItem->getPublicId());
         $item->setGuidHash(md5($item->getGuid()));
 
-        $lastmodified = $parsedItem->getLastModified() ?? new \DateTime();
+        $lastmodified = $parsedItem->getLastModified() ?? new DateTime();
         if ($parsedItem->getValue('pubDate') !== null) {
             $pubDT = new DateTime($parsedItem->getValue('pubDate'));
         } elseif ($parsedItem->getValue('published') !== null) {
@@ -288,8 +288,9 @@ class FeedFetcher implements IFeedFetcher
         $newFeed->setUrl($url);  // the url used to add the feed
         $newFeed->setLocation($location);  // the url where the feed was found
         $newFeed->setLink($feed->getLink());  // <link> attribute in the feed
-        $lastmodified = $feed->getLastModified() ?? new DateTime();
-        $newFeed->setLastModified($lastmodified->getTimestamp());
+        if ($feed->getLastModified() instanceof DateTime) {
+            $newFeed->setHttpLastModified($feed->getLastModified()->format(DateTime::RSS));
+        }
         $newFeed->setAdded($this->time->getTime());
 
         if (!$getFavicon) {

--- a/tests/Unit/Fetcher/FeedFetcherTest.php
+++ b/tests/Unit/Fetcher/FeedFetcherTest.php
@@ -195,10 +195,7 @@ class FeedFetcherTest extends TestCase
         $this->feed_link = 'http://tests/';
         $this->feed_image = '/an/image';
         $this->web_favicon = 'http://anon.google.com';
-        $this->modified = $this->getMockBuilder('\DateTime')->getMock();
-        $this->modified->expects($this->any())
-            ->method('getTimestamp')
-            ->will($this->returnValue(3));
+        $this->modified = new DateTime('@3');
         $this->encoding = 'UTF-8';
         $this->language = 'de-DE';
         $this->rtl = false;
@@ -661,7 +658,7 @@ class FeedFetcherTest extends TestCase
         $this->feed_mock->expects($this->exactly(1))
             ->method('getLink')
             ->will($this->returnValue($this->feed_link));
-        $this->feed_mock->expects($this->exactly(1))
+        $this->feed_mock->expects($this->exactly(2))
             ->method('getLastModified')
             ->will($this->returnValue($this->modified));
         $this->feed_mock->expects($this->exactly(1))
@@ -674,7 +671,7 @@ class FeedFetcherTest extends TestCase
         $feed->setLink($this->feed_link);
         $feed->setLocation($this->location);
         $feed->setUrl($url);
-        $feed->setLastModified(3);
+        $feed->setHttpLastModified((new DateTime('@3'))->format(DateTime::RSS));
         $feed->setAdded($this->time);
         if ($favicon) {
             $feed->setFaviconLink('http://anon.google.com');


### PR DESCRIPTION
Fix #588 

LastModified is used (in a feed context to see if a user edited a feed). httpLastModified to store the last-modified response from the source.

Without the patch the `http_last_modified` value is not longer updated hence updates for feeds will always request the whole data.

https://github.com/nextcloud/news/blob/becce6b7520912257c3d72697a3aefec9923a467/lib/Db/NewsMapper.php#L39-L49

`last_modified` seems to be a field to track changes for a record. `http_last_modified` is the field for the lastmodified timestamp.

