### PR TITLE
News 15 / NC 22 compatibility

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@
 - Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 - Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>15.4.5</version>
+    <version>15.4.6</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>
@@ -51,7 +51,7 @@
         <lib>json</lib>
 
         <owncloud max-version="0" min-version="0"/>
-        <nextcloud min-version="20" max-version="21"/>
+        <nextcloud min-version="20" max-version="22"/>
     </dependencies>
 
     <background-jobs>


### PR DESCRIPTION
News 15 seems compatible with Nextcloud 22.
I tried myself and didn't find any problem.