### PR TITLE
Release 17.0.0-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 
 ## [17.x.x]
 ### Changed
-- Drop support for Nextcloud 20
-- Use better sql commands, that were not possible with Nextcloud 20
 
 ### Fixed
 
 # Releases
+## [17.0.0-beta1]
+### Changed
+- Drop support for Nextcloud 20 (#1514)
+- Use better sql commands, that were not possible with Nextcloud 20 (#1514)
+- Add support for Nextcloud 23 (#1585)
+
 ## [16.2.1] - 2021-11-15
 ### Fixed
 - Catch network errors while fetching feed logos. (#1572, #1570)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -55,7 +55,7 @@ Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
         <lib>json</lib>
 
         <owncloud max-version="0" min-version="0"/>
-        <nextcloud min-version="21" max-version="22"/>
+        <nextcloud min-version="21" max-version="23"/>
     </dependencies>
 
     <background-jobs>


### PR DESCRIPTION
Changed
- Drop support for Nextcloud 20 (#1514)
- Use better sql commands, that were not possible with Nextcloud 20 (#1514)
- Add support for Nextcloud 23

Signed-off-by: Benjamin Brahmer <info@b-brahmer.de>