### PR TITLE
Require 64 bit integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 # Unreleased
 ## [16.x.x]
 ### Changed
+- News now requires a 64bit OS
 - v2 API implementation (folder part)
 - Implemented sharing news items between nextcloud users (#1191)
 - Updated the news items table in DB to include sharer data (#1191)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 Before you update to a new version, [check the changelog](https://github.com/nextcloud/news/blob/master/CHANGELOG.md) to avoid surprises.
 
 **Important**: To enable feed updates you will need to enable either [Nextcloud system cron](https://docs.nextcloud.org/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron) or use [an updater](https://github.com/nextcloud/news-updater) which uses the built in update API and disable cron updates. More information can be found [in the README](https://github.com/nextcloud/news).]]></description>
-    <version>15.4.0-beta4</version>
+    <version>16.0.0</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>
@@ -29,7 +29,7 @@ Before you update to a new version, [check the changelog](https://github.com/nex
     <screenshot small-thumbnail="https://raw.githubusercontent.com/nextcloud/news/master/screenshots/2-small.png">https://raw.githubusercontent.com/nextcloud/news/master/screenshots/2.png</screenshot>
     <screenshot small-thumbnail="https://raw.githubusercontent.com/nextcloud/news/master/screenshots/3-small.png">https://raw.githubusercontent.com/nextcloud/news/master/screenshots/3.png</screenshot>
     <dependencies>
-        <php min-version="7.2"/>
+        <php min-version="7.2" min-int-size="64"/>
         <database min-version="10">pgsql</database>
         <database>sqlite</database>
         <database min-version="8.0">mysql</database>


### PR DESCRIPTION
This relates to https://github.com/nextcloud/news/issues/1320

The most straight forward option we have is to simply require 64bit. 

The biggest impact would be probably that users of small ARM devices can't install newer news versions anymore and have to revert back to 15.3.x.
