### PR TITLE
Feature: Adding default feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 - Add BATS as integration tests
 - Update FeedFetcher to import categories from feeds (#1248)
 - Update serialization of item to include categories (#1248)
+- Set default feeds as an admin
  
 ### Fixed
 


### PR DESCRIPTION
This pull request is a **draft**. We saw that there's a demand for the ability to, as admins, set default feeds for users. It seems to be valuable for the news app.

The goal is to present our vision and our ideas on how to implement it, in hopes of hearing your opinion, before we start to code.

## 🚀 The feature

This feature will allow admins to set default feeds for all users.  

For now, as an admin, it's possible to add a feed for a user with a command line by using `./occ news:feed:add <user_id> <feed>.` However, the command line allows to add a feed for **only** **one user.** Also, it's more user friendly to have a interface to do this. Furthermore, this is a prety highly request demand, as seen on [this discussion](https://github.com/nextcloud/news/discussions/550#discussioncomment-306914).

The idea is to add a parameter that allows an administrator to define default feeds. These feeds will be added by default for all existing and new users on the server. This parameter will be modifiable on the settings page (`settings/admin/news`).

## 👨‍💻 Implementation

This new parameter will be added to the application configuration. On the front-end, there will be a list where admins will view default feeds and be able to add new ones, by adding their **RSS URLs,** or delete them. Each user on the server having the news app will have them by default. 

The array of **RSS URLs** will be stored in the `oc_appconfig` in a string in the JSON format. 

We have analyzed the code and here's a solution we would like to propose. 

### 1️⃣ Adding the new parameter

- Add new parameter in the config table (stored in `oc_appconfig` )
- Add input in front-end
- Send requests to the back-end to update the values

### 2️⃣ Adding and fetching defaults parameters for users

- For new users, we create a hook (or EventDispatcher), that on each user creation event, creates and fetches the default feeds for that user.
- For existing users, we will create & fetch default feeds for them when the parameter is modified.
    - We have also considered creating a hook which on each user login, checks if the user has the default feeds, and if not inserts them. This seems faster because we don't do everything at once. Also, users that are not active won't have the feeds inserted for them.
    - However, we're not sure if this is as clean as a solution as the first one, since it might be too much to check the feeds on each user login.
    - We'd like to hear your opinion and perspective before we start implementing this, so any comments are welcome!

Hope this will catch your interest! 

**Team Forward**,

- Marco NASSABAIN (@mnassabain)
- Aurélien DAVID 
- Jimmy HUYHN
- Hamza ELHADDAD
- Ilyes MALIH CHERGUI
- Nicolas WENDLING (@NicoWend) 