### PR TITLE
Release 15.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), older entries don't fully match.
+
+## [Unreleased]
+
+## [15.1.1] - 2020-12-27
 
 ### Fixed
 - Argument 2 passed to OCA\News\Db\FeedMapper::find() must be of the type int, string given #996

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 Before you update to a new version, [check the changelog](https://github.com/nextcloud/news/blob/master/CHANGELOG.md) to avoid surprises.
 
 **Important**: To enable feed updates you will need to enable either [Nextcloud system cron](https://docs.nextcloud.org/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron) or use [an updater](https://github.com/nextcloud/news-updater) which uses the built in update API and disable cron updates. More information can be found [in the README](https://github.com/nextcloud/news).]]></description>
-    <version>15.1.1-rc2</version>
+    <version>15.1.1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>
@@ -22,6 +22,7 @@ Before you update to a new version, [check the changelog](https://github.com/nex
     </documentation>
     <category>multimedia</category>
     <website>https://github.com/nextcloud/news</website>
+    <discussion>https://github.com/nextcloud/news/discussions</discussion>
     <bugs>https://github.com/nextcloud/news/issues</bugs>
     <repository type="git">https://github.com/nextcloud/news.git</repository>
     <screenshot small-thumbnail="https://raw.githubusercontent.com/nextcloud/news/master/screenshots/1-small.png">https://raw.githubusercontent.com/nextcloud/news/master/screenshots/1.png</screenshot>


### PR DESCRIPTION
Fixed
- Argument 2 passed to OCA\News\Db\FeedMapper::find() must be of the type int, string given #996

Signed-off-by: Benjamin Brahmer <info@b-brahmer.de>