### PR TITLE
Fix malformed feeds (without GUIDs) stopping the update process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 
 ### Fixed
 - Fix import of items when feed does not exist (1742)
+- Fix malformed feeds (without GUIDs) stopping the update process (#1738)
 
 # Releases
 ## [18.0.1-beta2] - 2022-03-22

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -18,6 +18,7 @@ use Favicon\Favicon;
 use FeedIo\Feed\ItemInterface;
 use FeedIo\FeedInterface;
 use FeedIo\FeedIo;
+use FeedIo\Reader\ReadErrorException;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ConnectException;
@@ -233,6 +234,9 @@ class FeedFetcher implements IFeedFetcher
         $item = new Item();
         $item->setUnread(true);
         $item->setUrl($parsedItem->getLink());
+        if ($parsedItem->getPublicId() == null) {
+            throw new ReadErrorException("Malformed feed: item has no GUID");
+        }
         $item->setGuid($parsedItem->getPublicId());
         $item->setGuidHash(md5($item->getGuid()));
 

--- a/tests/Unit/Fetcher/FeedFetcherTest.php
+++ b/tests/Unit/Fetcher/FeedFetcherTest.php
@@ -579,7 +579,7 @@ class FeedFetcherTest extends TestCase
         $this->item_mock->expects($this->exactly(2))
             ->method('getTitle')
             ->will($this->returnValue($this->title));
-        $this->item_mock->expects($this->exactly(1))
+        $this->item_mock->expects($this->exactly(2))
             ->method('getPublicId')
             ->will($this->returnValue($this->guid));
         $this->item_mock->expects($this->exactly(1))

--- a/tests/integration/feeds.bats
+++ b/tests/integration/feeds.bats
@@ -22,6 +22,17 @@ teardown() {
   fi
 }
 
+@test "[$TESTSUITE] Add feed without GUIDs" {
+  run ./occ news:feed:add "$user" "$NO_GUID_FEED"
+  [ "$status" -ne 0 ]
+
+  if ! echo "$output" | grep "No parser can handle this stream"; then
+    ret_status=$?
+    echo "Malformed feed exception wasn't properly caught"
+    return $ret_status
+  fi
+}
+
 @test "[$TESTSUITE] List all" {
   ./occ news:feed:add "$user" "$NC_FEED" --title "Something-${BATS_SUITE_TEST_NUMBER}"
 

--- a/tests/integration/feeds/no_guid_feed.xml
+++ b/tests/integration/feeds/no_guid_feed.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+  <channel>
+    <generator>RSS Builder by B!Soft</generator>
+    <title>Joshua Wright Dot Net</title>
+    <link>http://www.joshuawright.net</link>
+    <description>This is a feed of the latest comic masterpiece from joshuawright.net</description>
+    <language>en</language>
+    <managingEditor>joshua.wright@live.com.au (Josh Wright)</managingEditor>
+    <webMaster>joshua.wright@live.com.au (Josh Wright)</webMaster>
+    <copyright>2016 JoshuaWright</copyright>
+    <item>
+      <title>Slack Wyrm 911 - Feeling better</title>
+      <pubDate>Wed, 13 Apr 2022 09:07:01 +0100</pubDate>
+      <link>https://joshuawright.net/slack-wyrm-911.html</link>
+      <description><![CDATA[]]></description>
+    </item>
+    <item>
+      <title>Slack Wyrm 910 - Cake trip</title>
+      <pubDate>Mon, 11 Apr 2022 08:52:54 +0100</pubDate>
+      <link>https://joshuawright.net/slack-wyrm-910.html</link>
+      <description><![CDATA[]]></description>
+    </item>
+    <item>
+      <title>Slack Wyrm 909 - Cake time</title>
+      <pubDate>Fri, 8 Apr 2022 09:29:32 +0100</pubDate>
+      <description><![CDATA[]]></description>
+    </item>
+    <item>
+      <title>Slack Wyrm 908 - Dragons Lair</title>
+      <pubDate>Wed, 6 Apr 2022 09:00:13 +0100</pubDate>
+      <link>https://joshuawright.net/slack-wyrm-908.html</link>
+      <description><![CDATA[]]></description>
+    </item>
+    <item>
+      <title>Slack Wyrm 907 - Ten feet tall</title>
+      <pubDate>Mon, 4 Apr 2022 15:12:51 +0100</pubDate>
+      <link>https://joshuawright.net/slack-wyrm-907.html</link>
+      <description><![CDATA[]]></description>
+    </item>
+    <item>
+      <title>Slack Wyrm 906 - True self</title>
+      <pubDate>Fri, 1 Apr 2022 09:28:06 +1100</pubDate>
+      <link>https://joshuawright.net/slack-wyrm-906.html</link>
+      <description><![CDATA[]]></description>
+    </item>
+    <item>
+      <title>Slack Wyrm 905 - Drink up</title>
+      <pubDate>Wed, 30 Mar 2022 11:07:49 +1100</pubDate>
+      <link>https://joshuawright.net/slack-wyrm-905.html</link>
+      <description><![CDATA[]]></description>
+    </item>
+    <item>
+      <title>Slack Wyrm 904 - Marvellous medicine</title>
+      <pubDate>Mon, 28 Mar 2022 09:02:44 +1100</pubDate>
+      <link>https://joshuawright.net/slack-wyrm-904.html</link>
+      <description><![CDATA[]]></description>
+    </item>
+    <item>
+      <title>Slack Wyrm 903 - Golden still</title>
+      <pubDate>Fri, 25 Mar 2022 09:48:06 +1100</pubDate>
+      <link>https://joshuawright.net/slack-wyrm-903.html</link>
+      <description><![CDATA[]]></description>
+    </item>
+    <item>
+      <title>Slack Wyrm 902 - Janet the genius</title>
+      <pubDate>Wed, 23 Mar 2022 09:30:47 +1100</pubDate>
+      <link>https://joshuawright.net/slack-wyrm-902.html</link>
+      <description><![CDATA[]]></description>
+    </item>
+    <item>
+      <title>Slack Wyrm 901 - Bye bye Bucky</title>
+      <pubDate>Mon, 21 Mar 2022 09:01:36 +1100</pubDate>
+      <link>https://joshuawright.net/slack-wyrm-901.html</link>
+      <description><![CDATA[]]></description>
+    </item>
+  </channel>
+</rss>

--- a/tests/integration/helpers/settings.bash
+++ b/tests/integration/helpers/settings.bash
@@ -1,3 +1,4 @@
 user=admin
 NC_FEED="https://nextcloud.com/blog/static-feed/"
 HEISE_FEED="https://www.heise.de/rss/heise-atom.xml"
+NO_GUID_FEED="https://raw.githubusercontent.com/nextcloud/news/master/tests/integration/feeds/no_guid_feed.xml"


### PR DESCRIPTION
Fixes #1738

Regarding tests, I couldn't find an example on how to implement tests for this feature. I searched for other pull requests but couldn't find any that added a test. This feature would need to fetch a feed from a local file (as currently malformed feeds on the internet may be fixed in the future). If anyone has an example or guidance on how to implement tests for this fix, I'll try to implement them.