### PR TITLE
Release: create signature file (#1117)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -9,27 +9,50 @@ env:
 
 jobs:
   build_and_publish:
-    runs-on: ubuntu-latest
     environment: release
+    runs-on: ubuntu-latest
+    name: "Release: build, sign and upload the app"
+    strategy:
+      matrix:
+        php-versions: ['7.4']
+        nextcloud: ['v21.0.0beta6']
+        database: ['sqlite']
+        experimental: [false]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-          path: ${{ env.APP_NAME }}
-      - name: Run build
-        run: cd ${{ env.APP_NAME }} && make && make appstore
+          php-version: ${{ matrix.php-versions }}
+
+      - name: Set up server non MySQL
+        uses: SMillerDev/nextcloud-actions/setup-nextcloud@main
+        with:
+          cron: true
+          version: ${{ matrix.nextcloud }}
+          database-type: ${{ matrix.database }}
+
+      - name: Copy APP to the apps/ directory
+        run: cp -r ../${{ env.APP_NAME }} ../server/apps/
+
+      - name: build and create archive
+        run: cd ../server/apps/${{ env.APP_NAME }} && make && make appstore
         env:
           app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
           app_public_cert: ${{ secrets.APP_PUBLIC_CERT }}
+
       - name: Upload app tarball to release
         uses: svenstaro/upload-release-action@v2
         id: attach_to_release
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ env.APP_NAME }}/build/artifacts/appstore/${{ env.APP_NAME }}.tar.gz
-          asset_name: ${{ env.APP_NAME }}.tar.gz 
+          file: ../server/apps/${{ env.APP_NAME }}/build/artifacts/appstore/${{ env.APP_NAME }}.tar.gz
+          asset_name: ${{ env.APP_NAME }}.tar.gz
           tag: ${{ github.ref }}
           overwrite: true
+
       - name: Upload app to Nextcloud appstore
         uses: R0Wi/nextcloud-appstore-push-action@v1
         with:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['7.4']
-        nextcloud: ['v21.0.0beta6']
+        nextcloud: ['stable20']
         database: ['sqlite']
         experimental: [false]
     steps:
@@ -33,9 +33,6 @@ jobs:
           cron: true
           version: ${{ matrix.nextcloud }}
           database-type: ${{ matrix.database }}
-
-      - name: Copy APP to the apps/ directory
-        run: cp -r ../${{ env.APP_NAME }} ../server/apps/
 
       - name: build and create archive
         run: cd ../server/apps/${{ env.APP_NAME }} && make && make appstore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,10 @@ All notable changes to this project will be documented in this file.
 The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), older entries don't fully match.
 
 ## [Unreleased]
-
 ### Changed
 
 ### Fixed
-
+- Release: create signature file (#1117)
 ## [15.2.2] - 2021-02-02
 
 ### Fixed


### PR DESCRIPTION
The signature.json file was not created, which is very obvious but we missed that when we introduced the automation.

This uses the Nextcloud action we already used to clone the server, set it up, copy the news app into the server, build and sign it.
Example: https://github.com/Grotax/news/releases/tag/15.2.13
appinfo/signature.json

Related
https://github.com/nextcloud/documentation/pull/6001
#1117