### PR TITLE
Add file_from_env.php

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,8 +164,8 @@ appstore:
 	cp js/admin/Admin.js $(appstore_sign_dir)/$(app_name)/js/admin
 
 	# export the key and cert to a file
-	printf "%s" "$(app_private_key)" > "$(cert_dir)/$(app_name).key"
-	printf "%s" "$(app_public_crt)" > "$(cert_dir)/$(app_name).crt"
+	php ./bin/tools/file_from_env.php "app_private_key" "$(cert_dir)/$(app_name).key"
+	php ./bin/tools/file_from_env.php "app_public_crt" "$(cert_dir)/$(app_name).crt"
 
 	@if [ -f $(cert_dir)/$(app_name).key ]; then \
 		echo "Signing app files…"; \

--- a/bin/tools/file_from_env.php
+++ b/bin/tools/file_from_env.php
@@ -1,0 +1,24 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Nextcloud - News
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Benjamin Brahmer <info@b-brahmer.de>
+ * @copyright Benjamin Brahmer 2020
+*/
+
+if ($argc < 2) {
+    echo "This script expects two parameters:\n";
+    echo "./file_from_env.php ENV_VAR PATH_TO_FILE\n";
+    exit;
+}
+
+# Read environment variable
+$content = getenv($argv[1]);
+
+file_put_contents($argv[2], $content);
+
+echo "Done...\n";


### PR DESCRIPTION
To prevent the shell from reading the key/crt and doing interpretation :roll_eyes: I wrote a small php script.
It takes an environment variable name and a file path to write the content of that variable to that file. 