### PR TITLE
remove unused lastModified from feed fetcher

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3358,7 +3358,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -3417,7 +3417,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
             },
             "funding": [
                 {

--- a/lib/Command/ShowFeed.php
+++ b/lib/Command/ShowFeed.php
@@ -70,7 +70,7 @@ class ShowFeed extends Command
         $fullTextEnabled = (bool) $input->getOption('full-text');
 
         try {
-            list($feed, $items) = $this->feedFetcher->fetch($url, null, $fullTextEnabled, $user, $password);
+            list($feed, $items) = $this->feedFetcher->fetch($url, $fullTextEnabled, $user, $password);
         } catch (\Exception $ex) {
             $output->writeln('<error>Failed to fetch feed info:</error>');
             $output->writeln($ex->getMessage());

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -107,7 +107,6 @@ class FeedFetcher implements IFeedFetcher
      */
     public function fetch(
         string $url,
-        ?string $lastModified,
         bool $fullTextEnabled,
         ?string $user,
         ?string $password

--- a/lib/Fetcher/Fetcher.php
+++ b/lib/Fetcher/Fetcher.php
@@ -44,8 +44,6 @@ class Fetcher
      * Fetch a feed from remote
      *
      * @param  string      $url               remote url of the feed
-     * @param  string|null $lastModified      a last modified value from an http header defaults to false.
-     *                                    If lastModified matches the http header from the feed no results are fetched
      * @param  bool        $fullTextEnabled   If true use a scraper to download the full article
      * @param  string|null $user              if given, basic auth is set for this feed
      * @param  string|null $password          if given, basic auth is set for this feed. Ignored if user is empty
@@ -56,7 +54,6 @@ class Fetcher
      */
     public function fetch(
         string $url,
-        ?string $lastModified = null,
         bool $fullTextEnabled = false,
         ?string $user = null,
         ?string $password = null
@@ -67,7 +64,6 @@ class Fetcher
             }
             return $fetcher->fetch(
                 $url,
-                $lastModified,
                 $fullTextEnabled,
                 $user,
                 $password

--- a/lib/Fetcher/IFeedFetcher.php
+++ b/lib/Fetcher/IFeedFetcher.php
@@ -24,9 +24,7 @@ interface IFeedFetcher
      * Fetch feed content.
      *
      * @param  string      $url           remote url of the feed
-     * @param  string|null $lastModified  a last modified value from an http header defaults to false.
-     *                                    If lastModified matches the http header from the feed no results are fetched
-     * @param  bool      $fullTextEnabled If true use a scraper to download the full article
+     * @param  bool        $fullTextEnabled If true use a scraper to download the full article
      * @param  string|null $user          if given, basic auth is set for this feed
      * @param  string|null $password      if given, basic auth is set for this feed. Ignored if user is empty
      *
@@ -37,7 +35,6 @@ interface IFeedFetcher
      */
     public function fetch(
         string $url,
-        ?string $lastModified,
         bool $fullTextEnabled,
         ?string $user,
         ?string $password

--- a/lib/Service/FeedServiceV2.php
+++ b/lib/Service/FeedServiceV2.php
@@ -258,7 +258,6 @@ class FeedServiceV2 extends Service
              */
             list($fetchedFeed, $items) = $this->feedFetcher->fetch(
                 $location,
-                $feed->getHttpLastModified(),
                 $feed->getFullTextEnabled(),
                 $feed->getBasicAuthUser(),
                 $feed->getBasicAuthPassword()

--- a/tests/Unit/Command/ShowFeedTest.php
+++ b/tests/Unit/Command/ShowFeedTest.php
@@ -72,7 +72,7 @@ class ShowFeedTest extends TestCase
 
         $this->fetcher->expects($this->exactly(1))
                            ->method('fetch')
-                           ->with('feed', null, true, 'user', 'user')
+                           ->with('feed', true, 'user', 'user')
                            ->willReturn([['feed'], [['items']]]);
 
         $this->consoleOutput->expects($this->exactly(2))
@@ -106,7 +106,7 @@ class ShowFeedTest extends TestCase
 
         $this->fetcher->expects($this->exactly(1))
                            ->method('fetch')
-                           ->with('feed', null, true, 'user', 'user')
+                           ->with('feed', true, 'user', 'user')
                            ->will($this->throwException(new ServiceNotFoundException('test')));
 
         $this->consoleOutput->expects($this->exactly(2))

--- a/tests/Unit/Fetcher/FeedFetcherTest.php
+++ b/tests/Unit/Fetcher/FeedFetcherTest.php
@@ -310,7 +310,7 @@ class FeedFetcherTest extends TestCase
         $item = $this->createItem();
         $feed = $this->createFeed();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        $result = $this->fetcher->fetch($this->url, '@1553118393', false, null, null);
+        $result = $this->fetcher->fetch($this->url, false, null, null);
 
         $this->assertEquals([$feed, [$item]], $result);
     }
@@ -326,7 +326,6 @@ class FeedFetcherTest extends TestCase
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
         $result = $this->fetcher->fetch(
             $this->url,
-            '@1553118393',
             false,
             'account@email.com',
             'F9sEU*Rt%:KFK8HMHT&'
@@ -344,7 +343,7 @@ class FeedFetcherTest extends TestCase
         $item = $this->createItem('audio/ogg');
         $feed = $this->createFeed();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        $result = $this->fetcher->fetch($this->url, '@1553118393', false, null, null);
+        $result = $this->fetcher->fetch($this->url, false, null, null);
 
         $this->assertEquals([$feed, [$item]], $result);
     }
@@ -358,7 +357,7 @@ class FeedFetcherTest extends TestCase
         $item = $this->createItem('video/ogg');
         $feed = $this->createFeed();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        $result = $this->fetcher->fetch($this->url, '@1553118393', false, null, null);
+        $result = $this->fetcher->fetch($this->url, false, null, null);
 
         $this->assertEquals([$feed, [$item]], $result);
     }
@@ -373,7 +372,7 @@ class FeedFetcherTest extends TestCase
         $feed = $this->createFeed('de-DE');
         $item = $this->createItem();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        $result = $this->fetcher->fetch($this->url, '@1553118393', false, null, null);
+        $result = $this->fetcher->fetch($this->url, false, null, null);
 
         $this->assertEquals([$feed, [$item]], $result);
     }
@@ -387,7 +386,7 @@ class FeedFetcherTest extends TestCase
         $this->createFeed('he-IL');
         $this->createItem();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        list($_, $items) = $this->fetcher->fetch($this->url, '@1553118393', false, null, null);
+        list($_, $items) = $this->fetcher->fetch($this->url, false, null, null);
         $this->assertTrue($items[0]->getRtl());
     }
 
@@ -413,7 +412,7 @@ class FeedFetcherTest extends TestCase
 
 
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        list($feed, $items) = $this->fetcher->fetch($this->url, '@1553118393', false, null, null);
+        list($feed, $items) = $this->fetcher->fetch($this->url, false, null, null);
         $this->assertSame($items[0]->getPubDate(), 1522180229);
     }
 
@@ -439,7 +438,7 @@ class FeedFetcherTest extends TestCase
 
 
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        list($feed, $items) = $this->fetcher->fetch($this->url, '@1553118393', false, null, null);
+        list($feed, $items) = $this->fetcher->fetch($this->url, false, null, null);
         $this->assertSame($items[0]->getPubDate(), 1519761029);
     }
 

--- a/tests/Unit/Fetcher/FetcherTest.php
+++ b/tests/Unit/Fetcher/FetcherTest.php
@@ -54,14 +54,13 @@ class FetcherTest extends TestCase
             ->method('fetch')
             ->with(
                 $this->equalTo($url),
-                $this->equalTo(true),
                 $this->equalTo(1),
                 $this->equalTo(2),
                 $this->equalTo(3)
             );
         $this->fetcher->registerFetcher($mockFetcher);
 
-        $this->fetcher->fetch($url, true, 1, 2, 3);
+        $this->fetcher->fetch($url, 1, 2, 3);
     }
 
 


### PR DESCRIPTION
This removes lastModified from the Fetcher as it is no longer used since 42ea24f2f41ce04588aa929e5ffdaf1dbeb1a700

The original idea of lastModified was to reduce the amount of data news pulls from servers by checking the http header but that turned out to skip certain items in feeds ...

ref #975