### PR TITLE
[draft] Introduce 'purgeUnread' config parameter

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -64,6 +64,7 @@ class Application extends App implements IBootstrap
         'useCronUpdates'           => true,
         'exploreUrl'               => '',
         'updateInterval'           => 3600,
+        'purgeUnread'              => false,
     ];
 
     public function __construct(array $urlParams = [])

--- a/lib/Service/ItemService.php
+++ b/lib/Service/ItemService.php
@@ -274,8 +274,10 @@ class ItemService extends Service
             'autoPurgeCount',
             Application::DEFAULT_SETTINGS['autoPurgeCount']
         );
+        $purgeUnread = $this->readConfigParam('purgeUnread');
+
         if ($count >= 0) {
-            $this->itemMapper->deleteReadOlderThanThreshold($count);
+            $this->itemMapper->deleteReadOlderThanThreshold($count, $purgeUnread);
         }
     }
 
@@ -341,5 +343,20 @@ class ItemService extends Service
     public function findAll(): array
     {
         return $this->mapper->findAll();
+    }
+
+
+    /**
+     * Read configuration parameter from DB or take its default value from
+     * application.
+     *
+     * @param string $name  Name of the configuration parameter.
+     */
+    private function readConfigParam($name) {
+        return $this->config->getAppValue(
+            Application::NAME,
+            $name,
+            Application::DEFAULT_SETTINGS[$name]
+        );
     }
 }


### PR DESCRIPTION
Define a new configuration parameter 'purgeUnread' to control whether unread
items can be purged.  Its default value is 'false'.

Extract a method counting items to be removed and introduce another one that
ignores if items are still unread.

Rearrange 'unread' and 'starred' columns in retrieval and removal queries to
make relevant condition optional with a smaller SQL rewrite.

TODO:
- provide GUI widget to adjust purgeUnread parameter;
- introduce and use 'maxItemAge' parameter;
- cover with tests.