### PR TITLE
FeedFetcher: Use feeds logo instead of the favicon

### DIFF
--- a/.github/workflows/api-integration-tests.yml
+++ b/.github/workflows/api-integration-tests.yml
@@ -127,6 +127,7 @@ jobs:
         run: |
           ./occ news:feed:add 'admin' "https://nextcloud.com/blog/feed/"
           ./occ news:feed:list 'admin' | grep 'nextcloud\.com'
+          ./occ news:feed:list 'admin' | grep -F '"faviconLink": "https:\/\/nextcloud.com\/media\/screenshot-150x150.png"'
 
       - name: Functional tests opml
         working-directory: ../server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 - Remove outdated item DB code.
 - Stop returning all feeds after marking folder as read.
+- Always fetch favicon (#1164)
+- Use feed logo instead of favicon if it exists and is square
 
 ### Fixed
 

--- a/lib/Command/ShowFeed.php
+++ b/lib/Command/ShowFeed.php
@@ -70,7 +70,7 @@ class ShowFeed extends Command
         $fullTextEnabled = (bool) $input->getOption('full-text');
 
         try {
-            list($feed, $items) = $this->feedFetcher->fetch($url, true, null, $fullTextEnabled, $user, $password);
+            list($feed, $items) = $this->feedFetcher->fetch($url, null, $fullTextEnabled, $user, $password);
         } catch (\Exception $ex) {
             $output->writeln('<error>Failed to fetch feed info:</error>');
             $output->writeln($ex->getMessage());

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -21,6 +21,7 @@ use FeedIo\FeedIo;
 
 use Net_URL2;
 use OCP\IL10N;
+use OCP\ITempManager;
 
 use OCA\News\Db\Item;
 use OCA\News\Db\Feed;
@@ -53,6 +54,11 @@ class FeedFetcher implements IFeedFetcher
     private $l10n;
 
     /**
+     * @var ITempManager
+     */
+    private $ITempManager;
+
+    /**
      * @var Time
      */
     private $time;
@@ -67,6 +73,7 @@ class FeedFetcher implements IFeedFetcher
         Favicon $favicon,
         Scraper $scraper,
         IL10N $l10n,
+        ITempManager $ITempManager,
         Time $time,
         LoggerInterface $logger
     ) {
@@ -74,6 +81,7 @@ class FeedFetcher implements IFeedFetcher
         $this->faviconFactory = $favicon;
         $this->scraper        = $scraper;
         $this->l10n           = $l10n;
+        $this->ITempManager   = $ITempManager;
         $this->time           = $time;
         $this->logger         = $logger;
     }
@@ -99,7 +107,6 @@ class FeedFetcher implements IFeedFetcher
      */
     public function fetch(
         string $url,
-        bool $favicon,
         ?string $lastModified,
         bool $fullTextEnabled,
         ?string $user,
@@ -118,17 +125,19 @@ class FeedFetcher implements IFeedFetcher
         $feed = $this->buildFeed(
             $parsedFeed,
             $url,
-            $favicon,
             $location
         );
 
         $items = [];
         $RTL = $this->determineRtl($parsedFeed);
         $feedName = $parsedFeed->getTitle();
-        $this->logger->debug('Feed {url} was modified since last fetch. #{count} items', [
+        $this->logger->debug(
+            'Feed {url} was modified since last fetch. #{count} items',
+            [
             'url'   => $url,
             'count' => count($parsedFeed),
-        ]);
+            ]
+        );
 
         foreach ($parsedFeed as $item) {
             $body = null;
@@ -144,11 +153,14 @@ class FeedFetcher implements IFeedFetcher
             }
 
             $builtItem = $this->buildItem($item, $body, $currRTL);
-            $this->logger->debug('Added item {title} for feed {feed} publishdate: {datetime}', [
+            $this->logger->debug(
+                'Added item {title} for feed {feed} lastmodified: {datetime}',
+                [
                 'title' => $builtItem->getTitle(),
                 'feed'  => $feedName,
                 'datetime'  => $builtItem->getLastModified(),
-            ]);
+                ]
+            );
             $items[] = $builtItem;
         }
 
@@ -295,16 +307,54 @@ class FeedFetcher implements IFeedFetcher
     }
 
     /**
+     * Return the favicon for a given feed and url
+     *
+     * @param FeedInterface $feed     Feed to check for a logo
+     * @param string        $url      Original URL for the feed
+     *
+     * @return string|mixed|bool
+     */
+    protected function getFavicon(FeedInterface $feed, string $url)
+    {
+        $favicon = $feed->getLogo();
+
+        // check if feed has a logo
+        if (is_null($favicon)) {
+            return $this->faviconFactory->get($url);
+        }
+
+        $favicon_path = join("/", [$this->ITempManager->getTempBaseDir(), basename($favicon)]);
+        copy(
+            $favicon,
+            $favicon_path
+        );
+
+        $is_image = substr(mime_content_type($favicon_path), 0, 5) === "image";
+
+        // check if file is actually an image
+        if (!$is_image) {
+            return $this->faviconFactory->get($url);
+        }
+
+        list($width, $height, $type, $attr) = getimagesize($favicon_path);
+        // check if image is square else fall back to favicon
+        if ($width !== $height) {
+            return $this->faviconFactory->get($url);
+        }
+
+        return $favicon;
+    }
+
+    /**
      * Build a feed based on provided info
      *
-     * @param FeedInterface $feed       Feed to build from
-     * @param string        $url        URL to use
-     * @param boolean       $getFavicon To get the favicon
-     * @param string        $location   String base URL
+     * @param FeedInterface $feed     Feed to build from
+     * @param string        $url      URL to use
+     * @param string        $location String base URL
      *
      * @return Feed
      */
