### PR TITLE
Fix updated api not returning any item after marking item as read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 - Add routes for starring/unstarring items by id
 
 ### Fixed
+- Fix updated api not returning any item after marking item as read (#1713)
 
 # Releases
 

--- a/lib/Db/FeedMapperV2.php
+++ b/lib/Db/FeedMapperV2.php
@@ -186,14 +186,16 @@ class FeedMapperV2 extends NewsMapperV2
             },
             $this->db->executeQuery($idBuilder->getSQL(), $idBuilder->getParameters())->fetchAll()
         );
-
+        $time = new Time();
         $builder = $this->db->getQueryBuilder();
         $builder->update(ItemMapperV2::TABLE_NAME)
             ->set('unread', $builder->createParameter('unread'))
+            ->set('last_modified', $builder->createParameter('last_modified'))
             ->andWhere('id IN (:idList)')
             ->andWhere('unread != :unread')
             ->setParameter('unread', false, IQueryBuilder::PARAM_BOOL)
-            ->setParameter('idList', $idList, IQueryBuilder::PARAM_INT_ARRAY);
+            ->setParameter('idList', $idList, IQueryBuilder::PARAM_INT_ARRAY)
+            ->setParameter('last_modified', $time->getMicroTime(), IQueryBuilder::PARAM_STR);
 
         return $this->db->executeStatement(
             $builder->getSQL(),

--- a/lib/Db/FolderMapperV2.php
+++ b/lib/Db/FolderMapperV2.php
@@ -128,13 +128,16 @@ class FolderMapperV2 extends NewsMapperV2
             return intval($value['id']);
         }, $this->db->executeQuery($idBuilder->getSQL(), $idBuilder->getParameters())->fetchAll());
 
+        $time = new Time();
         $builder = $this->db->getQueryBuilder();
         $builder->update(ItemMapperV2::TABLE_NAME)
             ->set('unread', $builder->createParameter('unread'))
+            ->set('last_modified', $builder->createParameter('last_modified'))
             ->andWhere('id IN (:idList)')
             ->andWhere('unread != :unread')
             ->setParameter('unread', false, IQueryBuilder::PARAM_BOOL)
