### PR TITLE
Add tagesschau.de to feeds.de.json

### DIFF
--- a/lib/Explore/feeds/feeds.de.json
+++ b/lib/Explore/feeds/feeds.de.json
@@ -97,6 +97,13 @@
         "description": "Plattform für digitale Freiheitsrechte",
         "votes": 100
     }, {
+        "title": "tagesschau.de",
+        "favicon": "https:\/\/tagesschau.de\/favicon.ico",
+        "url": "https:\/\/tagesschau.de",
+        "feed": "https:\/\/www.tagesschau.de/xml/rss2_https",
+        "description": "Die Nachrichten der ARD",
+        "votes": 100
+    }, {
         "title": "Tarnkappe.info",
         "favicon": "https:\/\/tarnkappe.info\/favicon.ico",
         "url": "https:\/\/tarnkappe.info",


### PR DESCRIPTION
The RSS2 feed seems to be the preferred one, so I added it instead of the Atom feed.