### PR TITLE
update sorting column

### DIFF
--- a/lib/Db/ItemMapperV2.php
+++ b/lib/Db/ItemMapperV2.php
@@ -286,7 +286,7 @@ class ItemMapperV2 extends NewsMapperV2
                 ->innerJoin('items', FeedMapperV2::TABLE_NAME, 'feeds', 'items.feed_id = feeds.id')
                 ->where('feeds.user_id = :userId')
                 ->setParameter('userId', $userId)
-                ->orderBy('items.updated_date', 'DESC')
+                ->orderBy('items.last_modified', 'DESC')
                 ->addOrderBy('items.id', 'DESC')
                 ->setMaxResults(1);
 
@@ -312,7 +312,7 @@ class ItemMapperV2 extends NewsMapperV2
         $builder->select('items.*')
             ->from($this->tableName, 'items')
             ->innerJoin('items', FeedMapperV2::TABLE_NAME, 'feeds', 'items.feed_id = feeds.id')
-            ->andWhere('items.updated_date >= :updatedSince')
+            ->andWhere('items.last_modified >= :updatedSince')
             ->andWhere('feeds.user_id = :userId')
             ->andWhere('feeds.id = :feedId')
             ->setParameters([
@@ -320,7 +320,7 @@ class ItemMapperV2 extends NewsMapperV2
                 'feedId' => $feedId,
                 'userId'=> $userId,
             ])
