### PR TITLE
Automate release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -29,11 +29,11 @@ jobs:
           asset_name: ${{ env.APP_NAME }}.tar.gz 
           tag: ${{ github.ref }}
           overwrite: true
-#      - name: Upload app to Nextcloud appstore
-#        uses: R0Wi/nextcloud-appstore-push-action@v1
-#        with:
-#          app_name: ${{ env.APP_NAME }}
-#          appstore_token: ${{ secrets.APPSTORE_TOKEN }}
-#          download_url: ${{ steps.attach_to_release.outputs.browser_download_url }}
-#          app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
-#          nightly: ${{ github.event.release.prerelease }}
+     - name: Upload app to Nextcloud appstore
+       uses: R0Wi/nextcloud-appstore-push-action@v1
+       with:
+         app_name: ${{ env.APP_NAME }}
+         appstore_token: ${{ secrets.APPSTORE_TOKEN }}
+         download_url: ${{ steps.attach_to_release.outputs.browser_download_url }}
+         app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
+         nightly: ${{ github.event.release.prerelease }}

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ appstore:
 	cp js/admin/Admin.js $(appstore_sign_dir)/$(app_name)/js/admin
 
 	# export the key and cert to a file
+	mkdir -p $(cert_dir)
 	php ./bin/tools/file_from_env.php "app_private_key" "$(cert_dir)/$(app_name).key"
 	php ./bin/tools/file_from_env.php "app_public_crt" "$(cert_dir)/$(app_name).crt"
 


### PR DESCRIPTION
The last release failed due to the path was missing, where the key and cert are normally stored.

Also enabled the upload the app store and replaced the fake secrets, with the actual secrets.
I think we are almost there :)