### PR TITLE
Release 16.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Fixed
 
 # Releases
+## [16.2.0] - 2021-11-03
+No notable changes compared to the beta versions.
+
 ## [16.2.0-beta2] - 2021-10-23
 ### Changed
 - Updated "New Folder" and "All articles" icons to differentiate them from "Subscribe" and "All articles". (#1542)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>16.2.0-beta2</version>
+    <version>16.2.0</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
No notable changes compared to the beta versions.

---

According to the release plan of Nextcloud there will be another release of Nextcloud 20 in November (11.11.21)
https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule
That will probably be the last release of NC20 and it will be EOL.