### PR TITLE
Null check category label before trying to decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
+- Check category label for null (#1282)
 
 ## [15.4.0-beta3] - 2021-04-03
 ### Fixed
 - Allow negative limits (#1275)
 - Use boolean to check bool fields (#1278)
-- Check category label for null (#1282)
 
 ## [15.4.0-beta3] - 2021-04-03
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Fixed
 - Allow negative limits (#1275)
 - Use boolean to check bool fields (#1278)
+- Check category label for null (#1282)
 
 ## [15.4.0-beta3] - 2021-04-03
 ### Changed

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -258,7 +258,9 @@ class FeedFetcher implements IFeedFetcher
 
         $categories = [];
         foreach ($parsedItem->getCategories() as $category) {
-            $categories[] = $this->decodeTwice($category->getLabel());
+            if ($category->getLabel() !== null) {
+                $categories[] = $this->decodeTwice($category->getLabel());
+            }
         }
         $item->setCategories($categories);
 


### PR DESCRIPTION
Signed-off-by: skiingwiz <skiingwiz@gmail.com>

Using the latest beta, one of my feeds caused an error with the new categories code.  Everything else calling decodeTwice() is checking for null first, so this pull request adds that same logic to the category labels.

The error I was getting without this is:
`"Exception":"Exception","Message":"Argument 1 passed to OCA\\News\\Fetcher\\FeedFetcher::decodeTwice() must be of the type string, null given, called in /var/www/nextcloud/apps/news/lib/Fetcher/FeedFetcher.php on line 261"`
