### PR TITLE
Removes FeedReader from Sync Clients list

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Nextcloud News can be synced with the following apps:
   * [FeedSpider (Firefox OS, WebOS, LuneOS)](http://www.feedspider.net/), [open source](https://github.com/OthelloVentures/feedspider)
   * [fastReader (Windows Phone)](http://www.windowsphone.com/en-us/store/app/fastreader/e55e696d-aa45-4a49-bb1c-a1fc7fdabec1), closed source
   * [OwnCloud News Reader (WebOS)](http://www.webosnation.com/owncloud-news-reader), [open source](https://bitbucket.org/andpeters/webos-owncloud-news-reader)
-  * [FeedReader (Linux desktop)](http://jangernert.github.io/FeedReader/), [open source](https://github.com/jangernert/FeedReader)
   * [py3status](https://github.com/ultrabug/py3status/) for [i3 (UNIX-like)](http://i3wm.org/), [open source](https://github.com/i3/i3)
   * [newsboat](http://newsboat.org/) for Unix terminal, [open source](https://github.com/newsboat/newsboat)
   * [Newsie (Ubuntu Touch)](https://open-store.io/app/newsie.martinferretti), [open source](https://gitlab.com/ferrettim/newsie) 


### PR DESCRIPTION
FeedReader has been archived: https://github.com/jangernert/FeedReader/

The author has started working on a successor called NewsFlash, which currently doesn't support Nextcloud's News: https://gitlab.com/news-flash/news_flash_gtk

Quote from the README:

> Some services supported by FeedReader have not yet found their way into NewsFlash. Work for Google Reader style APIs is already on the way (FreshRSS, InoReader, The Old Reader). **Nextcloud News will probably only happen as soon as their [APIv2 draft](https://github.com/nextcloud/news/blob/ec3cc602f1bd363efe776ce4914319034d35c18e/docs/externalapi/External-Api.md) gets implemented.**