### PR TITLE
Release 16.0.0-beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 # Unreleased
 ## [16.x.x]
 ### Changed
+### Fixed
+## [15.x.x]
+### Changed
+### Fixed
+# Releases
+## [16.0.0-beta2] - 2021-06-01
+### Changed
+- Allow installation on Nextcloud v22
 - Remove deprecated API endpoints and occ comand (#935)
   - /api/v1-2/user
   - /api/v1-2/user/avatar
@@ -14,12 +22,6 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 - allow calling `/items?getRead=false` without a feed/folder (#1380 #1356)
 - newestId does not return newest ID but last updated (#1339)
 
-## [15.x.x]
-### Changed
-
-### Fixed
-
-# Releases
 ## [15.4.5] - 2021-05-26
 ### Fixed
 - newestId does not return newest ID but last updated (#1339)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@ Create a [bug report](https://github.com/nextcloud/news/issues/new/choose)
 Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>16.0.0-beta1</version>
+    <version>16.0.0-beta2</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>
@@ -51,7 +51,7 @@ Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
         <lib>json</lib>
 
         <owncloud max-version="0" min-version="0"/>
-        <nextcloud min-version="20" max-version="21"/>
+        <nextcloud min-version="20" max-version="22"/>
     </dependencies>
 
     <background-jobs>


### PR DESCRIPTION
## Changed
- Allow installation on Nextcloud v22
- Remove deprecated API endpoints and occ comand (#935)
  - /api/v1-2/user
  - /api/v1-2/user/avatar
  - ./occ news:updater:all-feeds
## Fixed
- allow calling `/items?getRead=false` without a feed/folder (#1380 #1356)
- newestId does not return newest ID but last updated (#1339)

Signed-off-by: Benjamin Brahmer <info@b-brahmer.de>