### PR TITLE
Fix spelling of receive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 ## [16.x.x]
 ### Changed
 - Remove dependency's large test files from release (#1519)
+- Fix spelling of "receive" in log files (#1520)
 
 ### Fixed
 

--- a/lib/Scraper/Scraper.php
+++ b/lib/Scraper/Scraper.php
@@ -61,7 +61,7 @@ class Scraper implements IScraper
     {
         list($content, $redirected_url) = $this->getHTTPContent($url);
         if ($content === false) {
-            $this->logger->error('Unable to recive content from {url}', [
+            $this->logger->error('Unable to receive content from {url}', [
                  'url' => $url,
             ]);
             $this->readability = null;


### PR DESCRIPTION
recive => receive

While going through my log files trying to debug why my feeds aren't updating anymore, I tried to search/grep for "receive" and was surprised to see no results. Fixing the spelling should make it easier for everyone to search/grep their log files.