-    protected function buildFeed(FeedInterface $feed, string $url, bool $getFavicon, string $location): Feed
+    protected function buildFeed(FeedInterface $feed, string $url, string $location): Feed
     {
         $newFeed = new Feed();
 
@@ -321,10 +371,9 @@ class FeedFetcher implements IFeedFetcher
         }
         $newFeed->setAdded($this->time->getTime());
 
-        if (!$getFavicon) {
-            return $newFeed;
-        }
-        $favicon = $this->faviconFactory->get($url);
+
+
+        $favicon = $this->getFavicon($feed, $url);
         $newFeed->setFaviconLink($favicon);
 
         return $newFeed;

--- a/lib/Fetcher/Fetcher.php
+++ b/lib/Fetcher/Fetcher.php
@@ -44,7 +44,6 @@ class Fetcher
      * Fetch a feed from remote
      *
      * @param  string      $url               remote url of the feed
-     * @param  boolean     $getFavicon        if the favicon should also be fetched, defaults to true
      * @param  string|null $lastModified      a last modified value from an http header defaults to false.
      *                                    If lastModified matches the http header from the feed no results are fetched
      * @param  bool        $fullTextEnabled   If true use a scraper to download the full article
@@ -57,7 +56,6 @@ class Fetcher
      */
     public function fetch(
         string $url,
-        bool $getFavicon = true,
         ?string $lastModified = null,
         bool $fullTextEnabled = false,
         ?string $user = null,
@@ -69,7 +67,6 @@ class Fetcher
             }
             return $fetcher->fetch(
                 $url,
-                $getFavicon,
                 $lastModified,
                 $fullTextEnabled,
                 $user,

--- a/lib/Fetcher/IFeedFetcher.php
+++ b/lib/Fetcher/IFeedFetcher.php
@@ -24,7 +24,6 @@ interface IFeedFetcher
      * Fetch feed content.
      *
      * @param  string      $url           remote url of the feed
-     * @param  boolean     $favicon       if the favicon should also be fetched, defaults to true
      * @param  string|null $lastModified  a last modified value from an http header defaults to false.
      *                                    If lastModified matches the http header from the feed no results are fetched
      * @param  bool      $fullTextEnabled If true use a scraper to download the full article
@@ -38,7 +37,6 @@ interface IFeedFetcher
      */
     public function fetch(
         string $url,
-        bool $favicon,
         ?string $lastModified,
         bool $fullTextEnabled,
         ?string $user,

--- a/lib/Service/FeedServiceV2.php
+++ b/lib/Service/FeedServiceV2.php
@@ -258,7 +258,6 @@ class FeedServiceV2 extends Service
              */
             list($fetchedFeed, $items) = $this->feedFetcher->fetch(
                 $location,
-                false,
                 $feed->getHttpLastModified(),
                 $feed->getFullTextEnabled(),
                 $feed->getBasicAuthUser(),

--- a/tests/Unit/Command/ShowFeedTest.php
+++ b/tests/Unit/Command/ShowFeedTest.php
@@ -72,7 +72,7 @@ class ShowFeedTest extends TestCase
 
         $this->fetcher->expects($this->exactly(1))
                            ->method('fetch')
-                           ->with('feed', true, null, true, 'user', 'user')
+                           ->with('feed', null, true, 'user', 'user')
                            ->willReturn([['feed'], [['items']]]);
 
         $this->consoleOutput->expects($this->exactly(2))
@@ -106,7 +106,7 @@ class ShowFeedTest extends TestCase
 
         $this->fetcher->expects($this->exactly(1))
                            ->method('fetch')
-                           ->with('feed', true, null, true, 'user', 'user')
+                           ->with('feed', null, true, 'user', 'user')
                            ->will($this->throwException(new ServiceNotFoundException('test')));
 
         $this->consoleOutput->expects($this->exactly(2))


### PR DESCRIPTION
This changes the behavior of fetching the favicon, since feed-io offers to get the feeds logo, we try to get that first, then fall back to the favicon.

I didn't change the var name, I'm not sure if we should do that. But that would include API changes if I'm not wrong.

Also I want to test this first.