### PR TITLE
Release 16.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
-- Catch network errors while fetching feed logos. (#1570)
 
 # Releases
+## [16.2.1] - 2021-11-15
+### Fixed
+- Catch network errors while fetching feed logos. (#1572, #1570)
+
 ## [16.2.0] - 2021-11-03
 No notable changes compared to the beta versions.
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>16.2.0</version>
+    <version>16.2.1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
Fixed
- Catch network errors while fetching feed logos. (#1572, #1570)

No beta release needed due to the small change