### PR TITLE
fix atom feed summary fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
+- content of atom feeds is missing
 
 # Releases
 ## [15.4.0] - 2021-04-26

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -266,7 +266,9 @@ class FeedFetcher implements IFeedFetcher
 
         // Use description from feed if body is not provided (by a scraper)
         if ($body === null) {
-            $body = $parsedItem->getValue("content:encoded") ?? $parsedItem->getDescription();
+            $body = $parsedItem->getValue("content:encoded")
+                    ?? $parsedItem->getDescription()
+                    ?? $parsedItem->getSummary();
         }
 
         // purification is done in the service layer


### PR DESCRIPTION
The content of an Atom feed is missing (probably caused by #1239) after updating to v15.4.0 (reported in the maintainer chat).
Validated for:
- https://en.wikipedia.org/w/api.php?action=featuredfeed&feed=potd&feedformat=atom
- https://rss.golem.de/rss.php?feed=ATOM1.0
- https://xkcd.com/atom.xml

For the master branch it's already fixed with 91db7113a8d844eb7d0e91596f8632e82210b6f6.