### PR TITLE
Release 15.4.0-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,22 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 ## [Unreleased]
 
 ### Changed
-- Remove outdated item DB code.
-- Stop returning all feeds after marking folder as read.
-- Always fetch favicon (#1164)
-- Use feed logo instead of favicon if it exists and is square
-- Add CI for item lists
 
 ### Fixed
-- Item list throwing error for folder and "all items"
+
+## [15.4.0-beta1] - 2021-02-23
+### Changed
+- Remove outdated item DB code. ( #1056)
+- Stop returning all feeds after marking folder as read. (#1056)
+- Always fetch favicon (#1164)
+- Use feed logo instead of favicon if it exists and is square (#1164)
+- Add CI for item lists (#1180)
+
+### Fixed
+- Item list throwing error for folder and "all items" (#1180)
 - Articles with high IDs can be placed lower than articles with low IDs (#1147)
-- Feeds are accidentally moved on rename
-- Item list not using ID for offset
+- Feeds are accidentally moved on rename (#1189)
+- Item list not using ID for offset (#1188)
 
 ## [15.3.2] - 2021-02-10
 No changes compared to RC2

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 Before you update to a new version, [check the changelog](https://github.com/nextcloud/news/blob/master/CHANGELOG.md) to avoid surprises.
 
 **Important**: To enable feed updates you will need to enable either [Nextcloud system cron](https://docs.nextcloud.org/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron) or use [an updater](https://github.com/nextcloud/news-updater) which uses the built in update API and disable cron updates. More information can be found [in the README](https://github.com/nextcloud/news).]]></description>
-    <version>15.3.2</version>
+    <version>15.4.0-beta1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
Changed
- Remove outdated item DB code. ( #1056)
- Stop returning all feeds after marking folder as read. (#1056)
- Always fetch favicon (#1164)
- Use feed logo instead of favicon if it exists and is square (#1164)
- Add CI for item lists (#1180)

Fixed
- Item list throwing error for folder and "all items" (#1180)
- Articles with high IDs can be placed lower than articles with low IDs (#1147)
- Feeds are accidentally moved on rename (#1189)
- Item list not using ID for offset (#1188)

Signed-off-by: Benjamin Brahmer <info@b-brahmer.de>