### PR TITLE
add more meta data to docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,7 @@
 site_name: Nextcloud News App
+site_url: https://nextcloud.github.io/news/
+site_description: Documentation for the Nextcloud News App
+site_author: Nextcloud News Team
 repo_url: https://github.com/nextcloud/news
 edit_uri: blob/master/documentation/
 


### PR DESCRIPTION
This might fix the broken 404 page, apparently when the site-url is missing some things including the 404 page break.

Unfortunately there is no way to test this locally ..