### PR TITLE
compact mode: add background for hover and odd content entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- add background & hover for entries
 
 ### Fixed
 - Fix #985

--- a/css/content.css
+++ b/css/content.css
@@ -203,11 +203,11 @@
     background-image: linear-gradient(to right, orange 0, orange 2px, transparent 2px);
 }
 
-#app-content li.item:nth-child(odd) div.utils {
+#app-content .compact li.item:nth-child(odd) div.utils {
     background-color: var(--color-primary-light);
 }
 
-#app-content li.item div.utils:hover {
+#app-content .compact li.item div.utils:hover {
     background-color: var(--color-background-hover);
 }
 

--- a/css/content.css
+++ b/css/content.css
@@ -203,6 +203,14 @@
     background-image: linear-gradient(to right, orange 0, orange 2px, transparent 2px);
 }
 
+#app-content li.item:nth-child(odd) div.utils {
+    background-color: var(--color-primary-light);
+}
+
+#app-content li.item div.utils:hover {
+    background-color: var(--color-background-hover);
+}
+
 #app-content :not(.compact) .item {
 }
 


### PR DESCRIPTION
~~Unfortunately I was not able to test this only in my dev tools, since I wasn't able to set up a dev environment.~~ Got it working.

This adds a background color for uneven entries & a hover effect in compact mode.

Since this targets just the div, this does not interfere with the content when opened.

Pictures:

Basic list:
![list](https://user-images.githubusercontent.com/9399034/102722264-e9b15380-42f7-11eb-8853-a92a086da580.png)


Hover over blue entry: 
![hover_blue](https://user-images.githubusercontent.com/9399034/102722257-d900dd80-42f7-11eb-8740-20cef7445ee1.png)

Hover over white entry:
![hover_white](https://user-images.githubusercontent.com/9399034/102722262-e3bb7280-42f7-11eb-900d-7066320406e5.png)

Opened blue & hovered white entry:
![opened](https://user-images.githubusercontent.com/9399034/102722273-f8980600-42f7-11eb-93c4-058d1bfc13e4.png)

