### PR TITLE
improve compatibility with postgres.

### DIFF
--- a/lib/Db/FeedMapperV2.php
+++ b/lib/Db/FeedMapperV2.php
@@ -52,7 +52,10 @@ class FeedMapperV2 extends NewsMapperV2
     public function findAllFromUser(string $userId, array $params = []): array
     {
         $builder = $this->db->getQueryBuilder();
-        $builder->select('feeds.*', $builder->func()->count('items.id', 'unreadCount'))
+        $builder->select('feeds.id', 'feeds.url', 'feeds.title', 'feeds.favicon_link', 'feeds.added',
+                         'feeds.folder_id', 'feeds.ordering', 'feeds.link', 'feeds.pinned',
+                         'feeds.update_error_count', 'feeds.last_update_error',
+                         $builder->func()->count('items.id', 'unreadCount'))
             ->from(static::TABLE_NAME, 'feeds')
             ->leftJoin(
                 'feeds',
@@ -62,7 +65,9 @@ class FeedMapperV2 extends NewsMapperV2
             )
             ->where('feeds.user_id = :user_id')
             ->andWhere('feeds.deleted_at = 0')
-            ->groupBy('feeds.id')
+            ->groupBy('feeds.id', 'feeds.url', 'feeds.title', 'feeds.favicon_link', 'feeds.added',
+                      'feeds.folder_id', 'feeds.ordering', 'feeds.link', 'feeds.pinned',
+                      'feeds.update_error_count', 'feeds.last_update_error')
             ->setParameter('unread', true, IQueryBuilder::PARAM_BOOL)
             ->setParameter('user_id', $userId);
 

--- a/tests/Unit/Db/FeedMapperTest.php
+++ b/tests/Unit/Db/FeedMapperTest.php
@@ -85,7 +85,9 @@ class FeedMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
                       ->method('select')
-                      ->with('feeds.*', $func)
+                      ->with('feeds.id',  'feeds.url', 'feeds.title', 'feeds.favicon_link', 'feeds.added',
+                         'feeds.folder_id', 'feeds.ordering', 'feeds.link', 'feeds.pinned',
+                         'feeds.update_error_count', 'feeds.last_update_error', $func)
                       ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
@@ -110,7 +112,9 @@ class FeedMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
                       ->method('groupby')
-                      ->with('feeds.id')
+                      ->with('feeds.id', 'feeds.url', 'feeds.title', 'feeds.favicon_link', 'feeds.added',
+                      'feeds.folder_id', 'feeds.ordering', 'feeds.link', 'feeds.pinned',
+                      'feeds.update_error_count', 'feeds.last_update_error')
                       ->will($this->returnSelf());
 
         $this->builder->expects($this->exactly(2))


### PR DESCRIPTION
Postgres doesn't allow grouping on columns from a select * and requires listing the columns for both the select and group by statement.

This is my attempt at solving #1290.

All of the official php tests passed for me with this patch. I hacked the github workflows to run tests when I pushed to my personal master branch. You should be able to see the github actions log at  https://github.com/detrout/nextcloud-news/tree/master

I didn't know of a better way of getting the tests to run than adding a commit to adjust the action a bit.

What else might be needed to do?