### PR TITLE
mitigate 32-bit issues with microseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
-
+- mitigate 32-bit issues by using `float` instead of `int` for microseconds (#1320)
 
 # Releases
 ## [15.4.2] - 2021-05-03

--- a/lib/Db/ItemMapperV2.php
+++ b/lib/Db/ItemMapperV2.php
@@ -312,7 +312,7 @@ class ItemMapperV2 extends NewsMapperV2
     /**
      * @param string $userId
      * @param int    $feedId
-     * @param int    $updatedSince
+     * @param float  $updatedSince
      * @param bool   $hideRead
      *
      * @return Item[]
@@ -320,7 +320,7 @@ class ItemMapperV2 extends NewsMapperV2
     public function findAllInFeedAfter(
         string $userId,
         int $feedId,
-        int $updatedSince,
+        float $updatedSince,
         bool $hideRead
     ): array {
         $builder = $this->db->getQueryBuilder();
@@ -333,7 +333,7 @@ class ItemMapperV2 extends NewsMapperV2
             ->andWhere('feeds.id = :feedId')
             ->andWhere('feeds.deleted_at = 0')
             ->setParameters([
-                'updatedSince' => $updatedSince,
+                'updatedSince' => number_format($updatedSince, 0, '.', ''),
                 'feedId' => $feedId,
                 'userId'=> $userId,
             ])
@@ -351,7 +351,7 @@ class ItemMapperV2 extends NewsMapperV2
     /**
      * @param string   $userId
      * @param int|null $folderId
-     * @param int      $updatedSince
+     * @param float    $updatedSince
      * @param bool     $hideRead
      *
      * @return Item[]
@@ -359,7 +359,7 @@ class ItemMapperV2 extends NewsMapperV2
     public function findAllInFolderAfter(
         string $userId,
         ?int $folderId,
-        int $updatedSince,
+        float $updatedSince,
         bool $hideRead
     ): array {
         $builder = $this->db->getQueryBuilder();
@@ -372,7 +372,11 @@ class ItemMapperV2 extends NewsMapperV2
             ->andWhere('feeds.user_id = :userId')
             ->andWhere('feeds.deleted_at = 0')
             ->andWhere('folders.id = :folderId')
-            ->setParameters(['updatedSince' => $updatedSince, 'folderId' => $folderId, 'userId' => $userId])
+            ->setParameters([
+                'updatedSince' => number_format($updatedSince, 0, '.', ''),
+                'folderId' => $folderId,
+                'userId' => $userId,
+            ])
             ->orderBy('items.last_modified', 'DESC')
             ->addOrderBy('items.id', 'DESC');
 
@@ -386,13 +390,13 @@ class ItemMapperV2 extends NewsMapperV2
 
     /**
      * @param string $userId
-     * @param int    $updatedSince
+     * @param float  $updatedSince
      * @param int    $feedType
      *
      * @return Item[]|Entity[]
      * @throws ServiceValidationException
      */
-    public function findAllAfter(string $userId, int $feedType, int $updatedSince): array
+    public function findAllAfter(string $userId, int $feedType, float $updatedSince): array
     {
         $builder = $this->db->getQueryBuilder();
 
@@ -402,7 +406,10 @@ class ItemMapperV2 extends NewsMapperV2
             ->andWhere('items.last_modified >= :updatedSince')
             ->andWhere('feeds.deleted_at = 0')
             ->andWhere('feeds.user_id = :userId')
-            ->setParameters(['updatedSince' => $updatedSince, 'userId' => $userId])
+            ->setParameters([
+                'updatedSince' => number_format($updatedSince, 0, '.', ''),
+                'userId' => $userId,
+            ])
             ->orderBy('items.last_modified', 'DESC')
             ->addOrderBy('items.id', 'DESC');
 

--- a/lib/Service/ItemServiceV2.php
+++ b/lib/Service/ItemServiceV2.php
@@ -271,12 +271,12 @@ class ItemServiceV2 extends Service
      * Returns all new items in a feed
      * @param string  $userId       the name of the user
      * @param int     $feedId       the id of the feed
-     * @param int     $updatedSince a timestamp with the minimal modification date
+     * @param float   $updatedSince a timestamp with the minimal modification date
      * @param boolean $hideRead     if unread items should also be returned
      *
      * @return array of items
      */
-    public function findAllInFeedAfter(string $userId, int $feedId, int $updatedSince, bool $hideRead): array
+    public function findAllInFeedAfter(string $userId, int $feedId, float $updatedSince, bool $hideRead): array
     {
         return $this->mapper->findAllInFeedAfter($userId, $feedId, $updatedSince, $hideRead);
     }
@@ -285,12 +285,12 @@ class ItemServiceV2 extends Service
      * Returns all new items in a folder
      * @param string   $userId       the name of the user
      * @param int|null $folderId     the id of the folder
-     * @param int      $updatedSince a timestamp with the minimal modification date
+     * @param float    $updatedSince a timestamp with the minimal modification date
      * @param boolean  $hideRead     if unread items should also be returned
      *
      * @return array of items
      */
-    public function findAllInFolderAfter(string $userId, ?int $folderId, int $updatedSince, bool $hideRead): array
+    public function findAllInFolderAfter(string $userId, ?int $folderId, float $updatedSince, bool $hideRead): array
     {
         return $this->mapper->findAllInFolderAfter($userId, $folderId, $updatedSince, $hideRead);
     }
@@ -300,13 +300,13 @@ class ItemServiceV2 extends Service
      *
      * @param string $userId       the name of the user
      * @param int    $feedType     the type of feed items to fetch. (starred || unread)
-     * @param int    $updatedSince a timestamp with the minimal modification date
+     * @param float  $updatedSince a timestamp with the minimal modification date
      *
      * @return array of items
      *
      * @throws ServiceValidationException
      */
-    public function findAllAfter(string $userId, int $feedType, int $updatedSince): array
+    public function findAllAfter(string $userId, int $feedType, float $updatedSince): array
     {
         if (!in_array($feedType, [ListType::STARRED, ListType::UNREAD, ListType::ALL_ITEMS], true)) {
             throw new ServiceValidationException('Trying to find in unknown type');


### PR DESCRIPTION
__Workaround for v15.4.x, further plans regarding 32-bit as of the next major are discussed in #1333.__

Since I'm not sure how the QueryBuilder handles floats like `1.620141854E+15` for bigint fields I've explicitly formated it into a string
```php
number_format($updatedSince, 0, '.', '')
```

Because I don't have any 32-bit OS here, I couldn't test it in depth.