### PR TITLE
Release 16.1.0-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,24 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 
 ## [16.x.x]
 ### Changed
-- Reimplemented relative time formatting as a filter (#1450)
-- Added new `news:updater:update-user` command to update the feeds of a single user (#1360).
 
-### Fixed
-- Set icon offset explicitly for navigation items
-- Removed spurious requests for `.../apps/news/%7B%7B%20::Content.getFeed(item.feedId).faviconLink%20%7D%7D` (#1488)
-
-## [15.x.x]
-### Changed
 ### Fixed
 
 # Releases
+## [16.1.0-beta1] - 2021-09-02
+### Changed
+- Added new `news:updater:update-user` command to update the feeds of a single user (#1360).
+
+### Fixed
+- Removed spurious requests for `.../apps/news/%7B%7B%20::Content.getFeed(item.feedId).faviconLink%20%7D%7D` (#1488)
+
+## [16.0.1] - 2021-08-02
+### Changed
+- Reimplemented relative time formatting as a filter (#1450)
+
+### Fixed
+- Set icon offset explicitly for navigation items (#1465)
+
 ## [16.0.0] - 2021-06-16
 There are no additional changes compared to the latest beta.
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@ Create a [bug report](https://github.com/nextcloud/news/issues/new/choose)
 Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>16.0.0</version>
+    <version>16.1.0-beta1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
Changed
- Added new `news:updater:update-user` command to update the feeds of a single user (#1360).

Fixed
- Removed spurious requests for `.../apps/news/%7B%7B%20::Content.getFeed(item.feedId).faviconLink%20%7D%7D` (#1488)

Signed-off-by: Benjamin Brahmer <info@b-brahmer.de>