### PR TITLE
Improve whitespace in compact mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 - Remove outdated feed DB code
 - add background & hover for entries
+- Improve spacing of open articles in compact mode (nextcloud/news#1017)
 
 ## [15.1.1] - 2020-12-27
 

--- a/css/content.css
+++ b/css/content.css
@@ -529,7 +529,7 @@
     color: var(--color-text-lighter);
     font-size: 15px;
     max-width: 770px;
-    padding-bottom: 25px;
+    padding: 25px 0;
 }
 
 #app-content .subtitle a {

--- a/css/content.css
+++ b/css/content.css
@@ -239,6 +239,10 @@
     opacity: 0.9;
 }
 
+#app-content .compact .open .utils {
+    padding-top: 15px;
+}
+
 #app-content .utils ul {
     height: 40px;
     list-style-type: none;


### PR DESCRIPTION
Since introducing the zebra-striped headlines, the subtitle and utility bar spacing was noticably off. This commit fixes that.

Before:
![Screenshot before style changes](https://user-images.githubusercontent.com/525780/103455886-3bdb7700-4cf1-11eb-9e26-2b029971db68.png)

After:
![Screenshot after style changes](https://user-images.githubusercontent.com/525780/103455864-19e1f480-4cf1-11eb-9317-f8a15991eda2.png)
