### PR TITLE
fix xDebug 3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,8 @@ ifeq (,$(composer))
 	composer:=php $(build_tools_directory)/composer.phar
 endif
 
+#Support xDebug 3.0+
+export XDEBUG_MODE=coverage
 
 all: build
 


### PR DESCRIPTION
xDebug which is used by phpunit to do code coverage tests, introduced some breaking change in 3.0 and requires this env-var to be set.
Shouldn't break anything for older versions