### PR TITLE
explicitly set icon offset in navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 - Added new `news:updater:update-user` command to update the feeds of a single user (#1360).
 
 ### Fixed
+- Set icon offset explicitly for navigation items
 
 ## [15.x.x]
 ### Changed

--- a/css/navigation.css
+++ b/css/navigation.css
@@ -31,9 +31,6 @@
     background-position: 14px center;
 }
 
-#app-navigation .add-new .heading button {
-}
-
 
 /* actual form content */
 #app-navigation .add-new-popup {
@@ -89,6 +86,11 @@
 }
 
 /* navigation */
+#app-navigation ul.with-icon > li > a,
+#app-navigation ul.with-icon > li > ul > li > a {
+    padding-left: 44px;
+}
+
 #app-navigation .icon-starred {
     background-image: url('../img/starred.png');
 }


### PR DESCRIPTION
Just updated to NC 22.1.0 RC1 and in the app navigation the icons and titles are overlapping (caused by nextcloud/server#27936)

| until NC 22.0.0 | since NC 22.1.0 RC1 |
|---|---|
| ![grafik](https://user-images.githubusercontent.com/15173012/127749680-962bdea0-9b06-4835-8a54-0040127d0eaf.png) | ![grafik](https://user-images.githubusercontent.com/15173012/127749675-861bbf8b-4e7b-4eb4-8fb4-cdaa10fdd014.png) |

The changes don't interfere with previous versions (tested on 21.0.3).