### PR TITLE
Always show the unread articles "folder"

### DIFF
--- a/js/app/Config.js
+++ b/js/app/Config.js
@@ -16,7 +16,8 @@ app.config(function ($routeProvider, $provide, $httpProvider, $locationProvider)
         STARRED: 2,
         SUBSCRIPTIONS: 3,
         SHARED: 4,
-        EXPLORE: 5
+        EXPLORE: 5,
+        UNREAD: 6
     };
 
     // default hashPrefix changed in angular 1.6 to '!'
@@ -189,6 +190,12 @@ app.config(function ($routeProvider, $provide, $httpProvider, $locationProvider)
             templateUrl: 'content.html',
             resolve: getItemResolve(feedType.STARRED),
             type: feedType.STARRED
+        })
+        .when('/items/unread', {
+            controller: 'ContentController as Content',
+            templateUrl: 'content.html',
+            resolve: getItemResolve(feedType.UNREAD),
+            type: feedType.UNREAD
         })
         .when('/items/feeds/:id', {
             controller: 'ContentController as Content',

--- a/js/app/Run.js
+++ b/js/app/Run.js
@@ -17,7 +17,7 @@ app.run(function ($rootScope, $location, $http, $q, $interval, $route, Loading, 
     // listen to keys in returned queries to automatically distribute the
     // incoming values to models
     Publisher.subscribe(ItemResource).toChannels(['items', 'newestItemId',
-        'starred']);
+        'starred', 'unread']);
     Publisher.subscribe(FolderResource).toChannels(['folders']);
     Publisher.subscribe(FeedResource).toChannels(['feeds']);
     Publisher.subscribe(SettingsResource).toChannels(['settings']);
@@ -49,12 +49,16 @@ app.run(function ($rootScope, $location, $http, $q, $interval, $route, Loading, 
                     url = '/explore';
                     break;
 
+                case FEED_TYPE.UNREAD:
+                    url = '/items/unread';
+                    break;
+
                 default:
                     url = '/items';
             }
 
             // only redirect if url is empty or faulty
-            if (!/^\/items(\/(starred|explore|feeds\/\d+|folders\/\d+))?\/?$/
+            if (!/^\/items(\/(starred|unread|explore|feeds\/\d+|folders\/\d+))?\/?$/
                 .test(path)) {
                 $location.path(url);
             }

--- a/lib/Db/FeedType.php
+++ b/lib/Db/FeedType.php
@@ -21,4 +21,5 @@ class FeedType
     const SUBSCRIPTIONS = 3;
     const SHARED        = 4;
     const EXPLORE       = 5;
+    const UNREAD        = 6;
 }

--- a/lib/Db/ItemMapper.php
+++ b/lib/Db/ItemMapper.php
@@ -64,7 +64,7 @@ class ItemMapper extends NewsMapper
         if (isset($type) && $type === FeedType::STARRED) {
             $sql = 'AND `items`.`starred` = ';
             $sql .= $this->db->quote(true, IQueryBuilder::PARAM_BOOL) . ' ';
-        } elseif (!$showAll) {
+        } elseif (!$showAll || $type === FeedType::UNREAD) {
             $sql .= 'AND `items`.`unread` = ';
             $sql .= $this->db->quote(true, IQueryBuilder::PARAM_BOOL) . ' ';
         }

--- a/templates/part.navigation.unreadfeed.php
+++ b/templates/part.navigation.unreadfeed.php
@@ -4,12 +4,8 @@
     }"
     class="subscriptions-feed with-counter with-menu">
 
-    <a class="icon-rss" ng-href="#/items/" ng-if="!Navigation.isShowAll()">
+    <a class="icon-rss" ng-href="#/items/unread" >
        <?php p($l->t('Unread articles'))?>
-    </a>
-
-    <a class="icon-rss" ng-href="#/items/" ng-if="Navigation.isShowAll()">
-       <?php p($l->t('All articles'))?>
     </a>
 
     <div class="app-navigation-entry-utils" ng-show="Navigation.isUnread()">
@@ -28,6 +24,39 @@
     </div>
 
     <div class="app-navigation-entry-menu">
+        <ul>
+            <li class="mark-read">
+                <button ng-click="Navigation.markRead()">
+                    <span class="icon-checkmark"></span>
+                    <span><?php p($l->t('Mark read')); ?></span>
+                </button>
+            </li>
+        </ul>
+    </div>
+
+</li>
+
+<li ng-class="{
+        active: Navigation.isSubscriptionsActive(),
+        unread: Navigation.isUnread()
+    }"
+    class="all-subscriptions-feed with-counter with-menu">
+
+    <a class="icon-rss" ng-href="#/items/" ng-if="Navigation.isShowAll()">
+       <?php p($l->t('All articles'))?>
+    </a>
+
+    <div class="app-navigation-entry-utils" ng-if="Navigation.isShowAll()">
+        <ul>
+            <li class="app-navigation-entry-utils-menu-button">
+                <button
+                    ng-click="optionsId = (optionsId == 'all' ? -1 : 'all')">
+                </button>
+            </li>
+        </ul>
+    </div>
+
+    <div class="app-navigation-entry-menu" ng-if="navigation.isShowAll()">
         <ul>
             <li class="mark-read">
                 <button ng-click="Navigation.markRead()">


### PR DESCRIPTION
The "Unread articles" folder will always be visible, regardless of the "Show all" setting. If that setting is on, then an additional "All articles" folder will be show as before, but it doesn't substitute the "Unread articles" one.

A new URL /apps/news/#/items/unread is also created that jumps to the unread articles.

I think this should fix issues #629, #534, #508, #310, #287, #248, at least to some extent.