### PR TITLE
update dependabot label config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     directory: "/js"
     schedule:
       interval: "daily"
-    default_labels:
+    labels:
       - "Skip-Changelog"
       - "javascript"
 
@@ -19,6 +19,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    default_labels:
+    labels:
       - "Skip-Changelog"
       - "php"


### PR DESCRIPTION
According to the [Dependabot docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#labels) the labels are configured slightly different. This also matches the error visible in the 'Insights'.

```
The property '#/updates/0/' contains additional properties ["default_labels"] outside of the schema when none are allowed
The property '#/updates/1/' contains additional properties ["default_labels"] outside of the schema when none are allowed
```