### PR TITLE
Allow directly adding a feed without going through the discovery process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 - Make PHPStan stricter
 - Restore search in news
 - Improve test coverage
+- Allow directly adding a feed without going through the discovery process (#1265)
 
 ### Fixed
 - Do not show deleted feeds in item list

--- a/js/controller/NavigationController.js
+++ b/js/controller/NavigationController.js
@@ -210,7 +210,9 @@ app.controller('NavigationController', function ($route, FEED_TYPE, FeedResource
                 feed.url += regResult[2];
             }
 
-            FeedResource.create(feed.url, existingFolder.id, undefined, feed.user, feed.password).then(function (data) {
+            var autoDiscover = feed.autoDiscover ? true : false;
+            FeedResource.create(feed.url, existingFolder.id, undefined, feed.user, feed.password, autoDiscover)
+            .then(function (data) {
                 Publisher.publishAll(data);
 
                 // set folder as default
@@ -220,6 +222,7 @@ app.controller('NavigationController', function ($route, FEED_TYPE, FeedResource
                 feed.url = '';
                 feed.user = '';
                 feed.password = '';
+                feed.autoDiscover = true;
                 self.addingFeed = false;
             });
 

--- a/js/service/FeedResource.js
+++ b/js/service/FeedResource.js
@@ -163,7 +163,7 @@ app.factory('FeedResource', function (Resource, $http, BASE_URL, $q) {
     };
 
 
-    FeedResource.prototype.create = function (url, folderId, title, user, password) {
+    FeedResource.prototype.create = function (url, folderId, title, user, password, fullDiscover) {
         url = url.trim();
         if (!url.startsWith('http')) {
             url = 'https://' + url;
@@ -191,7 +191,8 @@ app.factory('FeedResource', function (Resource, $http, BASE_URL, $q) {
                 parentFolderId: folderId || 0,
                 title: title,
                 user: user || null,
-                password: password || null
+                password: password || null,
+                fullDiscover: fullDiscover
             }
         }).then(function (response) {
             return response.data;

--- a/js/tests/unit/controller/NavigationControllerSpec.js
+++ b/js/tests/unit/controller/NavigationControllerSpec.js
@@ -361,7 +361,7 @@ describe('NavigationController', function () {
 
         expect(ctrl.showNewFolder).toBe(false);
         expect(FeedResource.create).toHaveBeenCalledWith('test', 3,
-            undefined, undefined, undefined);
+            undefined, undefined, undefined, false);
         expect(Publisher.publishAll).toHaveBeenCalledWith({feeds: [{
             id: 3,
             url: 'test',
@@ -441,7 +441,7 @@ describe('NavigationController', function () {
 
         expect(ctrl.showNewFolder).toBe(false);
         expect(FeedResource.create).toHaveBeenCalledWith('test', 19,
-            undefined, 'user', 'password');
+            undefined, 'user', 'password', false);
         expect(FolderResource.create).toHaveBeenCalledWith('john');
         expect(Publisher.publishAll).toHaveBeenCalledWith({
             folders: [{

--- a/lib/Controller/FeedController.php
+++ b/lib/Controller/FeedController.php
@@ -161,7 +161,8 @@ class FeedController extends Controller
         ?int $parentFolderId,
         ?string $title = null,
         ?string $user = null,
-        ?string $password = null
+        ?string $password = null,
+        bool $fullDiscover = true
     ) {
         if ($parentFolderId === 0) {
             $parentFolderId = null;
@@ -178,7 +179,8 @@ class FeedController extends Controller
                 false,
                 $title,
                 $user,
-                $password
+                $password,
+                $fullDiscover
             );
             $params = ['feeds' => [$feed]];
 

--- a/lib/Service/FeedServiceV2.php
+++ b/lib/Service/FeedServiceV2.php
@@ -189,15 +189,18 @@ class FeedServiceV2 extends Service
         bool $full_text = false,
         ?string $title = null,
         ?string $user = null,
-        ?string $password = null
+        ?string $password = null,
+        bool $full_discover = true
     ): Entity {
         if ($this->existsForUser($userId, $feedUrl)) {
             throw new ServiceConflictException('Feed with this URL exists');
         }
 
-        $feeds = $this->explorer->discover($feedUrl);
-        if ($feeds !== []) {
-            $feedUrl = array_shift($feeds);
+        if ($full_discover) {
+            $feeds = $this->explorer->discover($feedUrl);
+            if ($feeds !== []) {
+                $feedUrl = array_shift($feeds);
+            }
         }
 
         try {

--- a/templates/part.navigation.addfeed.php
+++ b/templates/part.navigation.addfeed.php
@@ -9,6 +9,7 @@
     <div class="add-new-popup" id="new-feed" news-add-feed="Navigation.feed">
 
         <form ng-submit="Navigation.createFeed(Navigation.feed)"
+              ng-init="Navigation.feed.autoDiscover=true"
               name="feedform">
             <fieldset ng-disabled="Navigation.addingFeed">
                 <input type="text"
@@ -97,6 +98,12 @@
                         placeholder="<?php p($l->t('Password')); ?>"
                         name="password" autocomplete="new-password">
                 </div>
+
+                <input type="checkbox"
+                       class="checkbox"
+                       ng-model="Navigation.feed.autoDiscover"
+                       id="add-feed-discover">
+                <label for="add-feed-discover"><?php p($l->t('Autodiscover Feed')); ?></label>
 
                 <!-- submit -->
                 <input type="submit"


### PR DESCRIPTION
This change adds a button to allow for directly adding a a feed by URL, bypassing feed-io's discovery process.  This is useful when a user knows a feed URL, but the discovery process causes an issue adding it to news. The new button is the + on the right side of the subscribe button.

This solves different problems that I'm having with 2 feeds. (#1226 and #1243).

![news-screenshot](https://user-images.githubusercontent.com/6622381/112740884-79e1e300-8f4e-11eb-8571-e26d8938fc9b.png)
