### PR TITLE
controller: getRead + all_items is now unread type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
+- allow calling `/items?getRead=false` without a feed/folder
 
 # Releases
 ## [15.4.3] - 2021-05-05

--- a/lib/Controller/ItemApiController.php
+++ b/lib/Controller/ItemApiController.php
@@ -94,6 +94,13 @@ class ItemApiController extends ApiController
                 );
                 break;
             default:
+                // Fallback in case people try getRead here
+                if ($getRead === false && $type === ListType::ALL_ITEMS) {
+                    $type = ListType::UNREAD;
+                } elseif ($getRead === false) {
+                    return ['message' => 'Setting getRead on an already filtered list is not allowed!'];
+                }
+
                 $items = $this->itemService->findAllWithFilters(
                     $this->getUserId(),
                     $type,

--- a/tests/Unit/Controller/ItemApiControllerTest.php
+++ b/tests/Unit/Controller/ItemApiControllerTest.php
@@ -156,6 +156,42 @@ class ItemApiControllerTest extends TestCase
     }
 
 
+    public function testIndexListensToGetReadOnAllItems()
+    {
+        $item = new Item();
+        $item->setId(5);
+        $item->setGuid('guid');
+        $item->setGuidHash('guidhash');
+        $item->setFeedId(123);
+
+        $this->itemService->expects($this->once())
+            ->method('findAllWithFilters')
+            ->with($this->uid, 6, -1, 0, false, [])
+            ->will($this->returnValue([$item]));
+
+        $response = $this->class->index(3, 0, false);
+
+        $this->assertEquals(['items' => [$item->toApi()]], $response);
+    }
+
+
+    public function testIndexListensToGetReadOnItems()
+    {
+        $item = new Item();
+        $item->setId(5);
+        $item->setGuid('guid');
+        $item->setGuidHash('guidhash');
+        $item->setFeedId(123);
+
+        $this->itemService->expects($this->never())
+            ->method('findAllWithFilters');
+
+        $response = $this->class->index(6, 0, false);
+
+        $this->assertEquals(['message' => 'Setting getRead on an already filtered list is not allowed!'], $response);
+    }
+
+
     public function testUpdatedFeed()
     {
         $item = new Item();


### PR DESCRIPTION
Should fix #1328

Allows people to call `/items?batchSize=-1&getRead=false&type=3`