-            ->orderBy('items.updated_date', 'DESC')
+            ->orderBy('items.last_modified', 'DESC')
             ->addOrderBy('items.id', 'DESC');
 
         if ($hideRead === true) {
@@ -350,11 +350,11 @@ class ItemMapperV2 extends NewsMapperV2
             ->from($this->tableName, 'items')
             ->innerJoin('items', FeedMapperV2::TABLE_NAME, 'feeds', 'items.feed_id = feeds.id')
             ->innerJoin('feeds', FolderMapperV2::TABLE_NAME, 'folders', 'feeds.folder_id = folders.id')
-            ->andWhere('items.updated_date >= :updatedSince')
+            ->andWhere('items.last_modified >= :updatedSince')
             ->andWhere('feeds.user_id = :userId')
             ->andWhere('folders.id = :folderId')
             ->setParameters(['updatedSince' => $updatedSince, 'folderId' => $folderId, 'userId' => $userId])
-            ->orderBy('items.updated_date', 'DESC')
+            ->orderBy('items.last_modified', 'DESC')
             ->addOrderBy('items.id', 'DESC');
 
         if ($hideRead === true) {
@@ -379,10 +379,10 @@ class ItemMapperV2 extends NewsMapperV2
         $builder->select('items.*')
             ->from($this->tableName, 'items')
             ->innerJoin('items', FeedMapperV2::TABLE_NAME, 'feeds', 'items.feed_id = feeds.id')
-            ->andWhere('items.updated_date >= :updatedSince')
+            ->andWhere('items.last_modified >= :updatedSince')
             ->andWhere('feeds.user_id = :userId')
             ->setParameters(['updatedSince' => $updatedSince, 'userId' => $userId])
-            ->orderBy('items.updated_date', 'DESC')
+            ->orderBy('items.last_modified', 'DESC')
             ->addOrderBy('items.id', 'DESC');
 
         switch ($feedType) {
@@ -430,7 +430,7 @@ class ItemMapperV2 extends NewsMapperV2
             ->setParameter('feedId', $feedId)
             ->setMaxResults($limit)
             ->setFirstResult($offset)
-            ->orderBy('items.updated_date', ($oldestFirst ? 'ASC' : 'DESC'))
+            ->orderBy('items.last_modified', ($oldestFirst ? 'ASC' : 'DESC'))
             ->addOrderBy('items.id', ($oldestFirst ? 'ASC' : 'DESC'));
 
         if ($search !== []) {
@@ -484,7 +484,7 @@ class ItemMapperV2 extends NewsMapperV2
             ->setParameter('userId', $userId)
             ->setMaxResults($limit)
             ->setFirstResult($offset)
-            ->orderBy('items.updated_date', ($oldestFirst ? 'ASC' : 'DESC'))
+            ->orderBy('items.last_modified', ($oldestFirst ? 'ASC' : 'DESC'))
             ->addOrderBy('items.id', ($oldestFirst ? 'ASC' : 'DESC'));
 
         if ($search !== []) {
@@ -530,7 +530,7 @@ class ItemMapperV2 extends NewsMapperV2
             ->setParameter('userId', $userId)
             ->setMaxResults($limit)
             ->setFirstResult($offset)
-            ->orderBy('items.updated_date', ($oldestFirst ? 'ASC' : 'DESC'))
+            ->orderBy('items.last_modified', ($oldestFirst ? 'ASC' : 'DESC'))
             ->addOrderBy('items.id', ($oldestFirst ? 'ASC' : 'DESC'));
 
         if ($search !== []) {

--- a/tests/Unit/Db/ItemMapperTest.php
+++ b/tests/Unit/Db/ItemMapperTest.php
@@ -431,7 +431,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'DESC')
+            ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -493,7 +493,7 @@ class ItemMapperTest extends MapperTestUtility
         $this->builder->expects($this->exactly(3))
             ->method('andWhere')
             ->withConsecutive(
-                ['items.updated_date >= :updatedSince'],
+                ['items.last_modified >= :updatedSince'],
                 ['feeds.user_id = :userId'],
                 ['feeds.id = :feedId']
             )
@@ -510,7 +510,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'DESC')
+            ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -557,7 +557,7 @@ class ItemMapperTest extends MapperTestUtility
         $this->builder->expects($this->exactly(4))
             ->method('andWhere')
             ->withConsecutive(
-                ['items.updated_date >= :updatedSince'],
+                ['items.last_modified >= :updatedSince'],
                 ['feeds.user_id = :userId'],
                 ['feeds.id = :feedId'],
                 ['items.unread = 1']
@@ -575,7 +575,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'DESC')
+            ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -625,7 +625,7 @@ class ItemMapperTest extends MapperTestUtility
         $this->builder->expects($this->exactly(3))
             ->method('andWhere')
             ->withConsecutive(
-                ['items.updated_date >= :updatedSince'],
+                ['items.last_modified >= :updatedSince'],
                 ['feeds.user_id = :userId'],
                 ['folders.id = :folderId']
             )
@@ -642,7 +642,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'DESC')
+            ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -692,7 +692,7 @@ class ItemMapperTest extends MapperTestUtility
         $this->builder->expects($this->exactly(4))
             ->method('andWhere')
             ->withConsecutive(
-                ['items.updated_date >= :updatedSince'],
+                ['items.last_modified >= :updatedSince'],
                 ['feeds.user_id = :userId'],
                 ['folders.id = :folderId'],
                 ['items.unread = 1']
@@ -710,7 +710,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'DESC')
+            ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -757,7 +757,7 @@ class ItemMapperTest extends MapperTestUtility
         $this->builder->expects($this->exactly(3))
             ->method('andWhere')
             ->withConsecutive(
-                ['items.updated_date >= :updatedSince'],
+                ['items.last_modified >= :updatedSince'],
                 ['feeds.user_id = :userId'],
                 ['items.unread = 1']
             )
@@ -773,7 +773,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'DESC')
+            ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -820,7 +820,7 @@ class ItemMapperTest extends MapperTestUtility
         $this->builder->expects($this->exactly(3))
             ->method('andWhere')
             ->withConsecutive(
-                ['items.updated_date >= :updatedSince'],
+                ['items.last_modified >= :updatedSince'],
                 ['feeds.user_id = :userId'],
                 ['items.starred = 1']
             )
@@ -836,7 +836,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'DESC')
+            ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -886,7 +886,7 @@ class ItemMapperTest extends MapperTestUtility
         $this->builder->expects($this->exactly(2))
             ->method('andWhere')
             ->withConsecutive(
-                ['items.updated_date >= :updatedSince'],
+                ['items.last_modified >= :updatedSince'],
                 ['feeds.user_id = :userId']
             )
             ->will($this->returnSelf());
@@ -901,7 +901,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'DESC')
+            ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -974,7 +974,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'DESC')
+            ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -1044,7 +1044,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'DESC')
+            ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -1115,7 +1115,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'DESC')
+            ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -1191,7 +1191,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'DESC')
+            ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -1262,7 +1262,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'DESC')
+            ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -1334,7 +1334,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'DESC')
+            ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -1410,7 +1410,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'DESC')
+            ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -1493,7 +1493,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'DESC')
+            ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -1577,7 +1577,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'DESC')
+            ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -1661,7 +1661,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'ASC')
+            ->with('items.last_modified', 'ASC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -1749,7 +1749,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('orderBy')
-            ->with('items.updated_date', 'DESC')
+            ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())


### PR DESCRIPTION
Follow-up for b4fa772bc5f23f84fc292f5d6bf884543d2bfe51 because of the `updated_date` which was removed in the meantime.

It will require a corrected `last_modified` value for the items before the next release..