### PR TITLE
Restore 32-bit support

### DIFF
--- a/lib/Controller/ItemApiController.php
+++ b/lib/Controller/ItemApiController.php
@@ -131,9 +131,9 @@ class ItemApiController extends ApiController
     {
         // needs to be turned into a microsecond timestamp to work properly
         if (strlen((string) $lastModified) <= 10) {
-            $paddedLastModified = (float)$lastModified * 1000000.0;
+            $paddedLastModified = $lastModified * 1000000;
         } else {
-            $paddedLastModified = (float)$lastModified;
+            $paddedLastModified = $lastModified;
         }
 
         switch ($type) {

--- a/lib/Controller/ItemApiController.php
+++ b/lib/Controller/ItemApiController.php
@@ -122,12 +122,12 @@ class ItemApiController extends ApiController
      *
      * @param int $type
      * @param int $id
-     * @param int $lastModified
+     * @param float $lastModified
      * @return array|JSONResponse
      *
      * @throws ServiceValidationException
      */
-    public function updated(int $type = 3, int $id = 0, int $lastModified = 0): array
+    public function updated(int $type = 3, int $id = 0, float $lastModified = 0): array
     {
         // needs to be turned into a microsecond timestamp to work properly
         if (strlen((string) $lastModified) <= 10) {

--- a/lib/Controller/ItemApiController.php
+++ b/lib/Controller/ItemApiController.php
@@ -129,11 +129,11 @@ class ItemApiController extends ApiController
      */
     public function updated(int $type = 3, int $id = 0, int $lastModified = 0): array
     {
-        // needs to be turned into a millisecond timestamp to work properly
+        // needs to be turned into a microsecond timestamp to work properly
         if (strlen((string) $lastModified) <= 10) {
-            $paddedLastModified = $lastModified * 1000000;
+            $paddedLastModified = (float)$lastModified * 1000000.0;
         } else {
-            $paddedLastModified = $lastModified;
+            $paddedLastModified = (float)$lastModified;
         }
 
         switch ($type) {

--- a/lib/Db/ItemMapperV2.php
+++ b/lib/Db/ItemMapperV2.php
@@ -311,7 +311,7 @@ class ItemMapperV2 extends NewsMapperV2
     /**
      * @param string $userId
      * @param int    $feedId
-     * @param int    $updatedSince
+     * @param float  $updatedSince
      * @param bool   $hideRead
      *
      * @return Item[]
@@ -319,7 +319,7 @@ class ItemMapperV2 extends NewsMapperV2
     public function findAllInFeedAfter(
         string $userId,
         int $feedId,
-        int $updatedSince,
+        float $updatedSince,
         bool $hideRead
     ): array {
         $builder = $this->db->getQueryBuilder();
@@ -349,7 +349,7 @@ class ItemMapperV2 extends NewsMapperV2
     /**
      * @param string   $userId
      * @param int|null $folderId
-     * @param int      $updatedSince
+     * @param float    $updatedSince
      * @param bool     $hideRead
      *
      * @return Item[]
@@ -357,7 +357,7 @@ class ItemMapperV2 extends NewsMapperV2
     public function findAllInFolderAfter(
         string $userId,
         ?int $folderId,
-        int $updatedSince,
+        float $updatedSince,
         bool $hideRead
     ): array {
         $builder = $this->db->getQueryBuilder();
@@ -383,13 +383,13 @@ class ItemMapperV2 extends NewsMapperV2
 
     /**
      * @param string $userId
-     * @param int    $updatedSince
+     * @param float  $updatedSince
      * @param int    $feedType
      *
      * @return Item[]|Entity[]
      * @throws ServiceValidationException
      */
-    public function findAllAfter(string $userId, int $feedType, int $updatedSince): array
+    public function findAllAfter(string $userId, int $feedType, float $updatedSince): array
     {
         $builder = $this->db->getQueryBuilder();
 

--- a/lib/Service/ItemServiceV2.php
+++ b/lib/Service/ItemServiceV2.php
@@ -306,7 +306,7 @@ class ItemServiceV2 extends Service
      *
      * @throws ServiceValidationException
      */
-    public function findAllAfter(string $userId, int $feedType, ifloat $updatedSince): array
+    public function findAllAfter(string $userId, int $feedType, float $updatedSince): array
     {
         if (!in_array($feedType, [ListType::STARRED, ListType::UNREAD, ListType::ALL_ITEMS], true)) {
             throw new ServiceValidationException('Trying to find in unknown type');

--- a/lib/Service/ItemServiceV2.php
+++ b/lib/Service/ItemServiceV2.php
@@ -271,12 +271,12 @@ class ItemServiceV2 extends Service
      * Returns all new items in a feed
      * @param string  $userId       the name of the user
      * @param int     $feedId       the id of the feed
-     * @param int     $updatedSince a timestamp with the minimal modification date
+     * @param float   $updatedSince a timestamp with the minimal modification date
      * @param boolean $hideRead     if unread items should also be returned
      *
      * @return array of items
      */
-    public function findAllInFeedAfter(string $userId, int $feedId, int $updatedSince, bool $hideRead): array
+    public function findAllInFeedAfter(string $userId, int $feedId, float $updatedSince, bool $hideRead): array
     {
         return $this->mapper->findAllInFeedAfter($userId, $feedId, $updatedSince, $hideRead);
     }
@@ -285,12 +285,12 @@ class ItemServiceV2 extends Service
      * Returns all new items in a folder
      * @param string   $userId       the name of the user
      * @param int|null $folderId     the id of the folder
-     * @param int      $updatedSince a timestamp with the minimal modification date
+     * @param float    $updatedSince a timestamp with the minimal modification date
      * @param boolean  $hideRead     if unread items should also be returned
      *
      * @return array of items
      */
-    public function findAllInFolderAfter(string $userId, ?int $folderId, int $updatedSince, bool $hideRead): array
+    public function findAllInFolderAfter(string $userId, ?int $folderId, float $updatedSince, bool $hideRead): array
     {
         return $this->mapper->findAllInFolderAfter($userId, $folderId, $updatedSince, $hideRead);
     }
@@ -300,13 +300,13 @@ class ItemServiceV2 extends Service
      *
      * @param string $userId       the name of the user
      * @param int    $feedType     the type of feed items to fetch. (starred || unread)
-     * @param int    $updatedSince a timestamp with the minimal modification date
+     * @param float $updatedSince a timestamp with the minimal modification date
      *
      * @return array of items
      *
      * @throws ServiceValidationException
      */
-    public function findAllAfter(string $userId, int $feedType, int $updatedSince): array
+    public function findAllAfter(string $userId, int $feedType, ifloat $updatedSince): array
     {
         if (!in_array($feedType, [ListType::STARRED, ListType::UNREAD, ListType::ALL_ITEMS], true)) {
             throw new ServiceValidationException('Trying to find in unknown type');


### PR DESCRIPTION
This PR might restore 32-bit support, by using a `float` instead of an `int` for handling timestamps.

This is probably safe, as discussed here in https://github.com/nextcloud/news/issues/1423#issuecomment-874222014

I'm not a PHP programmer so it's possible that this doesn't work at all, but hopefully it illustrates the idea.