### PR TITLE
Release 18.1.0-beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Fixed
 
 # Releases
-## [18.1.0-beta1]
+## [18.1.0-beta2] - 2022-05-31
+### Changed
+-  If items of feed do not provide an author fallback to feed author (#1803) 
+
+## [18.1.0-beta1] - 2022-05-29
 ### Changed
 - Add API v1.3 adding routes for starring/unstarring items by id and general fixes (#1727)
   https://nextcloud.github.io/news/api/api-v1-3/

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>18.1.0-beta1</version>
+    <version>18.1.0-beta2</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
### Changed
-  If items of feed do not provide an author fallback to feed author (#1803)

