### PR TITLE
Feature: Import related tags to articles (Categories)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 
 ### Changed
 - Add BATS as integration tests
-
+- Update FeedFetcher to import categories from feeds (#1248)
+- Update serialization of item to include categories (#1248)
+ 
 ### Fixed
 
 ## [15.4.0-beta2] - 2021-02-27

--- a/lib/Db/Item.php
+++ b/lib/Db/Item.php
@@ -131,6 +131,7 @@ class Item extends Entity implements IAPI, \JsonSerializable
                 html_entity_decode(strip_tags($this->getBody())) .
                 html_entity_decode($this->getAuthor()) .
                 html_entity_decode($this->getTitle()) .
+                html_entity_decode($this->getCategories()) .
                 $this->getUrl(),
                 'UTF-8'
             )

--- a/lib/Db/Item.php
+++ b/lib/Db/Item.php
@@ -516,7 +516,7 @@ class Item extends Entity implements IAPI, \JsonSerializable
         return $this;
     }
 
-    public function setTags(string $tags): self
+    public function setTags(string $tags = null): self
     {
         if ($this->tags !== $tags) {
             $this->tags = $tags;

--- a/lib/Db/Item.php
+++ b/lib/Db/Item.php
@@ -126,12 +126,16 @@ class Item extends Entity implements IAPI, \JsonSerializable
 
     public function generateSearchIndex(): void
     {
+        $categoriesString = !empty($this->getCategories())
+            ? implode('', $this->getCategories())
+            : '';
+
         $this->setSearchIndex(
             mb_strtolower(
                 html_entity_decode(strip_tags($this->getBody())) .
                 html_entity_decode($this->getAuthor()) .
                 html_entity_decode($this->getTitle()) .
-                html_entity_decode($this->getCategoriesJson()) .
+                html_entity_decode($categoriesString) .
                 $this->getUrl(),
                 'UTF-8'
             )

--- a/lib/Db/Item.php
+++ b/lib/Db/Item.php
@@ -63,6 +63,8 @@ class Item extends Entity implements IAPI, \JsonSerializable
     protected $unread = false;
     /** @var bool */
     protected $starred = false;
+    /** @var string|null */
+    protected $tags;
 
     public function __construct()
     {
@@ -85,6 +87,7 @@ class Item extends Entity implements IAPI, \JsonSerializable
         $this->addType('fingerprint', 'string');
         $this->addType('unread', 'boolean');
         $this->addType('starred', 'boolean');
+        $this->addType('tags', 'string');
     }
 
     /**
@@ -273,6 +276,14 @@ class Item extends Entity implements IAPI, \JsonSerializable
     public function isUnread(): bool
     {
         return $this->unread;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getTags(): ?string
+    {
+        return $this->tags;
     }
 
     /**
@@ -500,6 +511,16 @@ class Item extends Entity implements IAPI, \JsonSerializable
         ) {
             $this->url = $url;
             $this->markFieldUpdated('url');
+        }
+
+        return $this;
+    }
+
+    public function setTags(string $tags): self
+    {
+        if ($this->tags !== $tags) {
+            $this->tags = $tags;
+            $this->markFieldUpdated('tags');
         }
 
         return $this;

--- a/lib/Db/Item.php
+++ b/lib/Db/Item.php
@@ -64,7 +64,7 @@ class Item extends Entity implements IAPI, \JsonSerializable
     /** @var bool */
     protected $starred = false;
     /** @var string|null */
-    protected $tags;
+    protected $categories;
 
     public function __construct()
     {
@@ -87,7 +87,7 @@ class Item extends Entity implements IAPI, \JsonSerializable
         $this->addType('fingerprint', 'string');
         $this->addType('unread', 'boolean');
         $this->addType('starred', 'boolean');
-        $this->addType('tags', 'string');
+        $this->addType('categories', 'string');
     }
 
     /**
@@ -281,9 +281,9 @@ class Item extends Entity implements IAPI, \JsonSerializable
     /**
      * @return null|string
      */
-    public function getTags(): ?string
+    public function getCategories(): ?string
     {
-        return $this->tags;
+        return $this->categories;
     }
 
     /**
@@ -516,11 +516,11 @@ class Item extends Entity implements IAPI, \JsonSerializable
         return $this;
     }
 
-    public function setTags(string $tags = null): self
+    public function setCategories(string $categories = null): self
     {
-        if ($this->tags !== $tags) {
-            $this->tags = $tags;
-            $this->markFieldUpdated('tags');
+        if ($this->categories !== $categories) {
+            $this->categories = $categories;
+            $this->markFieldUpdated('categories');
         }
 
         return $this;

--- a/lib/Db/Item.php
+++ b/lib/Db/Item.php
@@ -64,7 +64,7 @@ class Item extends Entity implements IAPI, \JsonSerializable
     /** @var bool */
     protected $starred = false;
     /** @var string|null */
-    protected $categories;
+    protected $categoriesJson;
 
     public function __construct()
     {
@@ -87,7 +87,7 @@ class Item extends Entity implements IAPI, \JsonSerializable
         $this->addType('fingerprint', 'string');
         $this->addType('unread', 'boolean');
         $this->addType('starred', 'boolean');
-        $this->addType('categories', 'string');
+        $this->addType('categoriesJson', 'string');
     }
 
     /**
@@ -131,7 +131,7 @@ class Item extends Entity implements IAPI, \JsonSerializable
                 html_entity_decode(strip_tags($this->getBody())) .
                 html_entity_decode($this->getAuthor()) .
                 html_entity_decode($this->getTitle()) .
-                html_entity_decode($this->getCategories()) .
+                html_entity_decode($this->getCategoriesJson()) .
                 $this->getUrl(),
                 'UTF-8'
             )
@@ -282,9 +282,17 @@ class Item extends Entity implements IAPI, \JsonSerializable
     /**
      * @return null|string
      */
-    public function getCategories(): ?string
+    public function getCategoriesJson(): ?string
     {
-        return $this->categories;
+        return $this->categoriesJson;
+    }
+
+    /**
+     * @return null|array
+     */
+    public function getCategories(): ?array
+    {
+        return json_decode($this->getCategoriesJson());
     }
 
     /**
@@ -518,12 +526,20 @@ class Item extends Entity implements IAPI, \JsonSerializable
         return $this;
     }
 
-    public function setCategories(string $categories = null): self
+    public function setCategoriesJson(string $categoriesJson = null): self
     {
-        if ($this->categories !== $categories) {
-            $this->categories = $categories;
-            $this->markFieldUpdated('categories');
+        if ($this->categoriesJson !== $categoriesJson) {
+            $this->categoriesJson = $categoriesJson;
+            $this->markFieldUpdated('categoriesJson');
         }
+
+        return $this;
+    }
+
+    public function setCategories(array $categories = null): self
+    {
+        $categoriesJson = !empty($categories) ? json_encode($categories) : null;
+        $this->setCategoriesJson($categoriesJson);
 
         return $this;
     }

--- a/lib/Db/Item.php
+++ b/lib/Db/Item.php
@@ -312,6 +312,7 @@ class Item extends Entity implements IAPI, \JsonSerializable
             'rtl' => $this->getRtl(),
             'intro' => $this->getIntro(),
             'fingerprint' => $this->getFingerprint(),
+            'categories' => $this->getCategories()
         ];
     }
 

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -261,7 +261,7 @@ class FeedFetcher implements IFeedFetcher
             $categories[] = $this->decodeTwice($category->getLabel());
         }
         if (count($categories) > 0) {
-            $item->setTags(implode(',', $categories));
+            $item->setCategories(implode(',', $categories));
         }
 
         // Use description from feed if body is not provided (by a scraper)

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -260,9 +260,7 @@ class FeedFetcher implements IFeedFetcher
         foreach ($parsedItem->getCategories() as $category) {
             $categories[] = $this->decodeTwice($category->getLabel());
         }
-        if (count($categories) > 0) {
-            $item->setCategories(implode(',', $categories));
-        }
+        $item->setCategories($categories);
 
         // Use description from feed if body is not provided (by a scraper)
         if ($body === null) {

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -256,6 +256,14 @@ class FeedFetcher implements IFeedFetcher
             $item->setAuthor($this->decodeTwice($author->getName()));
         }
 
+        $categories = [];
+        foreach ($parsedItem->getCategories() as $category) {
+            $categories[] = $this->decodeTwice($category->getLabel());
+        }
+        if (count($categories) > 0) {
+            $item->setTags(implode(',', $categories));
+        }
+
         // Use description from feed if body is not provided (by a scraper)
         if ($body === null) {
             $body = $parsedItem->getValue("content:encoded") ?? $parsedItem->getDescription();

--- a/lib/Migration/Version150302Date20210312231251.php
+++ b/lib/Migration/Version150302Date20210312231251.php
@@ -34,7 +34,7 @@ class Version150302Date20210312231251 extends SimpleMigrationStep {
 
         if ($schema->hasTable('news_items')) {
             $table = $schema->getTable('news_items');
-			$table->addColumn('categories', 'text', [
+			$table->addColumn('categories_json', 'json', [
 				'notnull' => false
 			]);
         }

--- a/lib/Migration/Version150302Date20210312231251.php
+++ b/lib/Migration/Version150302Date20210312231251.php
@@ -34,7 +34,7 @@ class Version150302Date20210312231251 extends SimpleMigrationStep {
 
         if ($schema->hasTable('news_items')) {
             $table = $schema->getTable('news_items');
-			$table->addColumn('tags', 'text', [
+			$table->addColumn('categories', 'text', [
 				'notnull' => false
 			]);
         }

--- a/lib/Migration/Version150302Date20210312231251.php
+++ b/lib/Migration/Version150302Date20210312231251.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\News\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version150302Date20210312231251 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+        $schema = $schemaClosure();
+
+        if ($schema->hasTable('news_items')) {
+            $table = $schema->getTable('news_items');
+			$table->addColumn('tags', 'text', [
+				'notnull' => false
+			]);
+        }
+
+        return $schema;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+	}
+}

--- a/tests/Unit/Db/ItemTest.php
+++ b/tests/Unit/Db/ItemTest.php
@@ -244,8 +244,9 @@ class ItemTest extends TestCase
         $item->setUrl('http://link');
         $item->setAuthor('&auml;uthor');
         $item->setTitle('<a>t&auml;tle</a>');
+        $item->setCategories(['food', 'travel']);
         $item->generateSearchIndex();
-        $expected = 'somethängäuthortätlehttp://link';
+        $expected = 'somethängäuthortätlefoodtravelhttp://link';
         $this->assertEquals($expected, $item->getSearchIndex());
     }
 

--- a/tests/Unit/Db/ItemTest.php
+++ b/tests/Unit/Db/ItemTest.php
@@ -369,4 +369,19 @@ class ItemTest extends TestCase
         );
     }
 
+    public function testSetCategories()
+    {
+        $item = new Item();
+        $item->setCategories(['podcast', 'blog']);
+        $this->assertEquals(['podcast', 'blog'], $item->getCategories());
+        $this->assertArrayHasKey('categoriesJson', $item->getUpdatedFields());
+    }
+
+    public function testSetCategoriesJson()
+    {
+        $item = new Item();
+        $item->setCategoriesJson(json_encode(['podcast', 'blog']));
+        $this->assertEquals(json_encode(['podcast', 'blog']), $item->getCategoriesJson());
+        $this->assertArrayHasKey('categoriesJson', $item->getUpdatedFields());
+    }
 }

--- a/tests/Unit/Db/ItemTest.php
+++ b/tests/Unit/Db/ItemTest.php
@@ -136,6 +136,7 @@ class ItemTest extends TestCase
         $item->setFingerprint('fingerprint');
         $item->setStarred(true);
         $item->setLastModified(321);
+        $item->setCategories(['food']);
 
         $this->assertEquals(
             [
@@ -158,7 +159,8 @@ class ItemTest extends TestCase
             'lastModified' => 321,
             'rtl' => true,
             'intro' => 'this is a test',
-            'fingerprint' => 'fingerprint'
+            'fingerprint' => 'fingerprint',
+            'categories' => ['food']
             ], $item->jsonSerialize()
         );
     }

--- a/tests/Unit/Fetcher/FeedFetcherTest.php
+++ b/tests/Unit/Fetcher/FeedFetcherTest.php
@@ -18,6 +18,7 @@ use Favicon\Favicon;
 use FeedIo\Adapter\ResponseInterface;
 use FeedIo\Feed\Item\Author;
 use FeedIo\Feed\Item\MediaInterface;
+use FeedIo\Feed\Node\Category;
 use FeedIo\Feed\ItemInterface;
 use FeedIo\FeedInterface;
 use FeedIo\FeedIo;
@@ -211,6 +212,11 @@ class FeedFetcherTest extends TestCase
         $this->author = new Author();
         $this->author->setName('&lt;boogieman');
         $this->enclosure = 'http://enclosure.you';
+
+        $category = new Category();
+        $category->setLabel('food');
+        $this->categories = new \ArrayIterator([$category]);
+        $this->categoriesJson = json_encode(['food']);
 
         $this->feed_title = '&lt;a&gt;&amp;its a&lt;/a&gt; title';
         $this->feed_link = 'http://tests/';
@@ -575,6 +581,9 @@ class FeedFetcherTest extends TestCase
         $this->item_mock->expects($this->exactly(1))
             ->method('getAuthor')
             ->will($this->returnValue($this->author));
+        $this->item_mock->expects($this->exactly(1))
+            ->method('getCategories')
+            ->will($this->returnValue($this->categories));
 
         $item = new Item();
 
@@ -587,7 +596,8 @@ class FeedFetcherTest extends TestCase
             ->setRtl(false)
             ->setLastModified(3)
             ->setPubDate(3)
-            ->setAuthor(html_entity_decode($this->author->getName()));
+            ->setAuthor(html_entity_decode($this->author->getName()))
+            ->setCategoriesJson($this->categoriesJson);
 
         if ($enclosureType === 'audio/ogg' || $enclosureType === 'video/ogg') {
             $media = $this->getMockbuilder(MediaInterface::class)->getMock();


### PR DESCRIPTION
**Authors** : Jimmy HUYNH (@LinkJim) - Marco NASSABAIN (@mnassabain)
## 🚀 Feature
Import related tags for each article

- Could be useful to sort articles by tags (in future...)
- Could be integrated in front-end to show keywords
- Could be used to generate hashtags for sharing on social media (e.g.: Twitter)
- UX / UI Friendly !

We are already working on sharing articles with users and on social media. (pr existants)

In case of sharing articles on social medias, we thought that sharing posts, would be more relevant if hashtags were automatically generated. Being that generating tags based on a text is a complex problem, we would use the tags retrieved from the RSS feeds instead.

This is an example of usage that the newly added "tags" field would offer. But we think that there are surely more advantages.

## 💻 Implementation
- We added a migration that inserts a "tags" column for news_items.
- We updated the Item model to include the "tags" field.
- In the FeedFetcher, we simply import the tags using the "categories" tag from the RSS feed.

## 💡 Questions
- In our current implementation the "tags" column is a "text" field. We thought that it is more appropriate than a string with a defined length?
- This current implementation only adds tags for newly imported articles. Already existing articles in the database will not be updated.

## ✅ To do
- Add tests
- Update already existing items to fetch their tags? Would this be possible?
---
Any recommandation would be appreciated, thanks. ;-)