### PR TITLE
Release 16.2.0-beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,18 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 
 ## [16.x.x]
 ### Changed
-- Updated "New Folder" and "All articles" icons to differentiate them from "Subscribe" and "All articles".
 
 ### Fixed
-- Mark the latest post in a feed as read when clicking on the right arrow key.
 
 # Releases
-## [16.2.0] - 2021-10-18
+## [16.2.0-beta2] - 2021-10-23
+### Changed
+- Updated "New Folder" and "All articles" icons to differentiate them from "Subscribe" and "All articles". (#1542)
+
+### Fixed
+- Mark the latest post in a feed as read when clicking on the right arrow key. (#1546)
+
+## [16.2.0-beta1] - 2021-10-18
 ### Changed
 - Add changelog and DCO notice to CONTRIBUTING.md (#1521)
 - Download feed logos via guzzle to have better error handling (#1533)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>16.2.0-beta1</version>
+    <version>16.2.0-beta2</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
Changed
- Updated "New Folder" and "All articles" icons to differentiate them from "Subscribe" and "All articles".

Fixed
- Mark the latest post in a feed as read when clicking on the right arrow key.