-            ->setParameter('idList', $idList, IQueryBuilder::PARAM_INT_ARRAY);
+            ->setParameter('idList', $idList, IQueryBuilder::PARAM_INT_ARRAY)
+            ->setParameter('last_modified', $time->getMicroTime(), IQueryBuilder::PARAM_STR);
 
         return $this->db->executeStatement(
             $builder->getSQL(),

--- a/tests/Unit/Db/FeedMapperTest.php
+++ b/tests/Unit/Db/FeedMapperTest.php
@@ -49,6 +49,7 @@ class FeedMapperTest extends MapperTestUtility
         $feed2->resetUpdatedFields();
 
         $this->feeds = [$feed1, $feed2];
+
     }
 
     /**
@@ -519,13 +520,13 @@ class FeedMapperTest extends MapperTestUtility
             ->with('news_items')
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->exactly(2))
             ->method('createParameter')
             ->will($this->returnArgument(0));
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->exactly(2))
             ->method('set')
-            ->with('unread', 'unread')
+            ->withConsecutive(['unread', 'unread'], ['last_modified', 'last_modified'])
             ->will($this->returnSelf());
 
         $this->builder->expects($this->exactly(2))
@@ -533,11 +534,11 @@ class FeedMapperTest extends MapperTestUtility
             ->withConsecutive(['id IN (:idList)'], ['unread != :unread'])
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->exactly(2))
+        $this->builder->expects($this->exactly(3))
             ->method('setParameter')
-            ->withConsecutive(['unread', false], ['idList', [1, 2]])
+            ->withConsecutive(['unread', false], ['idList', [1, 2]], ['last_modified'])
             ->will($this->returnSelf());
-
+        
         $this->builder->expects($this->exactly(1))
             ->method('getSQL')
             ->will($this->returnValue('QUERY'));
@@ -616,7 +617,7 @@ class FeedMapperTest extends MapperTestUtility
             ->with('SQL QUERY')
             ->willReturn($result);
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->exactly(2))
             ->method('createParameter')
             ->will($this->returnArgument(0));
 
@@ -625,9 +626,9 @@ class FeedMapperTest extends MapperTestUtility
             ->with('news_items')
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->exactly(2))
             ->method('set')
-            ->with('unread', 'unread')
+            ->withConsecutive(['unread', 'unread'], ['last_modified', 'last_modified'])
             ->will($this->returnSelf());
 
         $this->builder->expects($this->exactly(2))
@@ -635,9 +636,9 @@ class FeedMapperTest extends MapperTestUtility
             ->withConsecutive(['id IN (:idList)'], ['unread != :unread'])
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->exactly(2))
+        $this->builder->expects($this->exactly(3))
             ->method('setParameter')
-            ->withConsecutive(['unread', false], ['idList', [1, 2]])
+            ->withConsecutive(['unread', false], ['idList', [1, 2]], ['last_modified'])
             ->will($this->returnSelf());
 
         $this->builder->expects($this->exactly(1))

--- a/tests/Unit/Db/FolderMapperTest.php
+++ b/tests/Unit/Db/FolderMapperTest.php
@@ -342,7 +342,7 @@ class FolderMapperTest extends MapperTestUtility
             ->with('SQL QUERY')
             ->willReturn($result);
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->exactly(2))
             ->method('createParameter')
             ->will($this->returnArgument(0));
 
@@ -351,9 +351,9 @@ class FolderMapperTest extends MapperTestUtility
             ->with('news_items')
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->exactly(2))
             ->method('set')
-            ->with('unread', 'unread')
+            ->withConsecutive(['unread', 'unread'], ['last_modified', 'last_modified'])
             ->will($this->returnSelf());
 
         $this->builder->expects($this->exactly(2))
@@ -361,9 +361,9 @@ class FolderMapperTest extends MapperTestUtility
             ->withConsecutive(['id IN (:idList)'], ['unread != :unread'])
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->exactly(2))
+        $this->builder->expects($this->exactly(3))
             ->method('setParameter')
-            ->withConsecutive(['unread', false], ['idList', [1, 2]])
+            ->withConsecutive(['unread', false], ['idList', [1, 2]], ['last_modified'])
             ->will($this->returnSelf());
 
         $this->builder->expects($this->exactly(1))
@@ -445,7 +445,7 @@ class FolderMapperTest extends MapperTestUtility
             ->with('SQL QUERY')
             ->willReturn($result);
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->exactly(2))
             ->method('createParameter')
             ->will($this->returnArgument(0));
 
@@ -454,9 +454,9 @@ class FolderMapperTest extends MapperTestUtility
             ->with('news_items')
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->exactly(2))
             ->method('set')
-            ->with('unread', 'unread')
+            ->withConsecutive(['unread', 'unread'], ['last_modified', 'last_modified'])
             ->will($this->returnSelf());
 
         $this->builder->expects($this->exactly(2))
@@ -464,9 +464,9 @@ class FolderMapperTest extends MapperTestUtility
             ->withConsecutive(['id IN (:idList)'], ['unread != :unread'])
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->exactly(2))
+        $this->builder->expects($this->exactly(3))
             ->method('setParameter')
-            ->withConsecutive(['unread', false], ['idList', [1, 2]])
+            ->withConsecutive(['unread', false], ['idList', [1, 2]], ['last_modified'])
             ->will($this->returnSelf());
 
         $this->builder->expects($this->exactly(1))


### PR DESCRIPTION
The updated items api is supposed to return updated items, the last modified date is used for that.

I tried to use the $time provided through dependency injection but for some reason it is null.

I don't really care if we can't use dep injection there, if I made a mistake though I would be happy to adjust it.