### PR TITLE
Fix: NotNullConstraintViolation when sharing with users 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), older entries don't fully match.
 
 # Unreleased
+- Fix NotNullConstraintViolation when sharing news items with users (#1406)
+
 ## [16.x.x]
 ### Changed
 ### Fixed

--- a/lib/Db/Item.php
+++ b/lib/Db/Item.php
@@ -99,6 +99,13 @@ class Item extends Entity implements IAPI, \JsonSerializable
 
     public function __clone()
     {
+        $this->setId(null);
+
+        /**
+         * Removes 'id' from updatedFields; this will avoid explicitly
+         * inserting the value NULL into the DB, and will instead allow a new
+         * id to be generated.
+         * */
         $this->resetUpdatedFields();
         $this->markFieldUpdated('contentHash');
         $this->markFieldUpdated('guidHash');

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -110,7 +110,6 @@ class ShareService
 
         // Duplicate item & initialize fields
         $sharedItem = clone $item;
-        $sharedItem->setId(null);
         $sharedItem->setUnread(true);
         $sharedItem->setStarred(false);
         $sharedItem->setSharedBy($userId);


### PR DESCRIPTION
Fixes #1375

## Details for the maintainers/reviewers

### Problem
When creating a copy of the item to be shared, we set the id to null. The goal of this was to allow the DBMS to automatically generate an id on insertion.

However, everytime an entities field changes, the field is marked as updated. In this case, it's the id field that gets marked as updated. Since Nextcloud has it's own code for persisting entities, it builds an SQL query with all of the updated fields. The result of this operation will be an SQL query explicitly setting the id to null - provoking an error (in some DBMS) since id is not nullable.

### Solution
The solution is not to mark the id field as updated. As a consequence, the SQL query won't specifically set it to null on persist. The id will instead be generated automatically by the DBMS.

### Implementation
1. First idea: Implement a `duplicate()` function that creates a new item (with no id), and copies all of the fields. This will allow us to avoid writing `setId(null)`, and avoid playing around with updated fields. I didn't implement this because I wanted to stick with the current logic and reuse the clone function. However, personally, I like this solution. I wanted to hear your thoughts on this idea, and if it's your preferred method, I can do reimplement the solution that way.
2. Second idea: Modify the clone function to set the id to NULL. This is done to set the id to null BEFORE resetting the updated fields. Also a pretty good solution, as it allows us to use the `clone` function. **This is the implemented solution in this pull request.**


Let me know what you think, thanks!