### PR TITLE
Fix 'news:updater:after-update' command

### DIFF
--- a/lib/Command/Updater/AfterUpdate.php
+++ b/lib/Command/Updater/AfterUpdate.php
@@ -44,7 +44,7 @@ class AfterUpdate extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $count = $input->getArgument('id');
+        $count = $input->getArgument('purge_count');
 
         echo $this->itemService->purgeOverThreshold($count);
 


### PR DESCRIPTION
The news:updater:after-update tries to load the wrong argument, hence it fails