### PR TITLE
GUI Update: Select correct item in feed when loading feed with Newest First or Default Ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Fixed
 - Fix updated api not returning any item after marking item as read (#1713)
 - Fix deprecation warning for strip_tags() on a null value (#1766)
+- Fix selected item being set incorrectly when using default ordering or newest first ordering (#1324)
 
 # Releases
 

--- a/js/controller/ContentController.js
+++ b/js/controller/ContentController.js
@@ -18,7 +18,7 @@ app.controller('ContentController', function (Publisher, FeedResource, ItemResou
     // distribute data to models based on key
     Publisher.publishAll(data);
 
-    var getOrdering = function () {
+    var isOldestFirst = function () {
         var ordering = SettingsResource.get('oldestFirst');
 
         if (self.isFeed()) {
@@ -35,13 +35,11 @@ app.controller('ContentController', function (Publisher, FeedResource, ItemResou
 
     this.getFirstItem = function () {
         var orderedItems = this.getItems();
-        var item = orderedItems[orderedItems.length - 1];
-        var firstItem = orderedItems[0];
-        // If getOrdering == 1, then the sorting is set to
-        // newest first. So, item should be the first item
-        //
-        if (getOrdering()) {
-            item = firstItem;
+        var item = orderedItems[0];
+        var lastItem = orderedItems[orderedItems.length - 1];
+        // If isOldestFirst is set, item should be the last item
+        if (isOldestFirst()) {
+            item = lastItem;
         }
         if (item === undefined) {
             return undefined;
@@ -152,7 +150,7 @@ app.controller('ContentController', function (Publisher, FeedResource, ItemResou
         return $route.current.$$route.type === FEED_TYPE.FEED;
     };
 
-    this.oldestFirst = getOrdering();
+    this.oldestFirst = isOldestFirst();
 
     this.autoPage = function () {
         if (this.isNothingMoreToAutoPage) {


### PR DESCRIPTION
Quick update to ContentController.js to correctly set the active element when newest first or default ordering is active for a feed or view.

Should resolve #1324 by making behavior match expectations