### PR TITLE
Return expected Value for Symfony Commands

### DIFF
--- a/lib/Command/Updater/AllFeeds.php
+++ b/lib/Command/Updater/AllFeeds.php
@@ -66,5 +66,6 @@ class AllFeeds extends Command
         }
 
         $output->write(json_encode($result));
+        return 0;
     }
 }


### PR DESCRIPTION
This fixes a bug when calling allfeeds by hand about not returning anything which makes the generated json unuusuable with errors appended to stdout.

TypeError: Return value of "OCA\News\Command\Updater\AllFeeds::execute()" must be of the type int, "null" returned. in apps/mail/vendor/symfony/console/Command/Command.php:261

Returning "no error/0" fixes it.