### PR TITLE
Actions: force enable app on pre-release versions

### DIFF
--- a/.github/workflows/api-integration-tests.yml
+++ b/.github/workflows/api-integration-tests.yml
@@ -101,6 +101,7 @@ jobs:
         with:
           app: 'news'
           check-code: true
+          force: ${{ matrix.experimental }}
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"


### PR DESCRIPTION
This enforces the enabling of news on pre-release (aka master) versions of nextcloud.

Which allows us to test on NC22 while we don't mark news as compatible to NC22.
We had the issue in the past that we would already enable the app for the next version of nextcloud to be able to test it, but meanwhile we would release another patch to the app store, including the enabling of NC22 for example.

Working with branches would be an alternative but I think this makes more sense for us.