### PR TITLE
Fix FAQ url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Read this when you want to:
 * Disable all browser add-ons to make sure that it's not a plugin's fault (adblockers, especially cosmetic filters)
 * Clear your PHP opcode cache if you use any by restarting your webserver.
 * [Check if they have already been reported](https://github.com/nextcloud/news/issues?state=open)
-* [Check if your problem is covered in the FAQ section](https://github.com/nextcloud/news#faq)
+* [Check if your problem is covered in the FAQ section]( https://nextcloud.github.io/news/faq)
 
 ### Debugging issues
 * Enable debug mode in your **config/config.php**:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,4 +98,4 @@ For linting JavaScript, a [jshint file](https://github.com/nextcloud/news/blob/m
 When you commit your change, remember to sign off that you adhere to [DCO requirements](https://developercertificate.org/) as described by [Probot](https://probot.github.io/apps/dco/).
 
 ### Change log
-Before you create a pull request, please remember to add an entry to [CHANGELOG.md](https://github.com/nextcloud/news/blob/master/CHANGELOG.md), using the format [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Before you create a pull request, please remember to add an entry to [CHANGELOG.md](https://github.com/nextcloud/news/blob/HEAD/CHANGELOG.md), using the format [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).


### PR DESCRIPTION
Unfortuantely the contribution guide has a wrong URL for FAQ, I haven't found it myself. Found it in https://github.com/nextcloud/news/issues/1702#issuecomment-1071065698

How do I sign of my changes?