### PR TITLE
Fix catching connect exceptions while fetching feed logos #1570

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
+* Fix catching network errors while fetching feed logos. (#1601)
 
 # Releases
 ## [17.0.0]

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -382,7 +382,7 @@ class FeedFetcher implements IFeedFetcher
                 'An error occurred while trying to download the feed logo of {url}: {error}',
                 [
                 'url'   => $url,
-                'error' => $e->getResponse() ?? 'Unknown'
+                'error' => $e->getMessage() ?? 'Unknown'
                 ]
             );
         }


### PR DESCRIPTION
Display the message instead of the response when catching an exception during feed logo fetching. As there is no response and thus no method `getResponse()` in `ConnectException`, this fixes a "call to undefined method"-error that prevented feeds from fetching if fetching the logo resulted in a `ConnectException`.