### PR TITLE
fixed active menu item and reload for unread

### DIFF
--- a/js/controller/NavigationController.js
+++ b/js/controller/NavigationController.js
@@ -140,6 +140,11 @@ app.controller('NavigationController', function ($route, FEED_TYPE, FeedResource
             $route.current.$$route.type === FEED_TYPE.SUBSCRIPTIONS;
     };
 
+    this.isUnreadActive = function () {
+        return $route.current &&
+            $route.current.$$route.type === FEED_TYPE.UNREAD;
+    };
+
     this.isStarredActive = function () {
         return $route.current &&
             $route.current.$$route.type === FEED_TYPE.STARRED;

--- a/templates/part.navigation.unreadfeed.php
+++ b/templates/part.navigation.unreadfeed.php
@@ -1,10 +1,10 @@
 <li ng-class="{
-        active: Navigation.isSubscriptionsActive(),
+        active: Navigation.isUnreadActive(),
         unread: Navigation.isUnread()
     }"
     class="subscriptions-feed with-counter with-menu">
 
-    <a class="icon-rss" ng-href="#/items/unread" >
+    <a class="icon-rss" ng-href="#/items/unread/" >
        <?php p($l->t('Unread articles'))?>
     </a>
 
@@ -40,13 +40,14 @@
         active: Navigation.isSubscriptionsActive(),
         unread: Navigation.isUnread()
     }"
-    class="all-subscriptions-feed with-counter with-menu">
+    ng-if="Navigation.isShowAll()"
+    class="all-subscriptions-feed with-menu">
 
-    <a class="icon-rss" ng-href="#/items/" ng-if="Navigation.isShowAll()">
+    <a class="icon-rss" ng-href="#/items/">
        <?php p($l->t('All articles'))?>
     </a>
 
-    <div class="app-navigation-entry-utils" ng-if="Navigation.isShowAll()">
+    <div class="app-navigation-entry-utils">
         <ul>
             <li class="app-navigation-entry-utils-menu-button">
                 <button
@@ -56,7 +57,7 @@
         </ul>
     </div>
 
-    <div class="app-navigation-entry-menu" ng-if="navigation.isShowAll()">
+    <div class="app-navigation-entry-menu">
         <ul>
             <li class="mark-read">
                 <button ng-click="Navigation.markRead()">


### PR DESCRIPTION
Since they shared the same function the "Unread" and "All" menu items were marked active at the same time.

Also the reload of the "Unread" by clicking it or pressing `r` didn't work. (fixes #671, fixes #673)