### PR TITLE
Changed spelling of "auto discover"

### DIFF
--- a/templates/part.navigation.addfeed.php
+++ b/templates/part.navigation.addfeed.php
@@ -103,7 +103,7 @@
                        class="checkbox"
                        ng-model="Navigation.feed.autoDiscover"
                        id="add-feed-discover">
-                <label for="add-feed-discover"><?php p($l->t('Autodiscover Feed')); ?></label>
+                <label for="add-feed-discover"><?php p($l->t('Auto discover Feed')); ?></label>
 
                 <!-- submit -->
                 <input type="submit"


### PR DESCRIPTION
It's a short form for "automatically discover".

Reported at Transifex.

Signed-off-by: rakekniven <mark.ziegler@rakekniven.de>