### PR TITLE
Allow feeds that produce protocol-less feed URLs to be fetched.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 # Unreleased
 ## [18.x.x]
 ### Changed
--  If items of feed do not provide an author fallback to feed author (#1803) 
+-  Feed URLs from feed fetcher that omit protocol now assume https (#1403)
 
 ### Fixed
 

--- a/lib/Db/Feed.php
+++ b/lib/Db/Feed.php
@@ -607,6 +607,12 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     public function setUrl(string $url): Feed
     {
         $url = trim($url);
+        if (strpos($url, '//') === 0) {
+            // NB: we "shouldn't get here as FeedService should correct, but this is a failsafe
+            // Would like to lof here, but this class isn't hooked up for logging and FeedService is
+            // So primary check and fix is there, and this failsafe is here
+            $url = 'https:' . $url;
+        }
         if (strpos($url, 'http') === 0 && $this->url !== $url) {
             $this->url = $url;
             $this->setUrlHash(md5($url));

--- a/lib/Service/FeedServiceV2.php
+++ b/lib/Service/FeedServiceV2.php
@@ -57,6 +57,13 @@ class FeedServiceV2 extends Service
      */
     protected $explorer;
 
+
+    /**
+     * Logger Interface
+     * @var LoggerInterface
+     */
+    protected $logger;
+
     /**
      * FeedService constructor.
      *
@@ -81,6 +88,7 @@ class FeedServiceV2 extends Service
         $this->itemService = $itemService;
         $this->explorer    = $explorer;
         $this->purifier    = $purifier;
+        $this->logger      = $logger;
     }
 
     /**
@@ -201,6 +209,20 @@ class FeedServiceV2 extends Service
             if ($feeds !== []) {
                 $feedUrl = array_shift($feeds);
             }
+        }
+
+        if (strpos($feedUrl, '//') === 0) {
+            // Feed URL starts with `//` no protocol specified, assume https
+            // Feeds providing protocall-less urls should accept both http and https,
+            // and https is prefered.
+            $this->logger->debug(
+                "Feed:{title} Url:{url} Missing protocol, assuming `https`",
+                [
+                'title' => $title,
+                'url'    => $feedUrl
+                ]
+            );
+            $feedUrl = 'https:' . $feedUrl;
         }
 
         try {


### PR DESCRIPTION
As noted in nextcloud/news#1403 some feeds produce a protocol-less url for the feed as a
sign that they should be fetched as http or https at the consumers discretion.

this change adds that discretion by assuming a url that begins `//` is a protocol-less
http/https feed and chooses the https option.