### PR TITLE
add dependency checks for Github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,12 @@ updates:
     labels:
       - "dependencies"
       - "Skip-Changelog"
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "Skip-Changelog"


### PR DESCRIPTION
Checks for dependency updates for packages used in workflows (everything after the `uses:` tag).

However I am not sure if we should use the 'dependencies' label there, since it is only an internal dependency here on GH. 