### PR TITLE
Basic Media-RSS support

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -351,6 +351,16 @@
                 <notnull>false</notnull>
             </field>
             <field>
+                <name>media_thumbnail</name>
+                <type>clob</type>
+                <notnull>false</notnull>
+            </field>
+            <field>
+                <name>media_description</name>
+                <type>clob</type>
+                <notnull>false</notnull>
+            </field>
+            <field>
                 <name>feed_id</name>
                 <type>integer</type>
                 <length>8</length>

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -112,6 +112,8 @@ The **addArticleAction** method expects a function with the following parameters
     * **body**: the html content
     * **enclosureMime**: if an enclosure is added, this is the mime type
     * **enclosureLink**: this is the source of the enclosure
+    * **mediaThumbnail**: if there is a media attached, this is its thumbnail
+    * **mediaDescription**: if there is a media attached, this is its description
     * **feedId**: the feed id it belongs to
     * **unread**: if the article is unread (bool)
     * **starred**: if the article is starred (bool)

--- a/lib/Db/Item.php
+++ b/lib/Db/Item.php
@@ -41,6 +41,10 @@ class Item extends Entity implements IAPI, \JsonSerializable
     protected $enclosureMime;
     /** @var string|null */
     protected $enclosureLink;
+    /** @var string|null */
+    protected $mediaThumbnail;
+    /** @var string|null */
+    protected $mediaDescription;
     /** @var int */
     protected $feedId;
     /** @var int */
@@ -84,6 +88,8 @@ class Item extends Entity implements IAPI, \JsonSerializable
         $item->setBody($import['body']);
         $item->setEnclosureMime($import['enclosureMime']);
         $item->setEnclosureLink($import['enclosureLink']);
+        $item->setMediaThumbnail($import['mediaThumbnail']);
+        $item->setMediaDescription($import['mediaDescription']);
         $item->setRtl($import['rtl']);
         $item->setUnread($import['unread']);
         $item->setStarred($import['starred']);
@@ -259,6 +265,8 @@ class Item extends Entity implements IAPI, \JsonSerializable
             'body' => $this->getBody(),
             'enclosureMime' => $this->getEnclosureMime(),
             'enclosureLink' => $this->getEnclosureLink(),
+            'mediaThumbnail' => $this->getMediaThumbnail(),
+            'mediaDescription' => $this->getMediaDescription(),
             'feedId' => $this->getFeedId(),
             'unread' => $this->isUnread(),
             'starred' => $this->isStarred(),
@@ -312,6 +320,22 @@ class Item extends Entity implements IAPI, \JsonSerializable
         if ($this->enclosureMime !== $enclosureMime) {
             $this->enclosureMime = $enclosureMime;
             $this->markFieldUpdated('enclosureMime');
+        }
+    }
+
+    public function setMediaThumbnail(string $mediaThumbnail = null)
+    {
+        if ($this->mediaThumbnail !== $mediaThumbnail) {
+            $this->mediaThumbnail = $mediaThumbnail;
+            $this->markFieldUpdated('mediaThumbnail');
+        }
+    }
+
+    public function setMediaDescription(string $mediaDescription = null)
+    {
+        if ($this->mediaDescription !== $mediaDescription) {
+            $this->mediaDescription = $mediaDescription;
+            $this->markFieldUpdated('mediaDescription');
         }
     }
 
@@ -446,6 +470,8 @@ class Item extends Entity implements IAPI, \JsonSerializable
             'body' => $this->getBody(),
             'enclosureMime' => $this->getEnclosureMime(),
             'enclosureLink' => $this->getEnclosureLink(),
+            'mediaThumbnail' => $this->getMediaThumbnail(),
+            'mediaDescription' => $this->getMediaDescription(),
             'feedId' => $this->getFeedId(),
             'unread' => $this->isUnread(),
             'starred' => $this->isStarred(),
@@ -468,6 +494,8 @@ class Item extends Entity implements IAPI, \JsonSerializable
             'body' => $this->getBody(),
             'enclosureMime' => $this->getEnclosureMime(),
             'enclosureLink' => $this->getEnclosureLink(),
