### PR TITLE
Release 17.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,18 @@ The format is almost based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
-* Fix catching network errors while fetching feed logos. (#1601)
+
 
 # Releases
-## [17.0.0]
+## [17.0.1] - 2021-12-08
+### Fixed
+- Fix catching network errors while fetching feed logos. (#1601)
+
+## [17.0.0] - 2021-11-29
 ### Fixed
 - fix link-icon-overlap in mobile-view (#1579)
 
-## [17.0.0-beta1]
+## [17.0.0-beta1] - 2021-11-18
 ### Changed
 - Drop support for Nextcloud 20 (#1514)
 - Use better sql commands, that were not possible with Nextcloud 20 (#1514)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>17.0.0</version>
+    <version>17.0.1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
Fixed
- Fix catching network errors while fetching feed logos. (#1601)

Signed-off-by: Benjamin Brahmer <info@b-brahmer.de>