### PR TITLE
remove deprecated colon prefix for parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 - add background & hover for entries
 - Improve spacing of open articles in compact mode (nextcloud/news#1017)
 
+### Fixed
+- `MissingNamedParameter` exception after upgrading to NC 21 beta5 (#1030)
+
 ## [15.1.1] - 2020-12-27
 
 ### Changed

--- a/lib/Db/FeedMapperV2.php
+++ b/lib/Db/FeedMapperV2.php
@@ -62,8 +62,8 @@ class FeedMapperV2 extends NewsMapperV2
                 ->where('feeds.user_id = :user_id')
                 ->andWhere('feeds.deleted_at = 0')
                 ->groupBy('feeds.id')
-                ->setParameter(':unread', true, IQueryBuilder::PARAM_BOOL)
-                ->setParameter(':user_id', $userId);
+                ->setParameter('unread', true, IQueryBuilder::PARAM_BOOL)
+                ->setParameter('user_id', $userId);
 
         return $this->findEntities($builder);
     }
@@ -86,8 +86,8 @@ class FeedMapperV2 extends NewsMapperV2
                 ->from(static::TABLE_NAME)
                 ->where('user_id = :user_id')
                 ->andWhere('id = :id')
-                ->setParameter(':user_id', $userId)
-                ->setParameter(':id', $id);
+                ->setParameter('user_id', $userId)
+                ->setParameter('id', $id);
 
         return $this->findEntity($builder);
     }
@@ -125,8 +125,8 @@ class FeedMapperV2 extends NewsMapperV2
                 ->from(static::TABLE_NAME)
                 ->where('user_id = :user_id')
                 ->andWhere('url = :url')
-                ->setParameter(':user_id', $userId)
-                ->setParameter(':url', $url);
+                ->setParameter('user_id', $userId)
+                ->setParameter('url', $url);
 
         return $this->findEntity($builder);
     }
@@ -148,7 +148,7 @@ class FeedMapperV2 extends NewsMapperV2
             $builder->where('folder_id IS NULL');
         } else {
             $builder->where('folder_id = :folder_id')
-                    ->setParameter(':folder_id', $id);
+                    ->setParameter('folder_id', $id);
         }
 
         return $this->findEntities($builder);

--- a/lib/Db/FolderMapperV2.php
+++ b/lib/Db/FolderMapperV2.php
@@ -52,7 +52,7 @@ class FolderMapperV2 extends NewsMapperV2
                 ->from($this->tableName)
                 ->where('user_id = :user_id')
                 ->andWhere('deleted_at = 0')
-                ->setParameter(':user_id', $userId);
+                ->setParameter('user_id', $userId);
 
         return $this->findEntities($builder);
     }
@@ -90,8 +90,8 @@ class FolderMapperV2 extends NewsMapperV2
             ->where('user_id = :user_id')
             ->andWhere('id = :id')
             ->andWhere('deleted_at = 0')
-            ->setParameter(':user_id', $userId)
-            ->setParameter(':id', $id);
+            ->setParameter('user_id', $userId)
+            ->setParameter('id', $id);
 
         return $this->findEntity($builder);
     }

--- a/lib/Db/ItemMapperV2.php
+++ b/lib/Db/ItemMapperV2.php
@@ -56,11 +56,11 @@ class ItemMapperV2 extends NewsMapperV2
                 ->innerJoin('items', FeedMapperV2::TABLE_NAME, 'feeds', 'items.feed_id = feeds.id')
                 ->where('feeds.user_id = :user_id')
                 ->andWhere('deleted_at = 0')
-                ->setParameter(':user_id', $userId, IQueryBuilder::PARAM_STR);
+                ->setParameter('user_id', $userId, IQueryBuilder::PARAM_STR);
 
         foreach ($params as $key => $value) {
             $builder->andWhere("${key} = :${key}")
-                    ->setParameter(":${key}", $value);
+                    ->setParameter($key, $value);
         }
 
         return $this->findEntities($builder);
@@ -90,8 +90,8 @@ class ItemMapperV2 extends NewsMapperV2
             ->where('feeds.user_id = :user_id')
             ->andWhere('items.id = :item_id')
             ->andWhere('deleted_at = 0')
-            ->setParameter(':user_id', $userId, IQueryBuilder::PARAM_STR)
-            ->setParameter(':item_id', $id, IQueryBuilder::PARAM_STR);
+            ->setParameter('user_id', $userId, IQueryBuilder::PARAM_STR)
+            ->setParameter('item_id', $id, IQueryBuilder::PARAM_STR);
 
         return $this->findEntity($builder);
     }
@@ -114,8 +114,8 @@ class ItemMapperV2 extends NewsMapperV2
             ->from($this->tableName)
             ->andWhere('feed_id = :feed_id')
             ->andWhere('guid_hash = :guid_hash')
-            ->setParameter(':feed_id', $feedId, IQueryBuilder::PARAM_INT)
-            ->setParameter(':guid_hash', $guidHash, IQueryBuilder::PARAM_STR);
+            ->setParameter('feed_id', $feedId, IQueryBuilder::PARAM_INT)
+            ->setParameter('guid_hash', $guidHash, IQueryBuilder::PARAM_STR);
 
         return $this->findEntity($builder);
     }
@@ -131,7 +131,7 @@ class ItemMapperV2 extends NewsMapperV2
         $builder->addSelect('*')
             ->from($this->tableName)
             ->andWhere('feed_id = :feed_id')