+            'mediaThumbnail' => $this->getMediaThumbnail(),
+            'mediaDescription' => $this->getMediaDescription(),
             'unread' => $this->isUnread(),
             'starred' => $this->isStarred(),
             'feedLink' => $feeds['feed' . $this->getFeedId()]->getLink(),

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -256,11 +256,19 @@ class FeedFetcher implements IFeedFetcher
         if ($parsedItem->hasMedia()) {
             // TODO: Fix multiple media support
             foreach ($parsedItem->getMedias() as $media) {
-                if (!$item->isSupportedMime($media->getType())) {
+                if (!$item->isSupportedMime($media->getType())
+                    && !$media->getThumbnail()
+                    && !$media->getDescription()
+                ) {
                     continue;
                 }
                 $item->setEnclosureMime($media->getType());
                 $item->setEnclosureLink($media->getUrl());
+                $item->setMediaThumbnail($media->getThumbnail());
+                if ($media->getDescription()) {
+                    $description = str_replace("\n", "<br>", $media->getDescription());
+                    $item->setMediaDescription($description);
+                }
             }
         }
 

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -144,6 +144,12 @@
                     </a>
                 </div>
 
+                <div class="enclosure thumbnail" ng-if="item.mediaThumbnail">
+                    <a ng-href="{{ ::item.enclosureLink }}"><img ng-src="{{ item.mediaThumbnail|trustUrl }}" alt="" /></a>
+                </div>
+
+                <div class="enclosure description" ng-if="item.mediaDescription" news-bind-html-unsafe="item.mediaDescription"></div>
+
                 <div class="body" news-bind-html-unsafe="item.body" ng-attr-dir="{{item.rtl && 'rtl'}}"></div>
 
             </div>

--- a/tests/Integration/Fixtures/ItemFixture.php
+++ b/tests/Integration/Fixtures/ItemFixture.php
@@ -30,6 +30,8 @@ class ItemFixture extends Item
             'body' => 'this is a body',
             'enclosureMime' => 'video/mpeg',
             'enclosureLink' => 'http://google.de/web.webm',
+            'mediaThumbnail' => 'https://i3.ytimg.com/vi/Zgge1O9wdPY/hqdefault.jpg',
+            'mediaDescription' => 'The best video ever',
             'feedId' => 0,
             'unread' => true,
             'starred' => false,

--- a/tests/Unit/Controller/ExportControllerTest.php
+++ b/tests/Unit/Controller/ExportControllerTest.php
@@ -131,10 +131,12 @@ class ExportControllerTest extends TestCase
         $this->assertEquals(
             '[{"guid":"guid","url":null,"title":null,' .
             '"author":null,"pubDate":null,"updatedDate":null,"body":null,"enclosureMime":null,' .
-            '"enclosureLink":null,"unread":false,"starred":false,' .
+            '"enclosureLink":null,"mediaThumbnail":null,"mediaDescription":null,'.
+            '"unread":false,"starred":false,' .
             '"feedLink":"http:\/\/goo","rtl":false},{"guid":"guid","url":null,' .
             '"title":null,"author":null,"pubDate":null,"updatedDate":null,"body":null,' .
-            '"enclosureMime":null,"enclosureLink":null,"unread":false,' .
+            '"enclosureMime":null,"enclosureLink":null,"mediaThumbnail":null,'.
+            '"mediaDescription":null,"unread":false,' .
             '"starred":false,"feedLink":"http:\/\/gee","rtl":false}]',
             $return->render()
         );

--- a/tests/Unit/Db/ItemTest.php
+++ b/tests/Unit/Db/ItemTest.php
@@ -79,6 +79,8 @@ class ItemTest extends TestCase
         $item->setBody('body');
         $item->setEnclosureMime('audio/ogg');
         $item->setEnclosureLink('enclink');
+        $item->setMediaThumbnail('https://i2.ytimg.com/vi/E6B3uvhrcQk/hqdefault.jpg');
+        $item->setMediaDescription('The best video ever');
         $item->setRtl(true);
         $item->setFeedId(1);
         $item->setStatus(0);
@@ -101,6 +103,8 @@ class ItemTest extends TestCase
             'body' => 'body',
             'enclosureMime' => 'audio/ogg',
             'enclosureLink' => 'enclink',
+            'mediaThumbnail' => 'https://i2.ytimg.com/vi/E6B3uvhrcQk/hqdefault.jpg',
+            'mediaDescription' => 'The best video ever',
             'feedId' => 1,
             'unread' => true,
             'starred' => true,
@@ -127,6 +131,8 @@ class ItemTest extends TestCase
         $item->setBody('<body><div>this is a test</body>');
         $item->setEnclosureMime('audio/ogg');
         $item->setEnclosureLink('enclink');
+        $item->setMediaThumbnail('https://i2.ytimg.com/vi/E6B3uvhrcQk/hqdefault.jpg');
+        $item->setMediaDescription('The best video ever');
         $item->setFeedId(1);
         $item->setStatus(0);
         $item->setRtl(true);
@@ -148,6 +154,8 @@ class ItemTest extends TestCase
             'body' => '<body><div>this is a test</body>',
             'enclosureMime' => 'audio/ogg',
             'enclosureLink' => 'enclink',
+            'mediaThumbnail' => 'https://i2.ytimg.com/vi/E6B3uvhrcQk/hqdefault.jpg',
+            'mediaDescription' => 'The best video ever',
             'feedId' => 1,
             'unread' => true,
             'starred' => true,
@@ -173,6 +181,8 @@ class ItemTest extends TestCase
         $item->setBody('body');
         $item->setEnclosureMime('audio/ogg');
         $item->setEnclosureLink('enclink');
+        $item->setMediaThumbnail('https://i2.ytimg.com/vi/E6B3uvhrcQk/hqdefault.jpg');
+        $item->setMediaDescription('The best video ever');
         $item->setFeedId(1);
         $item->setRtl(true);
         $item->setStatus(0);
@@ -195,6 +205,8 @@ class ItemTest extends TestCase
             'body' => 'body',
             'enclosureMime' => 'audio/ogg',
             'enclosureLink' => 'enclink',
+            'mediaThumbnail' => 'https://i2.ytimg.com/vi/E6B3uvhrcQk/hqdefault.jpg',
+            'mediaDescription' => 'The best video ever',
             'unread' => false,
             'starred' => true,
             'feedLink' => 'http://test',
@@ -257,6 +269,8 @@ class ItemTest extends TestCase
             'body' => $item->getBody(),
             'enclosureMime' => $item->getEnclosureMime(),
             'enclosureLink' => $item->getEnclosureLink(),
+            'mediaThumbnail' => $item->getMediaThumbnail(),
+            'mediaDescription' => $item->getMediaDescription(),
             'unread' => $item->isUnread(),
             'starred' => $item->isStarred(),
             'rtl' => $item->getRtl()
@@ -282,6 +296,8 @@ class ItemTest extends TestCase
             'body' => $item->getBody(),
             'enclosureMime' => $item->getEnclosureMime(),
             'enclosureLink' => $item->getEnclosureLink(),
+            'mediaThumbnail' => $item->getMediaThumbnail(),
+            'mediaDescription' => $item->getMediaDescription(),
             'unread' => $item->isUnread(),
             'starred' => $item->isStarred(),
             'rtl' => $item->getRtl()


### PR DESCRIPTION
This is an attempt to tackle #570 

This adds support for media thumbnails and description, available since Feedio 4.5.

Now youtube feeds display correctly:
![Screenshot_2019-12-28 News (13) - Nextcloud](https://user-images.githubusercontent.com/60163/71546537-2e7e0500-2998-11ea-8ad6-aef555e61b87.png)

I am not a PHP expert, neither an angular one, so I am not really used to good practices with those tools. Do not hesitate to tell me if there is anything I can improve.
