### PR TITLE
Fix id sorting bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 
 ### Fixed
 - Item list throwing error for folder and "all items"
+- Articles with high IDs can be placed lower than articles with low IDs (#1147)
 
 ## [15.3.2] - 2021-02-10
 No changes compared to RC2

--- a/js/tests/unit/controller/ContentControllerSpec.js
+++ b/js/tests/unit/controller/ContentControllerSpec.js
@@ -64,27 +64,19 @@ describe('ContentController', function () {
     }));
 
 
-    it('should return order by',
-        inject(function ($controller, SettingsResource, FEED_TYPE) {
-            var route = {
-                current: {
-                    $$route: {
-                        type: FEED_TYPE.FOLDER
-                    }
-                }
-            };
+    it('should sort feed items', inject(function ($controller) {
+        var ctrl = $controller('ContentController', {
+            data: {}
+        });
+        var first = {value: 11, type: 'number'};
+        var second = {value: 12, type: 'number'};
+        var third = {value: 101, type: 'number'};
+        expect(ctrl.sortIds(first, second)).toBe(1);
+        expect(ctrl.sortIds(second, first)).toBe(-1);
+        expect(ctrl.sortIds(second, second)).toBe(-1);
+        expect(ctrl.sortIds(first, third)).toBe(1);
+    }));
 
-            var ctrl = $controller('ContentController', {
-                data: {},
-                $route: route
-            });
-
-            expect(ctrl.orderBy()).toBe('-id');
-
-            SettingsResource.set('oldestFirst', true);
-
-            expect(ctrl.orderBy()).toBe('id');
-        }));
 
     it('should return order if custom ordering',
         inject(function ($controller, SettingsResource, FeedResource,
@@ -107,11 +99,11 @@ describe('ContentController', function () {
                 }
             });
 
-            expect(ctrl.orderBy()).toBe('id');
+            expect(ctrl.oldestFirst).toBe(true);
 
-            SettingsResource.set('oldestFirst', true);
+            SettingsResource.set('oldestFirst', false);
 
-            expect(ctrl.orderBy()).toBe('id');
+            expect(ctrl.oldestFirst).toBe(true);
         }));
 
 

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -19,7 +19,7 @@
     <ul>
         <li class="item {{ ::Content.getFeed(item.feedId).cssClass }}"
             ng-repeat="item in Content.getItems() |
-                orderBy:[Content.orderBy()] track by item.id"
+                orderBy:'id':Content.oldestFirst:Content.sortIds track by item.id"
             ng-mouseup="Content.markRead(item.id)"
             ng-click="Content.markRead(item.id); Content.setItemActive(item.id)"
             news-on-active="Content.setItemActive(item.id)"


### PR DESCRIPTION
fixes #1147 

Rather than using Angular's built-in comparison on the `id` field, we need to parse them as integers first. Otherwise, they get compared alphabetically, and the sorted order can end up like 1, 101, 2, 3, etc. (1 comes before 2, and
the comparison stops there.)