### PR TITLE
don't copy symlinks into the release tar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ endif
 appstore:
 	rm -rf $(appstore_build_directory) $(appstore_sign_dir) $(appstore_artifact_directory)
 	mkdir -p $(appstore_sign_dir)/$(app_name)
-	cp -r \
+	rsync -rv \
 	"appinfo" \
 	"css" \
 	"img" \


### PR DESCRIPTION
As we think symlinks are not allowed anymore since NC 20.0.6 we drop the links in /bin

I checked with diff -r if there are any other symlinks, but those are the only links we have.