### PR TITLE
Update to new BackgroudJob logic

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 Before you update to a new version, [check the changelog](https://github.com/nextcloud/news/blob/master/CHANGELOG.md) to avoid surprises.
 
 **Important**: To enable feed updates you will need to enable either [Nextcloud system cron](https://docs.nextcloud.org/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron) or use [an updater](https://github.com/nextcloud/news-updater) which uses the built in update API and disable cron updates. More information can be found [in the README](https://github.com/nextcloud/news).]]></description>
-    <version>14.1.11</version>
+    <version>14.2.0</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>

--- a/js/admin/Admin.js
+++ b/js/admin/Admin.js
@@ -29,6 +29,8 @@
             $('#news input[name="news-max-size"]');
         var exploreUrlInput =
             $('#news input[name="news-explore-url"]');
+        var updateInterval =
+            $('#news input[name="news-update-interval"]');
         var savedMessage = $('#news-saved-message');
 
         var saved = function () {
@@ -50,6 +52,7 @@
             var feedFetcherTimeout = feedFetcherTimeoutInput.val();
             var maxSize = maxSizeInput.val();
             var exploreUrl = exploreUrlInput.val();
+            var updateInterval = updateIntervalInput.val()
             var useCronUpdates = useCronUpdatesInput.is(':checked');
 
             var data = {
@@ -60,7 +63,8 @@
                 feedFetcherTimeout: parseInt(feedFetcherTimeout, 10),
                 maxSize: parseInt(maxSize, 10),
                 useCronUpdates: useCronUpdates,
-                exploreUrl: exploreUrl
+                exploreUrl: exploreUrl,
+                updateInterval: parseInt(updateInterval, 10)
             };
 
             var url = OC.generateUrl('/apps/news/admin');
@@ -81,6 +85,7 @@
                 feedFetcherTimeoutInput.val(data.feedFetcherTimeout);
                 useCronUpdatesInput.prop('checked', data.useCronUpdates);
                 exploreUrlInput.val(data.exploreUrl);
+                updateInterval.val(data.updateInterval);
             });
 
         };

--- a/lib/Config/Config.php
+++ b/lib/Config/Config.php
@@ -32,6 +32,7 @@ class Config
     private $loggerParams;
     private $maxSize;
     private $exploreUrl;
+    private $updateInterval;
 
     public function __construct(
         Folder $fileSystem,
@@ -48,6 +49,7 @@ class Config
         $this->logger = $logger;
         $this->exploreUrl = '';
         $this->loggerParams = $LoggerParameters;
+        $this->updateInterval = 3600;
     }
 
     public function getAutoPurgeMinimumInterval()
@@ -94,6 +96,10 @@ class Config
         return $this->exploreUrl;
     }
 
+    public function getUpdateInterval()
+    {
+        return $this->updateInterval;
+    }
 
     public function setAutoPurgeMinimumInterval($value)
     {
@@ -134,6 +140,12 @@ class Config
     {
         $this->exploreUrl = $value;
     }
+
+    public function setUpdateInterval($value)
+    {
+        $this->updateInterval = $value;
+    }
+
 
 
     public function read($configPath, $createIfNotExists = false)

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -73,6 +73,7 @@ class AdminController extends Controller
             'useCronUpdates' => $this->config->getUseCronUpdates(),
             'maxSize' => $this->config->getMaxSize(),
             'exploreUrl' => $this->config->getExploreUrl(),
+            'updateInterval' => $this->config->getupdateInterval(),
         ];
         return new TemplateResponse($this->appName, 'admin', $data, 'blank');
     }
@@ -88,6 +89,7 @@ class AdminController extends Controller
      * @param int    $maxSize                  New max feed size
      * @param bool   $useCronUpdates           Whether or not to use cron updates
      * @param string $exploreUrl               URL to use for the explore feed
+     * @param int    $updateInterval           Interval in which the feeds will be updated
      *
      * @return array with the updated values
      */
@@ -98,7 +100,8 @@ class AdminController extends Controller
         $feedFetcherTimeout,
         $maxSize,
         $useCronUpdates,
-        $exploreUrl
+        $exploreUrl,
+        $updateInterval
     ) {
         $this->config->setAutoPurgeMinimumInterval($autoPurgeMinimumInterval);
         $this->config->setAutoPurgeCount($autoPurgeCount);
@@ -107,6 +110,7 @@ class AdminController extends Controller
         $this->config->setFeedFetcherTimeout($feedFetcherTimeout);
         $this->config->setUseCronUpdates($useCronUpdates);
         $this->config->setExploreUrl($exploreUrl);
+        $this->config->setupdateInterval($updateInterval);
         $this->config->write($this->configPath);
 
         return [
@@ -118,6 +122,7 @@ class AdminController extends Controller
             'feedFetcherTimeout' => $this->config->getFeedFetcherTimeout(),
             'useCronUpdates' => $this->config->getUseCronUpdates(),
             'exploreUrl' => $this->config->getExploreUrl(),
+            'updateInterval' => $this->config->getupdateInterval(),
         ];
     }
 }

--- a/lib/Cron/Updater.php
+++ b/lib/Cron/Updater.php
@@ -11,13 +11,13 @@
 
 namespace OCA\News\Cron;
 
