### PR TITLE
remove stable20 from psalm run

### DIFF
--- a/.github/workflows/api-php-static-code-check.yml
+++ b/.github/workflows/api-php-static-code-check.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         php-versions: [ '7.4' ]
-        nextcloud: [ 'stable20', 'stable21' ]
+        nextcloud: [ 'stable21' ]
         database: [ 'sqlite' ]
     name: "Psalm: Nextcloud ${{ matrix.nextcloud }}"
     steps:


### PR DESCRIPTION
This removes the psalm run for stable20 as it crashes for some reason.

I also think if we want to support multiple versions of NC to detect comparability issues with psalm, we need to run the install of christophwurst/nextcloud dynamically, that was dropped in #1125