### PR TITLE
Release 14.1.0

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -111,6 +111,7 @@
 * [blackcrack](mailto:blackcrack@blackysgate.de)
 * [comradekingu](mailto:epost@anotheragency.no)
 * [joeplus](mailto:joerg@honululu.Speedport_W_723V_1_32_000)
+* [kesselb](mailto:mail@danielkesselberg.de)
 * [kondou](mailto:kondou@ts.unde.re)
 * [markusj](mailto:markusj@users.noreply.github.com)
 * [nexus-uw](mailto:you@example.com)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## 14.1.0
+
+### Changed
+- Minimum PHP version is now 7.2
+- Reimplement full-text scraping #563
+- Update for nextcloud 18 #593 #583
+- Update httpLastModified from the feed response #594
+
 ## 14.0.2
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,7 +29,7 @@ Before you update to a new version, [check the changelog](https://github.com/nex
     <screenshot small-thumbnail="https://raw.githubusercontent.com/nextcloud/news/master/screenshots/3-small.png">https://raw.githubusercontent.com/nextcloud/news/master/screenshots/3.png</screenshot>
     <dependencies>
         <php min-version="7.2"/>
-        <database min-version="9.4">pgsql</database>
+        <database min-version="10">pgsql</database>
         <database>sqlite</database>
         <database min-version="5.5">mysql</database>
         <lib min-version="2.7.8">libxml</lib>

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "ezyang/htmlpurifier": "4.12.0",
     "pear/net_url2": "2.2.2",
     "riimu/kit-pathjoin": "1.2.0",
-    "debril/feed-io": "^4.4",
+    "debril/feed-io": "^4.5",
     "arthurhoaro/favicon": "^1.2",
     "ext-json": "*",
     "ext-simplexml": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03f971debae1540040f4920fa45fe92e",
+    "content-hash": "bfa19511b33aa02162fc87b7406e9bc0",
     "packages": [
         {
             "name": "andreskrey/readability.php",


### PR DESCRIPTION
Will be rebased once #594 is merged.

## 14.1.0

### Changed
- Minimum PHP version is now 7.2
- Reimplement full-text scraping #563
- Update for nextcloud 18 #593 #583
- Update httpLastModified from the feed response #594