### PR TITLE
Fix favicon element making broken requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 
 ### Fixed
 - Set icon offset explicitly for navigation items
+- Removed spurious requests for `.../apps/news/%7B%7B%20::Content.getFeed(item.feedId).faviconLink%20%7D%7D` (#1488)
 
 ## [15.x.x]
 ### Changed

--- a/templates/part.content.php
+++ b/templates/part.content.php
@@ -196,7 +196,7 @@
                     <span ng-if="!item.sharedBy" class="source"><?php p($l->t('from')) ?>
                         <a ng-href="#/items/feeds/{{ ::item.feedId }}/">
                             {{ ::Content.getFeed(item.feedId).title }}
-                            <img ng-if="Content.getFeed(item.feedId).faviconLink && !Content.isCompactView()" src="{{ ::Content.getFeed(item.feedId).faviconLink }}" alt="favicon">
+                            <img ng-if="Content.getFeed(item.feedId).faviconLink && !Content.isCompactView()" ng-src="{{ ::Content.getFeed(item.feedId).faviconLink }}" alt="favicon">
                         </a>
                     </span>
                     <span ng-if="item.sharedBy">


### PR DESCRIPTION
The markup for favicon `<img>` element in feed item used `src` instead of
`ng-src`, causing browser to make broken requests for
`.../apps/news/%7B%7B%20::Content.getFeed(item.feedId).faviconLink%20%7D%7D`

Changing the attribute to `ng-src` fixed that.