### PR TITLE
Remove Totalbiscuit from Explore

### DIFF
--- a/lib/Explore/feeds/feeds.en.json
+++ b/lib/Explore/feeds/feeds.en.json
@@ -54,13 +54,6 @@
         "votes": 500
     }],
     "Gaming": [{
-        "title": "TotalBiscuit, The Cynical Brit",
-        "favicon": "https:\/\/s.ytimg.com\/yts\/img\/favicon-vflz7uhzw.ico",
-        "url": "http:\/\/www.youtube.com\/channel\/UCy1Ms_5qBTawC-k7PVjHXKQ",
-        "feed": "http:\/\/www.youtube.com\/feeds\/videos.xml?channel_id=UCy1Ms_5qBTawC-k7PVjHXKQ",
-        "description": "General gaming news and reviews",
-        "votes": 100
-    }, {
         "title": "Force Gaming",
         "favicon": "https:\/\/s.ytimg.com\/yts\/img\/favicon-vflz7uhzw.ico",
         "url": "http:\/\/www.youtube.com\/channel\/UCGhs9S33RAeT5DEuKTO4Oew",


### PR DESCRIPTION
As unfortunate as it is, John "TotalBiscuit" Bain passed away in 2018, with the last video uploaded to his channel being posted close to a year ago at this point. It is probably best to open up space for other feeds.