### PR TITLE
check if variable is null before striping tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 
 ### Fixed
 - Fix updated api not returning any item after marking item as read (#1713)
+- Fix deprecation warning for strip_tags() on a null value (#1766)
 
 # Releases
 

--- a/lib/Db/Item.php
+++ b/lib/Db/Item.php
@@ -383,8 +383,10 @@ class Item extends Entity implements IAPI, \JsonSerializable
 
     public function setAuthor(string $author = null): self
     {
-        $author = strip_tags($author);
-
+        if (!is_null($author)) {
+            $author = strip_tags($author);
+        }
+        
         if ($this->author !== $author) {
             $this->author = $author;
             $this->markFieldUpdated('author');
@@ -549,8 +551,10 @@ class Item extends Entity implements IAPI, \JsonSerializable
 
     public function setTitle(string $title = null): self
     {
-        $title = trim(strip_tags($title));
-
+        if (!is_null($title)) {
+            $title = trim(strip_tags($title));
+        }
+        
         if ($this->title !== $title) {
             $this->title = $title;
             $this->markFieldUpdated('title');


### PR DESCRIPTION
My suggestion to fix #1765 
To keep the functionality the same.