### PR TITLE
Release 14.1.1

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -96,6 +96,7 @@
 * [Roeland Jago Douma](mailto:roeland@famdouma.nl)
 * [Simon](mailto:sschubert89@gmail.com)
 * [Simon Gilliot](mailto:simon@gilliot.fr)
+* [SuliacLEGUILLOU](mailto:suliac.leguillou@pm.me)
 * [TexasGamer](mailto:tpgaubert@gmail.com)
 * [The Gitter Badger](mailto:badger@gitter.im)
 * [Thomas Wouters](mailto:twouters@users.noreply.github.com)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## 14.1.1
+
+### Changed
+- feed-io updated to v4.5.1 #613
+- Automatically convert youtube channel urls in feed url #612
+
+###  Fixed
+- Scraper breaks feed fetching when it fails #606
+
 ## 14.1.0
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 Before you update to a new version, [check the changelog](https://github.com/nextcloud/news/blob/master/CHANGELOG.md) to avoid surprises.
 
 **Important**: To enable feed updates you will need to enable either [Nextcloud system cron](https://docs.nextcloud.org/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron) or use [an updater](https://github.com/nextcloud/news-updater) which uses the built in update API and disable cron updates. More information can be found [in the README](https://github.com/nextcloud/news).]]></description>
-    <version>14.1.0</version>
+    <version>14.1.1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
Changed
- feed-io updated to v4.5.1 #613
- Automatically convert youtube channel urls in feed url #612

Fixed
- Scraper breaks feed fetching when it fails #606

Signed-off-by: Benjamin Brahmer <info@b-brahmer.de>