### PR TITLE
Release 15.4.0-beta3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,21 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 ## [Unreleased]
 
 ### Changed
-- Add BATS as integration tests
+
+### Fixed
+
+## [15.4.0-beta3] - 2021-04-03
+### Changed
+- Add BATS as integration tests (#1213)
 - Update FeedFetcher to import categories from feeds (#1248)
 - Update serialization of item to include categories (#1248)
-- Make PHPStan stricter
-- Restore search in news
-- Improve test coverage
+- Make PHPStan stricter (#955)
+- Search: Add folder search (#1215)
+- Improve test coverage (#1263)
 - Allow directly adding a feed without going through the discovery process (#1265)
 
 ### Fixed
-- Do not show deleted feeds in item list
+- Do not show deleted feeds in item list (#1214)
 - Fix update queries (#1211)
 
 ## [15.4.0-beta2] - 2021-02-27

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 Before you update to a new version, [check the changelog](https://github.com/nextcloud/news/blob/master/CHANGELOG.md) to avoid surprises.
 
 **Important**: To enable feed updates you will need to enable either [Nextcloud system cron](https://docs.nextcloud.org/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron) or use [an updater](https://github.com/nextcloud/news-updater) which uses the built in update API and disable cron updates. More information can be found [in the README](https://github.com/nextcloud/news).]]></description>
-    <version>15.4.0-beta2</version>
+    <version>15.4.0-beta3</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
Changed
- Add BATS as integration tests (#1213)
- Update FeedFetcher to import categories from feeds (#1248)
- Update serialization of item to include categories (#1248)
- Make PHPStan stricter (#955)
- Search: Add folder search (#1215)
- Improve test coverage (#1263)
- Allow directly adding a feed without going through the discovery process (#1265)

Fixed
- Do not show deleted feeds in item list (#1214)
- Fix update queries (#1211)