-use OC\BackgroundJob\Job;
+use OC\BackgroundJob\TimedJob;
 
 use OCA\News\Config\Config;
 use OCA\News\Service\StatusService;
 use OCA\News\Utility\Updater as UpdaterService;
 
-class Updater extends Job
+class Updater extends TimedJob
 {
 
     /**
@@ -34,6 +34,7 @@ class Updater extends Job
     private $updaterService;
 
     public function __construct(
+        ITimeFactroy $time,
         Config $config,
         StatusService $status,
         UpdaterService $updaterService
@@ -41,6 +42,8 @@ class Updater extends Job
         $this->config = $config;
         $this->status = $status;
         $this->updaterService = $updaterService;
+
+        parent::setInterval($this->config->getupdateInterval());
     }
 
     protected function run($argument)

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -27,6 +27,7 @@ class Admin implements ISettings
             'useCronUpdates' => $this->config->getUseCronUpdates(),
             'maxSize' => $this->config->getMaxSize(),
             'exploreUrl' => $this->config->getExploreUrl(),
+            'updateInterval' => $this->config->getUpdateInterval(),
         ];
         return new TemplateResponse('news', 'admin', $data, '');
     }

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -125,6 +125,25 @@ style('news', 'admin');
         <p><input type="text" name="news-explore-url"
                value="<?php p($_['exploreUrl']); ?>"></p>
     </div>
+    <div class="form-line">
+        <p>
+            <label for="news-updater-interval">
+                <?php p($l->t('Update Interval')); ?>
+            </label>
+        </p>
+        <p>
+            <em>
+                <?php p($l->t(
+                    'Interval in which the feeds will be updated '
+                )); ?>.
+            </em>
+            <a href="https://github.com/nextcloud/news/tree/master/docs/updateInterval"><?php p($l->t(
+                'For more information check the wiki'
+            )); ?></a>
+        </p>
+        <p><input type="text" name="news-update-interval"
+               value="<?php p($_['updateInterval']); ?>"></p>
+    </div>
     <div id="news-saved-message">
         <span class="msg success"><?php p($l->t('Saved')); ?></span>
     </div>

--- a/tests/Unit/Controller/AdminControllerTest.php
+++ b/tests/Unit/Controller/AdminControllerTest.php
@@ -62,7 +62,8 @@ class AdminControllerTest extends TestCase
             'feedFetcherTimeout' => 4,
             'useCronUpdates' => 5,
             'maxSize' => 7,
-            'exploreUrl' => 'test'
+            'exploreUrl' => 'test',
+            'updateInterval' => 3600
         ];
         $this->config->expects($this->once())
             ->method('getAutoPurgeMinimumInterval')
@@ -85,6 +86,9 @@ class AdminControllerTest extends TestCase
         $this->config->expects($this->once())
             ->method('getExploreUrl')
             ->will($this->returnValue($expected['exploreUrl']));
+        $this->config->expects($this->once())
+            ->method('getUpdateInterval')
+            ->will($this->returnValue($expected['updateInterval']));
 
         $response = $this->controller->index();
         $data = $response->getParams();
@@ -106,7 +110,8 @@ class AdminControllerTest extends TestCase
             'feedFetcherTimeout' => 4,
             'useCronUpdates' => 5,
             'maxSize' => 7,
-            'exploreUrl' => 'test'
+            'exploreUrl' => 'test',
+            'updateInterval' => 3600
         ];
 
         $this->config->expects($this->once())
@@ -127,6 +132,9 @@ class AdminControllerTest extends TestCase
         $this->config->expects($this->once())
             ->method('setExploreUrl')
             ->with($this->equalTo($expected['exploreUrl']));
+        $this->config->expects($this->once())
+            ->method('setUpdateInterval')
+            ->with($this->equalTo($expected['updateInterval']));
         $this->config->expects($this->once())
             ->method('write')
             ->with($this->equalTo($this->configPath));
@@ -152,6 +160,9 @@ class AdminControllerTest extends TestCase
         $this->config->expects($this->once())
             ->method('getExploreUrl')
             ->will($this->returnValue($expected['exploreUrl']));
+        $this->config->expects($this->once())
+            ->method('getUpdateInterval')
+            ->will($this->returnValue($expected['updateInterval']));
 
         $response = $this->controller->update(
             $expected['autoPurgeMinimumInterval'],
@@ -160,7 +171,8 @@ class AdminControllerTest extends TestCase
             $expected['feedFetcherTimeout'],
             $expected['maxSize'],
             $expected['useCronUpdates'],
-            $expected['exploreUrl']
+            $expected['exploreUrl'],
+            $expected['updateInterval']
         );
 
         $this->assertEquals($expected, $response);


### PR DESCRIPTION
I investigated #643 again and figured out that the way we defined our background job is probably no longer valid.
So I tried to implement the new way.
Interesting side effect of this is that we are no longer depending on the cron update interval but that the interval to update the feeds can be set in the settings, not individually per feed or user but system wide.

I still think that this would be an cool addition to news and allow people to reduce the amount of traffic they cause, as the new default for nextcloud is every 5min every 30min would probably be enough for most people.

This PR is marked as draft as documentation is still missing and I'm not that confident about my code.
I tried my best though (actually I'm more of an python developer :D) 

Tests are running and I installed it in a snap installation locally I will test it a bit to find our if it works, help would be very much appreciated.