### PR TITLE
Release 18.1.0-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,22 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 # Unreleased
 ## [18.x.x]
 ### Changed
-- Add routes for starring/unstarring items by id
-- Improve styling of tables in articles
-- Allow fetching feeds that omit guid by using link as stand-in
+
+### Fixed
+
+# Releases
+## [18.1.0-beta1]
+### Changed
+- Add API v1.3 adding routes for starring/unstarring items by id and general fixes (#1727)
+  https://nextcloud.github.io/news/api/api-v1-3/
+- Improve styling of tables in articles (#1779)
+- Allow fetching feeds that omit guid by using link as stand-in (#1785)
 
 ### Fixed
 - Fix updated api not returning any item after marking item as read (#1713)
 - Fix deprecation warning for strip_tags() on a null value (#1766)
 - Fix selected item being set incorrectly when using default ordering or newest first ordering (#1324)
 - Fix doubling the height of the content area (#1796)
-
-# Releases
 
 ## [18.0.1] - 2022-04-22
 No major changes since the beta versions.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>18.0.1</version>
+    <version>18.1.0-beta1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>

--- a/docs/api/api-v1-3.md
+++ b/docs/api/api-v1-3.md
@@ -354,7 +354,7 @@ Deletes a feed with the id feedId and all of its  items
 
 #### Rename a feed
 
-* **Status**: Implemented in 1.807
+* **Status**: Implemented in News 1.807
 * **Method**: POST
 * **Route**: /feeds/{feedId}/rename
 * **Parameters**:
@@ -524,7 +524,7 @@ This is used to stay up to date.
 * **Returns**: nothing
 
 #### Mark multiple items as read
-* **Status**: Implemented in 1.2
+* **Status**: Implemented in API 1.2
 * **Method**: POST
 * **Route**: /items/read/multiple
 * **Parameters**:
@@ -545,7 +545,7 @@ This is used to stay up to date.
 * **Returns**: nothing
 
 #### Mark multiple items as unread
-* **Status**: Implemented in 1.2
+* **Status**: Implemented in API 1.2
 * **Method**: POST
 * **Route**: /items/unread/multiple
 * **Parameters**:
@@ -557,7 +557,7 @@ This is used to stay up to date.
 * **Returns**: nothing
 
 #### Mark an item as starred
-* **Status**: Implemented in 1.3
+* **Status**: Implemented in API 1.3
 * **Method**: POST
 * **Route**: /items/{itemId}/star
 * **Parameters**: none
@@ -566,7 +566,7 @@ This is used to stay up to date.
 * **Returns**: nothing
 
 #### Mark multiple items as starred
-* **Status**: Implemented in 1.3
+* **Status**: Implemented in API 1.3
 * **Method**: POST
 * **Route**: /items/star/multiple
 * **Parameters**:
@@ -578,7 +578,7 @@ This is used to stay up to date.
 * **Returns**: nothing
 
 #### Mark an item as unstarred
-* **Status**: Implemented in 1.3
+* **Status**: Implemented in API 1.3
 * **Method**: POST
 * **Route**: /items/{itemId}/unstar
 * **Parameters**: none
@@ -587,7 +587,7 @@ This is used to stay up to date.
 * **Returns**: nothing
 
 #### Mark multiple items as unstarred
-* **Status**: Implemented in 1.3
+* **Status**: Implemented in API 1.3
 * **Method**: POST
 * **Route**: /items/unstar/multiple
 * **Parameters**:
@@ -632,7 +632,7 @@ This [implementation in Python](https://github.com/nextcloud/news-updater) shoul
 #### Trigger cleanup before update
 This is used to clean up the database. It deletes folders and feeds that are marked for deletion
 
-* **Status**: Implemented in 1.601
+* **Status**: Implemented in News 1.601
 * **Authentication**: Requires admin user
 * **Method**: GET
 * **Route**: /cleanup/before-update
@@ -644,7 +644,7 @@ This is used to clean up the database. It deletes folders and feeds that are mar
 
 #### Get feed ids and usernames for all feeds
 
-* **Status**: Implemented in 1.203
+* **Status**: Implemented in News 1.203
 * **Authentication**: Requires admin user
 * **Method**: GET
 * **Route**: /feeds/all
@@ -668,7 +668,7 @@ This is used to clean up the database. It deletes folders and feeds that are mar
 
 #### Trigger a feed update
 
-* **Status**: Implemented in 1.601
+* **Status**: Implemented in News 1.601
 * **Authentication**: Requires admin user
 * **Method**: GET
 * **Route**: /feeds/update
@@ -690,7 +690,7 @@ This is used to clean up the database. It deletes folders and feeds that are mar
 #### Trigger cleanup after update
 This is used to clean up the database. It removes old read articles which are not starred
 
-* **Status**: Implemented in 1.601
+* **Status**: Implemented in News 1.601
 * **Authentication**: Requires admin user
 * **Method**: GET
 * **Route**: /cleanup/after-update
@@ -721,7 +721,7 @@ This API can be used to display warnings and errors in your client if the web ap
 
 #### Get the status
 
-* **Status**: Implemented in 5.2.4
+* **Status**: Implemented in News 5.2.4
 * **Method**: GET
 * **Route**: /status
 * **Parameters**: none
@@ -757,7 +757,7 @@ DEPRECATED: This API is deprecated, use the Nextcloud APIs instead.
 
 #### Get the status
 
-* **Status**: Implemented in 6.0.5
+* **Status**: Implemented in News 6.0.5
 * **Method**: GET
 * **Route**: /user
 * **Parameters**: none

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -11,7 +11,8 @@ News offers an API that can be used by clients to synchronize with the server.
 There are two API declarations, so far only V1 has been fully implemented.
 Work on V2 has started with low priority.
 
-- [API-V1](api/api-v1.md)
+- [API-V1.2](api/api-v1-2.md)
+- [API-V1.3](api/api-v1-3.md)
 - [API-V2](api/api-v2.md)
 
 ## Coding Style Guidelines

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,8 @@ nav:
     - Plugins: features/plugins.md
     - Themes: features/themes.md
   - REST API:
-    - API v1: api/api-v1.md
+    - API v1.2: api/api-v1-2.md
+    - API v1.3: api/api-v1-3.md
     - API v2: api/api-v2.md
   - maintenance.md
 


### PR DESCRIPTION
### Changed
- Add API v1.3 adding routes for starring/unstarring items by id and general fixes (#1727)
  https://nextcloud.github.io/news/api/api-v1-3/
- Improve styling of tables in articles (#1779)
- Allow fetching feeds that omit guid by using link as stand-in (#1785)

### Fixed
- Fix updated api not returning any item after marking item as read (#1713)
- Fix deprecation warning for strip_tags() on a null value (#1766)
- Fix selected item being set incorrectly when using default ordering or newest first ordering (#1324)
- Fix doubling the height of the content area (#1796)