### PR TITLE
compiled image: Remove readability tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 
 ## [16.x.x]
 ### Changed
+- Remove dependency's large test files from release (#1519)
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,8 @@ appstore:
 	rm -rf $(appstore_sign_dir)/$(app_name)/vendor/bin
 	# the App Store doesn't like .git
 	rm -rf $(appstore_sign_dir)/$(app_name)/vendor/arthurhoaro/favicon/.git
+	# remove large test files
+	rm -rf $(appstore_sign_dir)/$(app_name)/vendor/andreskrey/readability.php/test
 
 	install "COPYING" $(appstore_sign_dir)/$(app_name)
 	install "AUTHORS.md" $(appstore_sign_dir)/$(app_name)


### PR DESCRIPTION
This should make the released app 3x smaller.