### PR TITLE
Reimplement getRelativeDate() and drop dependency on deprecated moment.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 
 ## [16.x.x]
 ### Changed
+- Reimplemented relative time formatting
+
 ### Fixed
 
 ## [15.x.x]

--- a/js/.jshintrc
+++ b/js/.jshintrc
@@ -25,7 +25,6 @@
     "jquery": true,
     "globals": {
         "angular": true,
-        "moment": true,
         "app": true,
         "OC": true,
         "csrfToken": true,

--- a/js/gulpfile.js
+++ b/js/gulpfile.js
@@ -28,7 +28,6 @@ const sources = [
     'node_modules/angular-animate/angular-animate.min.js',
     'node_modules/angular-route/angular-route.min.js',
     'node_modules/angular-sanitize/angular-sanitize.min.js',
-    'node_modules/moment/min/moment-with-locales.min.js',
     'node_modules/masonry-layout/dist/masonry.pkgd.min.js',
     'app/App.js', 'app/Config.js', 'app/Run.js',
     'controller/**/*.js',

--- a/js/karma.conf.js
+++ b/js/karma.conf.js
@@ -17,7 +17,6 @@ module.exports = function (config) {
         // list of files / patterns to load in the browser
         files: [
             'node_modules/jquery/dist/jquery.js',
-            'node_modules/moment/min/moment-with-locales.js',
             'node_modules/angular/angular.js',
             'node_modules/angular-mocks/angular-mocks.js',
             'node_modules/angular-route/angular-route.js',

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -4206,11 +4206,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
-    },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",

--- a/js/package.json
+++ b/js/package.json
@@ -58,7 +58,6 @@
     "angular-route": "^1.8.2",
     "angular-sanitize": "^1.8.2",
     "debug": "^4.3.2",
-    "masonry-layout": "^4.2.2",
-    "moment": "^2.29.1"
+    "masonry-layout": "^4.2.2"
   }
 }


### PR DESCRIPTION
This is a re-implementation of `getRelativeDate()`, which was mentioned in #1433. Original version used NodeJS module `moment.js`, which is obsolete, deprecated, and slated for removal from Nextcloud base.

This version uses pure JavaScript `Intl.RelativeTimeFormat`, with fallback to plain date formatting for older browsers. Dependency on `moment.js` is dropped. The new function is, however, slightly different from the original:

  - If the distance between now and the timestamp is more than 90 days (and for older browsers), absolute date/time format is used. I didn't want to use "N months ago" relative format, since it's difficult to calculate correctly; and "N weeks ago" seems to be less readable for long distances.
  - The function returns "N weeks ago" for distances greater than 7 days, "N days ago" for distances greater than 1 day, and so on.
  - In the fallback (absolute format) branch the function returns time only to minutes. If the timestamp is within half-day from now, only time is printed; if the timestamp is within 7 days from now, weekday is added; otherwise, full date is added.
 
My last encounter with JavaScript was about twenty years ago, so any corrections or improvements are welcome.