### PR TITLE
Fix only one item marked as read by Feed API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
+- Fix only one item marked as read by Feed API (#1687)
 
 # Releases
 ## [18.0.0] - 2022-02-23

--- a/lib/Controller/FeedApiController.php
+++ b/lib/Controller/FeedApiController.php
@@ -152,7 +152,7 @@ class FeedApiController extends ApiController
      */
     public function read(int $feedId, int $newestItemId): void
     {
-        $this->itemService->read($this->getUserId(), $feedId, $newestItemId);
+        $this->feedService->read($this->getUserId(), $feedId, $newestItemId);
     }
 
 

--- a/tests/Unit/Controller/FeedApiControllerTest.php
+++ b/tests/Unit/Controller/FeedApiControllerTest.php
@@ -284,7 +284,7 @@ class FeedApiControllerTest extends TestCase
 
     public function testRead()
     {
-        $this->itemService->expects($this->once())
+        $this->feedService->expects($this->once())
             ->method('read')
             ->with($this->userID,3,30);
 


### PR DESCRIPTION
I looked at #1544

And investigated the code a bit, it seems like the wrong service was called since we introduced the new controllers.
It didn't throw any errors because both read functions have the same signature but the parameters are used in a totally different way ...

Not tested yet only based on logical reading.