### PR TITLE
fix FeedMapper find exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+- Argument 2 passed to OCA\News\Db\FeedMapper::find() must be of the type int, string given #996
+
 ## 15.1.1-rc2
 
 ### Changed

--- a/lib/Db/FeedMapper.php
+++ b/lib/Db/FeedMapper.php
@@ -197,6 +197,6 @@ class FeedMapper extends NewsMapper
 
     public function findFromUser(string $userId, int $id): Entity
     {
-        return $this->find($id, $userId);
+        return $this->find($userId, $id);
     }
 }


### PR DESCRIPTION
`Exception: Argument 2 passed to OCA\News\Db\FeedMapper::find() must be of the type int, string given` (#996)

The called function arguments are switched.
https://github.com/nextcloud/news/blob/d542cf5376ca5869d19aa45849428354596d74d2/lib/Db/FeedMapper.php#L38

Got this error multiple times after updating my test instance to 15.1.1-rc2, but don't know what exactly caused this, since my main instance works fine.