### PR TITLE
update only relevant item fields

### DIFF
--- a/lib/Db/ItemMapperV2.php
+++ b/lib/Db/ItemMapperV2.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\FetchMode;
 use OCA\News\Utility\Time;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\Entity;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
@@ -95,6 +96,16 @@ class ItemMapperV2 extends NewsMapperV2
         return $this->findEntity($builder);
     }
 
+    /**
+     * Find an item by a GUID hash.
+     *
+     * @param string $guidHash hash to find with
+     *
+     * @return Item|Entity
+     *
+     * @throws DoesNotExistException
+     * @throws MultipleObjectsReturnedException
+     */
     public function findByGuidHash(string $guidHash): Item
     {
         $builder = $this->db->getQueryBuilder();

--- a/lib/Service/ItemServiceV2.php
+++ b/lib/Service/ItemServiceV2.php
@@ -76,7 +76,12 @@ class ItemServiceV2 extends Service
     {
         try {
             $db_item = $this->mapper->findByGuidHash($item->getGuidHash());
-            $item->setId($db_item->getId());
+
+            // Transfer user modifications
+            $item->setUnread($db_item->isUnread())
+                 ->setStarred($db_item->isStarred())
+                 ->setId($db_item->getId());
+
             $this->mapper->update($item);
         } catch (DoesNotExistException $exception) {
             $this->mapper->insert($item);


### PR DESCRIPTION
The old way of updating items seems better as mentioned in https://github.com/nextcloud/news/issues/827#issuecomment-703149126, so I've adopted it.

The line
```php
$db_item->setBody($item->getBody());
```
may have some side effects with the following, but they should have been there already until now.
https://github.com/nextcloud/news/blob/b17f1ca26de1a4c69a1f398cfd781847806d0f45/lib/Db/Item.php#L316-L318

Fixes #827