### PR TITLE
fix TypeError caused by type conversion in ItemApiController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Fixed
 - opened state of folders is not restored (#1040)
 - Argument 3 passed to OCA\News\Db\ItemMapper::makeSelectQuery() must be of the type bool, array given (#1044)
+- Argument 2 passed to OCA\News\Db\ItemMapper::findAllNewFeed() must be of the type int, string given (#1049)
 
 ## [15.2.0-beta1] - 2021-01-11
 

--- a/lib/Controller/ItemApiController.php
+++ b/lib/Controller/ItemApiController.php
@@ -93,14 +93,14 @@ class ItemApiController extends ApiController
     {
         // needs to be turned into a millisecond timestamp to work properly
         if (strlen((string) $lastModified) <= 10) {
-            $paddedLastModified = $lastModified . '000000';
+            $paddedLastModified = $lastModified * 1000000;
         } else {
             $paddedLastModified = $lastModified;
         }
         $items = $this->oldItemService->findAllNew(
             $id,
             $type,
-            $paddedLastModified,
+            (int) $paddedLastModified,
             true,
             $this->getUserId()
         );

--- a/lib/Db/ItemMapper.php
+++ b/lib/Db/ItemMapper.php
@@ -225,7 +225,7 @@ class ItemMapper extends Mapper
         $sql = $this->buildStatusQueryPart($showAll);
 
         $folderWhere = is_null($id) ? 'IS' : '=';
-        $sql .= "AND `feeds`.`folder_id` ${$folderWhere} ? " .
+        $sql .= "AND `feeds`.`folder_id` ${folderWhere} ? " .
             'AND `items`.`last_modified` >= ? ';
         $sql = $this->makeSelectQuery($sql);
         $params = [$userId, $id, $updatedSince];

--- a/lib/Service/ItemService.php
+++ b/lib/Service/ItemService.php
@@ -73,7 +73,7 @@ class ItemService extends Service
      *
      * @return array of items
      */
-    public function findAllNew(?int $id, $type, $updatedSince, $showAll, $userId)
+    public function findAllNew(?int $id, $type, int $updatedSince, bool $showAll, string $userId)
     {
         switch ($type) {
             case FeedType::FEED:

--- a/tests/Unit/Controller/ItemApiControllerTest.php
+++ b/tests/Unit/Controller/ItemApiControllerTest.php
@@ -150,7 +150,7 @@ class ItemApiControllerTest extends TestCase
             ->with(
                 $this->equalTo(2),
                 $this->equalTo(1),
-                $this->equalTo('30000000'),
+                $this->equalTo(30000000),
                 $this->equalTo(true),
                 $this->equalTo($this->user->getUID())
             )


### PR DESCRIPTION
`$paddedLastModified` needs to be an int later on but was converted to string if shorter than 11 digits.

fixes #1049