### PR TITLE
Release 15.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
-- Item purger does not work with PostgreSQL (#1094)
 
+## [15.2.0] - 2021-02-02
+
+### Changed
+You can now delete unread items via occ:
+`occ news:updater:after-update --purge-unread [<purge-count>]`
+
+### Fixed
+- Item purger does not work with PostgreSQL (#1094)
 - Export starred/unread correctly (#1010)
 
 ## [15.2.0-rc1] - 2021-01-31

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 Before you update to a new version, [check the changelog](https://github.com/nextcloud/news/blob/master/CHANGELOG.md) to avoid surprises.
 
 **Important**: To enable feed updates you will need to enable either [Nextcloud system cron](https://docs.nextcloud.org/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron) or use [an updater](https://github.com/nextcloud/news-updater) which uses the built in update API and disable cron updates. More information can be found [in the README](https://github.com/nextcloud/news).]]></description>
-    <version>15.2.0-rc1</version>
+    <version>15.2.0</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
Changed
You can now delete unread items via occ:
`occ news:updater:after-update --purge-unread [<purge-count>]`

Fixed
- Item purger does not work with PostgreSQL (#1094)
- Export starred/unread correctly (#1010)

Signed-off-by: Benjamin Brahmer <info@b-brahmer.de>