### PR TITLE
fix invalid UserId when logged out

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -71,7 +71,7 @@ class PageController extends Controller
         IL10N $l10n,
         RecommendedSites $recommendedSites,
         StatusService $statusService,
-        string $UserId
+        ?string $UserId
     ) {
         parent::__construct($appName, $request);
         $this->settings = $settings;


### PR DESCRIPTION
When calling the news URL while not logged in it causes an Internal server error since the `$UserId` is null.

For example https://cloud.example.com/apps/news/#/items/unread should redirect to the login page instead of crashing.