### PR TITLE
db: no longer order by `items.last_modified`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
+- newestId does not return newest ID but last updated
 
 # Releases
 ## [15.4.4] - 2021-05-21

--- a/lib/Db/ItemMapperV2.php
+++ b/lib/Db/ItemMapperV2.php
@@ -302,7 +302,6 @@ class ItemMapperV2 extends NewsMapperV2
                 ->innerJoin('items', FeedMapperV2::TABLE_NAME, 'feeds', 'items.feed_id = feeds.id')
                 ->where('feeds.user_id = :userId')
                 ->setParameter('userId', $userId)
-                ->orderBy('items.last_modified', 'DESC')
                 ->addOrderBy('items.id', 'DESC')
                 ->setMaxResults(1);
 
@@ -337,7 +336,6 @@ class ItemMapperV2 extends NewsMapperV2
                 'feedId' => $feedId,
                 'userId'=> $userId,
             ])
-            ->orderBy('items.last_modified', 'DESC')
             ->addOrderBy('items.id', 'DESC');
 
         if ($hideRead === true) {
@@ -377,7 +375,6 @@ class ItemMapperV2 extends NewsMapperV2
                 'folderId' => $folderId,
                 'userId' => $userId,
             ])
-            ->orderBy('items.last_modified', 'DESC')
             ->addOrderBy('items.id', 'DESC');
 
         if ($hideRead === true) {
@@ -410,7 +407,6 @@ class ItemMapperV2 extends NewsMapperV2
                 'updatedSince' => number_format($updatedSince, 0, '.', ''),
                 'userId' => $userId,
             ])
-            ->orderBy('items.last_modified', 'DESC')
             ->addOrderBy('items.id', 'DESC');
 
         switch ($feedType) {

--- a/tests/Unit/Db/ItemMapperAfterTest.php
+++ b/tests/Unit/Db/ItemMapperAfterTest.php
@@ -81,7 +81,7 @@ class ItemMapperAfterTest extends MapperTestUtility
             ])
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->never())
             ->method('orderBy')
             ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
@@ -152,7 +152,7 @@ class ItemMapperAfterTest extends MapperTestUtility
             ->with('unread', true)
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->never())
             ->method('orderBy')
             ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
@@ -220,7 +220,7 @@ class ItemMapperAfterTest extends MapperTestUtility
             ])
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->never())
             ->method('orderBy')
             ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
@@ -294,7 +294,7 @@ class ItemMapperAfterTest extends MapperTestUtility
             ->with('unread', true)
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->never())
             ->method('orderBy')
             ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
@@ -363,7 +363,7 @@ class ItemMapperAfterTest extends MapperTestUtility
             ->with('unread', true)
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->never())
             ->method('orderBy')
             ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
@@ -432,7 +432,7 @@ class ItemMapperAfterTest extends MapperTestUtility
             ->with('starred', true)
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->never())
             ->method('orderBy')
             ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
@@ -495,7 +495,7 @@ class ItemMapperAfterTest extends MapperTestUtility
             ])
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->never())
             ->method('orderBy')
             ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());
@@ -561,7 +561,7 @@ class ItemMapperAfterTest extends MapperTestUtility
             ])
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->never())
             ->method('orderBy')
             ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());

--- a/tests/Unit/Db/ItemMapperTest.php
+++ b/tests/Unit/Db/ItemMapperTest.php
@@ -432,7 +432,7 @@ class ItemMapperTest extends MapperTestUtility
             ->with('items', 'news_feeds', 'feeds', 'items.feed_id = feeds.id')
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->never())
             ->method('orderBy')
             ->with('items.last_modified', 'DESC')
             ->will($this->returnSelf());


### PR DESCRIPTION
This might fix some issues some people/apps have been having.

Most notably: https://github.com/nextcloud/news/issues/1324