### PR TITLE
fix config test

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -823,16 +823,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.40",
+            "version": "0.12.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "dce7293ad7b59fc09a9ab9b0b5b44902c092ca17"
+                "reference": "7c43b7c2d5ca6554f6231e82e342a710163ac5f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dce7293ad7b59fc09a9ab9b0b5b44902c092ca17",
-                "reference": "dce7293ad7b59fc09a9ab9b0b5b44902c092ca17",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7c43b7c2d5ca6554f6231e82e342a710163ac5f4",
+                "reference": "7c43b7c2d5ca6554f6231e82e342a710163ac5f4",
                 "shasum": ""
             },
             "require": {
@@ -875,7 +875,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-26T19:06:20+00:00"
+            "time": "2020-09-02T13:14:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/lib/Config/Config.php
+++ b/lib/Config/Config.php
@@ -199,7 +199,7 @@ class Config
             'updateInterval = ' .
                 $this->updateInterval . "\n" .
             'useCronUpdates = ' .
-                var_export($this->useCronUpdates, true);  
+                var_export($this->useCronUpdates, true);
         ;
 
         $this->fileSystem->get($configPath)->putContent($ini);

--- a/tests/Unit/Config/ConfigTest.php
+++ b/tests/Unit/Config/ConfigTest.php
@@ -35,7 +35,9 @@ class ConfigTest extends TestCase
         $this->fileSystem = $this->getMockBuilder(Folder::class)->getMock();
         $this->loggerParams = ['hi'];
         $this->config = new Config(
-            $this->fileSystem, $this->logger, $this->loggerParams
+            $this->fileSystem,
+            $this->logger,
+            $this->loggerParams
         );
         $this->configPath = 'config.json';
     }

--- a/tests/Unit/Config/ConfigTest.php
+++ b/tests/Unit/Config/ConfigTest.php
@@ -27,7 +27,7 @@ class ConfigTest extends TestCase
     private $configPath;
     private $loggerParams;
 
-    public function setUp() 
+    public function setUp()
     {
         $this->logger = $this->getMockBuilder('OCA\News\Utility\PsrLogger')
             ->disableOriginalConstructor()
@@ -41,19 +41,20 @@ class ConfigTest extends TestCase
     }
 
 
-    public function testDefaults() 
+    public function testDefaults()
     {
         $this->assertEquals(60, $this->config->getAutoPurgeMinimumInterval());
         $this->assertEquals(200, $this->config->getAutoPurgeCount());
         $this->assertEquals(10, $this->config->getMaxRedirects());
         $this->assertEquals(60, $this->config->getFeedFetcherTimeout());
+        $this->assertEquals(3600, $this->config->getUpdateInterval());
         $this->assertEquals(true, $this->config->getUseCronUpdates());
         $this->assertEquals('', $this->config->getExploreUrl());
         $this->assertEquals(1024*1024*100, $this->config->getMaxSize());
     }
 
 
-    public function testRead() 
+    public function testRead()
     {
         $file = $this->getMockBuilder(File::class)->getMock();
         $this->fileSystem->expects($this->once())
@@ -76,7 +77,7 @@ class ConfigTest extends TestCase
     }
 
 
-    public function testReadIgnoresVeryLowPurgeInterval() 
+    public function testReadIgnoresVeryLowPurgeInterval()
     {
         $file = $this->getMockBuilder(File::class)->getMock();
         $this->fileSystem->expects($this->once())
@@ -94,7 +95,7 @@ class ConfigTest extends TestCase
 
 
 
-    public function testReadBool() 
+    public function testReadBool()
     {
         $file = $this->getMockBuilder(File::class)->getMock();
         $this->fileSystem->expects($this->once())
@@ -116,7 +117,7 @@ class ConfigTest extends TestCase
     }
 
 
-    public function testReadLogsInvalidValue() 
+    public function testReadLogsInvalidValue()
     {
         $file = $this->getMockBuilder(File::class)->getMock();
         $this->fileSystem->expects($this->once())
@@ -140,7 +141,7 @@ class ConfigTest extends TestCase
     }
 
 
-    public function testReadLogsInvalidINI() 
+    public function testReadLogsInvalidINI()
     {
         $file = $this->getMockBuilder(File::class)->getMock();
         $this->fileSystem->expects($this->once())
@@ -161,7 +162,7 @@ class ConfigTest extends TestCase
     }
 
 
-    public function testWrite() 
+    public function testWrite()
     {
         $json = 'autoPurgeMinimumInterval = 60' . "\n" .
             'autoPurgeCount = 3' . "\n" .
@@ -169,6 +170,7 @@ class ConfigTest extends TestCase
             'maxSize = 399' . "\n" .
             'exploreUrl = http://google.de' . "\n" .
             'feedFetcherTimeout = 60' . "\n" .
+            'updateInterval = 3600' . "\n" .
             'useCronUpdates = true';
         $this->config->setAutoPurgeCount(3);
         $this->config->setMaxSize(399);
@@ -188,7 +190,7 @@ class ConfigTest extends TestCase
 
 
 
-    public function testReadingNonExistentConfigWillWriteDefaults() 
+    public function testReadingNonExistentConfigWillWriteDefaults()
     {
         $this->fileSystem->expects($this->once())
             ->method('nodeExists')
@@ -203,6 +205,7 @@ class ConfigTest extends TestCase
             'maxSize = 104857600' . "\n" .
             'exploreUrl = ' . "\n" .
             'feedFetcherTimeout = 60' . "\n" .
+            'updateInterval = 3600' . "\n" .
             'useCronUpdates = false';
 
         $this->fileSystem->expects($this->once())
@@ -221,7 +224,7 @@ class ConfigTest extends TestCase
     }
 
 
-    public function testNoLowMinimumAutoPurgeInterval() 
+    public function testNoLowMinimumAutoPurgeInterval()
     {
         $this->config->setAutoPurgeMinimumInterval(59);
         $interval = $this->config->getAutoPurgeMinimumInterval();
@@ -230,7 +233,7 @@ class ConfigTest extends TestCase
     }
 
 
-    public function testMinimumAutoPurgeInterval() 
+    public function testMinimumAutoPurgeInterval()
     {
         $this->config->setAutoPurgeMinimumInterval(61);
         $interval = $this->config->getAutoPurgeMinimumInterval();
@@ -238,7 +241,7 @@ class ConfigTest extends TestCase
         $this->assertSame(61, $interval);
     }
 
-    public function testMaxRedirects() 
+    public function testMaxRedirects()
     {
         $this->config->setMaxRedirects(21);
         $redirects = $this->config->getMaxRedirects();
@@ -246,7 +249,7 @@ class ConfigTest extends TestCase
         $this->assertSame(21, $redirects);
     }
 
-    public function testFeedFetcherTimeout() 
+    public function testFeedFetcherTimeout()
     {
         $this->config->setFeedFetcherTimeout(2);
         $timout = $this->config->getFeedFetcherTimeout();


### PR DESCRIPTION
PHPCBF complained about a whitespace, no idea where it sees a whitespace in that line 

```
FILE: /home/grotax/git/nc-server/apps/news/lib/Config/Config.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 202 | ERROR | [x] Whitespace found at end of line
----------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
```