### PR TITLE
update dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,8 @@ updates:
     schedule:
       interval: "daily"
     labels:
+      - "dependencies"
       - "Skip-Changelog"
-      - "javascript"
 
   # Maintain dependencies for Composer
   - package-ecosystem: "composer"
@@ -20,5 +20,5 @@ updates:
     schedule:
       interval: "daily"
     labels:
+      - "dependencies"
       - "Skip-Changelog"
-      - "php"


### PR DESCRIPTION
According to https://github.com/nextcloud/news/pull/998#issuecomment-749357923 the language specific labels where removed.