### PR TITLE
remove migrations command from ci

### DIFF
--- a/.github/workflows/api-integration-tests.yml
+++ b/.github/workflows/api-integration-tests.yml
@@ -41,9 +41,6 @@ jobs:
             nextcloud: pre-release
             database: sqlite
             experimental: true
-        exclude: #unsupported combination
-          - php-versions: 7.4
-            nextcloud: 17
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
@@ -112,7 +109,6 @@ jobs:
       - name: Functional tests maintenance
         working-directory: ../server
         run: |
-          ./occ migrations:migrate news
           ./occ maintenance:repair
 
       - name: Functional tests


### PR DESCRIPTION
As the migrations command is not needed, we can simply drop it
fixes #1389 