### PR TITLE
Release 16.0.0-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 # Unreleased
 ## [16.x.x]
 ### Changed
+
+### Fixed
+
+## [15.x.x]
+### Changed
+
+### Fixed
+
+# Releases
+## [16.0.0-beta1] - 2021-05-22
+### Changed
 - News now requires a 64bit OS
 - v2 API implementation (folder part)
 - Implemented sharing news items between nextcloud users (#1191)
@@ -15,14 +26,6 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 - Added sharing articles with nextcloud users (#1217)
 - Added sharing articles on social media (Facebook, Twitter) or mail (#1217)
 
-### Fixed
-
-## [15.x.x]
-### Changed
-
-### Fixed
-
-# Releases
 ## [15.4.4] - 2021-05-21
 ### Fixed
 - allow calling `/items?getRead=false` without a feed/folder

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@ Create a [bug report](https://github.com/nextcloud/news/issues/new/choose)
 Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>16.0.0</version>
+    <version>16.0.0-beta1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
Changed
- News now requires a 64bit OS
- v2 API implementation (folder part)
- Implemented sharing news items between nextcloud users (#1191)
- Updated the news items table in DB to include sharer data (#1191)
- Added route for sharing news items (#1191)
- Added share data in news items serialization (#1191)
- Added tests for the news items share feature (#1191)
- Added sharing articles with nextcloud users (#1217)
- Added sharing articles on social media (Facebook, Twitter) or mail (#1217)

Signed-off-by: Benjamin Brahmer <info@b-brahmer.de>