### PR TITLE
Fix import of items when feed does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
+- Fix import of items when feed does not exist (1742)
 
 # Releases
 ## [18.0.1-beta2] - 2022-03-22

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -75,8 +75,6 @@ class ImportService
      */
     public function importArticles(string $userId, array $json): ?\OCP\AppFramework\Db\Entity
     {
-        $url = 'http://nextcloud/nofeed';
-
         // build assoc array for fast access
         $feeds = $this->feedService->findAllForUser($userId);
         $feedsDict = [];
@@ -90,21 +88,22 @@ class ImportService
         // if the feed does not exist, create a separate feed for them
         foreach ($json as $entry) {
             $item = Item::fromImport($entry);
-            $feedLink = $entry['feedLink'];  // this is not set on the item yet
+            $feedLink = $entry['feedLink'];  // this is not set on the item
 
             if (array_key_exists($feedLink, $feedsDict)) {
                 $feed = $feedsDict[$feedLink];
             } else {
+                $this->logger->info("Creating new feed for import of {url}", ['url' => $feedLink]);
                 $createdFeed = true;
                 $feed = new Feed();
                 $feed->setUserId($userId)
-                     ->setUrlHash(md5($url))
-                     ->setLink($url)
-                     ->setUrl($url)
-                     ->setTitle('Articles without feed')
+                     ->setUrlHash(md5($feedLink))
+                     ->setLink($feedLink)
+                     ->setUrl($feedLink)
+                     ->setTitle('No Title')
                      ->setAdded(time())
                      ->setFolderId(null)
-                     ->setPreventUpdate(true);
+                     ->setPreventUpdate(false);
 
                 /** @var Feed $feed */
                 $feed = $this->feedService->insert($feed);
@@ -121,6 +120,6 @@ class ImportService
             return null;
         }
 
-        return $this->feedService->findByURL($userId, $url);
+        return $this->feedService->findByURL($userId, $feedLink);
     }
 }


### PR DESCRIPTION
This fixes #1562

The issue with the old logic was that it would create a new feed for each item as the feedLink coming from the json would never exist in the array of feeds.
Because the feed would be added with this placeholder url.

I don't see a need not to use this placeholder url and also no reason to disable updates.

I tested this by adding a feed, exporting the opml and the items.

1. import of items only, creates the feed, just the title is "No Title" as the json does not contain that information.
2. import opml first then items, the feed exists with title and items already before the import, importing the items doesn't cause any problems.