### PR TITLE
Fix background color when loading content

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -122,6 +122,7 @@
  */
 #app-content.loading-content {
     background: url('../img/loading.gif') no-repeat;
+    background-color: var(--color-main-background);
     background-position: calc(50% - 16px) calc(50% - 16px);
     /* Overrides the snap.js animation making the loading icon to fly in app-content. */
     transition: none !important;


### PR DESCRIPTION
When loading content background-color should be set from theme.

I'm pretty sure this wasn't an issue before but I've no idea when or where it was introduced, so it might affect more than just the background when loading articles.