### PR TITLE
Allow data URI scheme inside the body of an item.

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -153,6 +153,20 @@ class Application extends App
                 'player.vimeo.com/video/|' .
                 'vk.com/video_ext.php)%'
             ); //allow YouTube and Vimeo
+
+            // Additionally to the defaults, allow the data URI scheme.
+            // See http://htmlpurifier.org/live/configdoc/plain.html#URI.AllowedSchemes
+            $config->set('URI.AllowedSchemes', [
+                'http' => true,
+                'https' => true,
+                'data' => true,
+                'mailto' => true,
+                'ftp' => true,
+                'nntp' => true,
+                'news' => true,
+                'tel' => true,
+            ]);
+
             $def = $config->getHTMLDefinition(true);
             $def->addAttribute('iframe', 'allowfullscreen', 'Bool');
             return new HTMLPurifier($config);


### PR DESCRIPTION
As a followup for https://github.com/nextcloud/news/issues/477

I setup a local copy of nextcloud news to configure it properly.

I also researched a bit on the security side of it and I think it is pretty safe as browsers will block attempts to use data URIs for phising attacks

https://en.wikipedia.org/wiki/Data_URI_scheme#Malware_and_phishing
