### PR TITLE
Release 15.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,12 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
-- mitigate 32-bit issues by using `float` instead of `int` for microseconds (#1320)
 
 # Releases
+## [15.4.3] - 2021-05-05
+### Fixed
+- mitigate 32-bit issues by using `float` instead of `int` for microseconds (#1320)
+
 ## [15.4.2] - 2021-05-03
 ### Fixed
 - revert accidentally merged dependency updates (#1332)
@@ -33,6 +36,9 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 - Fix some of the favicon fetching errors (#1319)
 
 ## [15.4.0] - 2021-04-26
+### Known Issue
+If you use a 32bit OS your will run into #1320
+
 See previous notes for a full overview.
 ### Fixed
 - Fix search results not redirecting to the news app

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 Before you update to a new version, [check the changelog](https://github.com/nextcloud/news/blob/master/CHANGELOG.md) to avoid surprises.
 
 **Important**: To enable feed updates you will need to enable either [Nextcloud system cron](https://docs.nextcloud.org/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron) or use [an updater](https://github.com/nextcloud/news-updater) which uses the built in update API and disable cron updates. More information can be found [in the README](https://github.com/nextcloud/news).]]></description>
-    <version>15.4.2</version>
+    <version>15.4.3</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
Fixed
- mitigate 32-bit issues by using `float` instead of `int` for microseconds (#1320)

Signed-off-by: Benjamin Brahmer <info@b-brahmer.de>