### PR TITLE
fix TypeError in ItemMapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 
 ### Fixed
 - opened state of folders is not restored (#1040)
+- Argument 3 passed to OCA\News\Db\ItemMapper::makeSelectQuery() must be of the type bool, array given (#1044)
 
 ## [15.2.0-beta1] - 2021-01-11
 

--- a/lib/Db/ItemMapper.php
+++ b/lib/Db/ItemMapper.php
@@ -281,7 +281,7 @@ class ItemMapper extends Mapper
                 $this->getOperator($oldestFirst) . ' ? ';
             $params[] = $offset;
         }
-        $sql = $this->makeSelectQuery($sql, $oldestFirst, $search);
+        $sql = $this->makeSelectQuery($sql, $oldestFirst);
         return $this->findEntitiesIgnoringNegativeLimit($sql, $params, $limit);
     }
 
@@ -308,7 +308,7 @@ class ItemMapper extends Mapper
             $sql .= 'AND `items`.`id` ' . $this->getOperator($oldestFirst) . ' ? ';
             $params[] = $offset;
         }
-        $sql = $this->makeSelectQuery($sql, $oldestFirst, $search);
+        $sql = $this->makeSelectQuery($sql, $oldestFirst);
         return $this->findEntitiesIgnoringNegativeLimit($sql, $params, $limit);
     }
 


### PR DESCRIPTION
`$search` is already handled by `buildSearchQueryPart()` and the third argument is actually a (unused) bool named `$distinctFingerprint`.

fixes #1044
refs #1022