### PR TITLE
Remove release drafter

### DIFF
--- a/.github/workflows/post-merge-tasks.yml
+++ b/.github/workflows/post-merge-tasks.yml
@@ -4,13 +4,6 @@ on:
     branches:
       - master
 jobs:
-  update-release-draft:
-    runs-on: ubuntu-latest
-    name: "Release Drafter"
-    steps:
-      - uses: release-drafter/release-drafter@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   php:
     runs-on: ubuntu-latest
     continue-on-error: false


### PR DESCRIPTION
I don't need it anymore, I prefer the integrate function by GitHub.