### PR TITLE
Do not create spurious links in item body

### DIFF
--- a/lib/Db/Item.php
+++ b/lib/Db/Item.php
@@ -291,7 +291,7 @@ class Item extends Entity implements IAPI, \JsonSerializable
     {
         // FIXME: this should not happen if the target="_blank" is already
         // on the link
-        $body = str_replace('<a', '<a target="_blank" rel="noreferrer"', $body);
+        $body = str_replace('<a ', '<a target="_blank" rel="noreferrer" ', $body);
 
         if ($this->body !== $body) {
             $this->body = $body;


### PR DESCRIPTION
The 'str_replace' will match any HTML element that starts with '<a',
including things like '<address' or '<article', thus creating spurious
links in item bodies. Fix that by simply adding one whitespace.

Fixes issue #527.