### PR TITLE
Add tagesschau.de to feeds.de.json

### DIFF
--- a/lib/Explore/feeds/feeds.de.json
+++ b/lib/Explore/feeds/feeds.de.json
@@ -97,6 +97,13 @@
         "description": "Plattform für digitale Freiheitsrechte",
         "votes": 100
     }, {
+        "title": "tagesschau.de",
+        "favicon": "https:\/\/tagesschau.de\/favicon.ico",
+        "url": "https:\/\/tagesschau.de",
+        "feed": "https:\/\/www.tagesschau.de/xml/rss2_https",
+        "description": "Die Nachrichten der ARD",
+        "votes": 100
+    }, {
         "title": "Tarnkappe.info",
         "favicon": "https:\/\/tarnkappe.info\/favicon.ico",
         "url": "https:\/\/tarnkappe.info",


### PR DESCRIPTION
According to their website, the RSS2 feed seems to be preferred and has images etc, which the Atom feed does not have.
This is a duplicate of #779 because I didn't know about Signed-off-by and I'm too lazy to figure out how to edit my commit message.

Signed-off-by: felurx