-            ->setParameter(':feed_id', $feedId, IQueryBuilder::PARAM_INT);
+            ->setParameter('feed_id', $feedId, IQueryBuilder::PARAM_INT);
 
         return $this->findEntities($builder);
     }

--- a/lib/Db/NewsMapperV2.php
+++ b/lib/Db/NewsMapperV2.php
@@ -86,12 +86,12 @@ abstract class NewsMapperV2 extends QBMapper
 
         if ($userID !== null) {
             $builder->andWhere('user_id = :user_id')
-                ->setParameter(':user_id', $userID);
+                ->setParameter('user_id', $userID);
         }
 
         if ($oldestDelete !== null) {
             $builder->andWhere('deleted_at < :deleted_at')
-                    ->setParameter(':deleted_at', $oldestDelete);
+                    ->setParameter('deleted_at', $oldestDelete);
         }
 
         $builder->execute();

--- a/tests/Unit/Db/FeedMapperTest.php
+++ b/tests/Unit/Db/FeedMapperTest.php
@@ -109,7 +109,7 @@ class FeedMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->exactly(2))
                       ->method('setParameter')
-                      ->withConsecutive([':unread', true], [':user_id', 'jack'])
+                      ->withConsecutive(['unread', true], ['user_id', 'jack'])
                       ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -159,7 +159,7 @@ class FeedMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->exactly(2))
                       ->method('setParameter')
-                      ->withConsecutive([':user_id', 'jack'], [':id', 1])
+                      ->withConsecutive(['user_id', 'jack'], ['id', 1])
                       ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -208,7 +208,7 @@ class FeedMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->exactly(2))
             ->method('setParameter')
-            ->withConsecutive([':user_id', 'jack'], [':id', 1])
+            ->withConsecutive(['user_id', 'jack'], ['id', 1])
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -256,7 +256,7 @@ class FeedMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->exactly(2))
             ->method('setParameter')
-            ->withConsecutive([':user_id', 'jack'], [':url', 'https://url.com'])
+            ->withConsecutive(['user_id', 'jack'], ['url', 'https://url.com'])
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -306,7 +306,7 @@ class FeedMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->exactly(2))
             ->method('setParameter')
-            ->withConsecutive([':user_id', 'jack'], [':id', 1])
+            ->withConsecutive(['user_id', 'jack'], ['id', 1])
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -390,7 +390,7 @@ class FeedMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->exactly(1))
             ->method('setParameter')
-            ->withConsecutive([':folder_id', 1])
+            ->withConsecutive(['folder_id', 1])
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())

--- a/tests/Unit/Db/FolderMapperTest.php
+++ b/tests/Unit/Db/FolderMapperTest.php
@@ -74,7 +74,7 @@ class FolderMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
                       ->method('setParameter')
-                      ->with(':user_id', 'jack')
+                      ->with('user_id', 'jack')
                       ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -124,7 +124,7 @@ class FolderMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->exactly(2))
                       ->method('setParameter')
-                      ->withConsecutive([':user_id', 'jack'], [':id', 1])
+                      ->withConsecutive(['user_id', 'jack'], ['id', 1])
                       ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -173,7 +173,7 @@ class FolderMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->exactly(2))
             ->method('setParameter')
-            ->withConsecutive([':user_id', 'jack'], [':id', 1])
+            ->withConsecutive(['user_id', 'jack'], ['id', 1])
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -222,7 +222,7 @@ class FolderMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->exactly(2))
             ->method('setParameter')
-            ->withConsecutive([':user_id', 'jack'], [':id', 1])
+            ->withConsecutive(['user_id', 'jack'], ['id', 1])
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())

--- a/tests/Unit/Db/NewsMapperTest.php
+++ b/tests/Unit/Db/NewsMapperTest.php
@@ -193,7 +193,7 @@ class NewsMapperTest extends TestCase
 
         $qb->expects($this->once())
             ->method('setParameter')
-            ->with(':user_id', 'jack')
+            ->with('user_id', 'jack')
             ->will($this->returnSelf());
 
         $qb->expects($this->once())
@@ -226,7 +226,7 @@ class NewsMapperTest extends TestCase
 
         $qb->expects($this->once())
             ->method('setParameter')
-            ->with(':deleted_at', 1)
+            ->with('deleted_at', 1)
             ->will($this->returnSelf());
 
         $qb->expects($this->once())
@@ -259,7 +259,7 @@ class NewsMapperTest extends TestCase
 
         $qb->expects($this->exactly(2))
             ->method('setParameter')
-            ->withConsecutive([':user_id', 'jack'], [':deleted_at', 1])
+            ->withConsecutive(['user_id', 'jack'], ['deleted_at', 1])
             ->will($this->returnSelf());
 
         $qb->expects($this->once())


### PR DESCRIPTION
With NC 21.0 beta5, the dbal dependency was updated from 2.12.0 to 3.0.0, and with it the (deprecated) support for the colon prefix for `->setParameter` has been removed.

- [Deprecation note](https://github.com/doctrine/dbal/blob/3.0.0/UPGRADE.md#deprecated-colon-prefix-for-prepared-statement-parameters)
- [Removal note](https://github.com/doctrine/dbal/blob/3.0.0/UPGRADE.md#bc-break-leading-colon-in-named-parameter-names-not-supported)

Fixes #1030