### PR TITLE
Only build docs when files in the docs path change

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'docs/*'
 
 jobs:
   build:


### PR DESCRIPTION
This should change the behavior of the docs builder, there is no need to build on every push to master. 