### PR TITLE
Fix/php8.1 depreciation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
+- fix PHP 8.1 deprecations (#1861)
+- document api item types (#1861)
 
 # Releases
 ## [18.1.1] - 2022-08-12

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
     "phpstan/phpstan-strict-rules": "^1.3.0",
     "phpstan/phpstan-phpunit": "^1.0.0",
     "phpstan/extension-installer": "^1.1.0",
+    "phpstan/phpstan-deprecation-rules": "^1.0",
     "guzzlehttp/guzzle": "^7.3.0",
     "doctrine/dbal": "^3.4.1",
     "symfony/console": "^4.4.19",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be4b7c96428a2a97bc7b232d8f1c66f9",
+    "content-hash": "9b976f8d731e7bdeb9206e114975dd04",
     "packages": [
         {
             "name": "arthurhoaro/favicon",
@@ -1332,6 +1332,56 @@
                 }
             ],
             "time": "2022-07-20T09:57:31+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-deprecation-rules",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
+                "reference": "e5ccafb0dd8d835dd65d8d7a1a0d2b1b75414682"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/e5ccafb0dd8d835dd65d8d7a1a0d2b1b75414682",
+                "reference": "e5ccafb0dd8d835dd65d8d7a1a0d2b1b75414682",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpstan": "^1.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.0.0"
+            },
+            "time": "2021-09-23T11:02:21+00:00"
         },
         {
             "name": "phpstan/phpstan-doctrine",

--- a/docs/api/api-v1-2.md
+++ b/docs/api/api-v1-2.md
@@ -399,6 +399,30 @@ The following attributes are **not sanitized** meaning: including them in your w
 * **mediaThumbnail**
 * **mediaDescription**
 
+#### Types
+| Name             | Default | Types        |
+|------------------|---------|--------------|
+| author           | null    | string\|null |
+| body             |         | string\|null |
+| contentHash      |         | string\|null |
+| enclosureLink    |         | string\|null |
+| enclosureMime    |         | string\|null |
+| feedId           |         | int          |
+| fingerprint      |         | string\|null |
+| guid             |         | string       |
+| guidHash         |         | string       |
+| id               |         | int          |
+| lastModified     | \"0\"   | string\|null |
+| mediaDescription |         | string\|null |
+| mediaThumbnail   |         | string\|null |
+| pubDate          |         | int\|null    |
+| rtl              | false   | bool         |
+| starred          | false   | bool         |
+| title            |         | string\|null |
+| unread           | false   | bool         |
+| updatedDate      |         | string\|null |
+| url              |         | string\|null |
+    
 #### Get items
 * **Status**: Implemented
 * **Method**: GET

--- a/docs/api/api-v1-3.md
+++ b/docs/api/api-v1-3.md
@@ -399,6 +399,30 @@ The following attributes are **not sanitized** meaning: including them in your w
 * **mediaThumbnail**
 * **mediaDescription**
 
+#### Types
+| Name             | Default | Types        |
+|------------------|---------|--------------|
+| author           | null    | string\|null |
+| body             |         | string\|null |
+| contentHash      |         | string\|null |
+| enclosureLink    |         | string\|null |
+| enclosureMime    |         | string\|null |
+| feedId           |         | int          |
+| fingerprint      |         | string\|null |
+| guid             |         | string       |
+| guidHash         |         | string       |
+| id               |         | int          |
+| lastModified     | \"0\"   | string\|null |
+| mediaDescription |         | string\|null |
+| mediaThumbnail   |         | string\|null |
+| pubDate          |         | int\|null    |
+| rtl              | false   | bool         |
+| starred          | false   | bool         |
+| title            |         | string\|null |
+| unread           | false   | bool         |
+| updatedDate      |         | string\|null |
+| url              |         | string\|null |
+
 #### Get items
 * **Status**: Implemented
 * **Method**: GET

--- a/lib/Db/Item.php
+++ b/lib/Db/Item.php
@@ -170,10 +170,9 @@ class Item extends Entity implements IAPI, \JsonSerializable
             ? implode('', $this->getCategories())
             : '';
 
+        $stripedBody = "";
         if (!is_null($this->getBody())) {
             $stripedBody = strip_tags($this->getBody());
-        } else {
-            $stripedBody = "";
         }
         
         $input_list = array($stripedBody, $this->getAuthor(), $this->getTitle(), $categoriesString);
@@ -181,17 +180,14 @@ class Item extends Entity implements IAPI, \JsonSerializable
         $search_string = "";
 
         foreach ($input_list as $value) {
-            if (is_null($value)) {
-                $search_string .= "";
-            } else {
+            if (!is_null($value)) {
                 $search_string .= html_entity_decode($value);
             }
         }
 
         $search_string .= $this->getUrl();
-        $search_string .= 'UTF-8';
 
-        $this->setSearchIndex(mb_strtolower($search_string));
+        $this->setSearchIndex(mb_strtolower($search_string, 'UTF-8'));
         $this->setFingerprint($this->computeFingerprint());
         $this->setContentHash($this->computeContentHash());
     }
@@ -358,6 +354,9 @@ class Item extends Entity implements IAPI, \JsonSerializable
      */
     public function getCategories(): ?array
     {
+        if (is_null($this->getCategoriesJson())) {
+            return null;
+        }
         return json_decode($this->getCategoriesJson());
     }
 
@@ -606,6 +605,10 @@ class Item extends Entity implements IAPI, \JsonSerializable
 
     public function setUrl(string $url = null): self
     {
+        if (is_null($url)) {
+            return $this;
+        }
+        
         $url = trim($url);
         if ((strpos($url, 'http') === 0 || strpos($url, 'magnet') === 0)
             && $this->url !== $url
@@ -613,7 +616,7 @@ class Item extends Entity implements IAPI, \JsonSerializable
             $this->url = $url;
             $this->markFieldUpdated('url');
         }
-
+    
         return $this;
     }
 

--- a/lib/Db/Item.php
+++ b/lib/Db/Item.php
@@ -170,16 +170,28 @@ class Item extends Entity implements IAPI, \JsonSerializable
             ? implode('', $this->getCategories())
             : '';
 
-        $this->setSearchIndex(
-            mb_strtolower(
-                html_entity_decode(strip_tags($this->getBody())) .
-                html_entity_decode($this->getAuthor()) .
-                html_entity_decode($this->getTitle()) .
-                html_entity_decode($categoriesString) .
-                $this->getUrl(),
-                'UTF-8'
-            )
-        );
+        if (!is_null($this->getBody())) {
+            $stripedBody = strip_tags($this->getBody());
+        } else {
+            $stripedBody = "";
+        }
+        
+        $input_list = array($stripedBody, $this->getAuthor(), $this->getTitle(), $categoriesString);
+
+        $search_string = "";
+
+        foreach ($input_list as $value) {
+            if (is_null($value)){
+                $search_string .= "";
+            } else {
+                html_entity_decode($value);
+            }
+        }
+
+        $search_string .= $this->getUrl();
+        $search_string .= 'UTF-8';
+
+        $this->setSearchIndex(mb_strtolower($search_string));
         $this->setFingerprint($this->computeFingerprint());
         $this->setContentHash($this->computeContentHash());
     }

--- a/lib/Db/Item.php
+++ b/lib/Db/Item.php
@@ -181,7 +181,7 @@ class Item extends Entity implements IAPI, \JsonSerializable
         $search_string = "";
 
         foreach ($input_list as $value) {
-            if (is_null($value)){
+            if (is_null($value)) {
                 $search_string .= "";
             } else {
                 html_entity_decode($value);

--- a/lib/Db/Item.php
+++ b/lib/Db/Item.php
@@ -184,7 +184,7 @@ class Item extends Entity implements IAPI, \JsonSerializable
             if (is_null($value)) {
                 $search_string .= "";
             } else {
-                html_entity_decode($value);
+                $search_string .= html_entity_decode($value);
             }
         }
 

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -354,9 +354,14 @@ class FeedFetcher implements IFeedFetcher
      */
     protected function getFavicon(FeedInterface $feed, string $url)
     {
+        $favicon = null;
         // trim the string because authors do funny things
-        $favicon = trim($feed->getLogo());
-
+        $feed_logo = $feed->getLogo();
+        
+        if (!is_null($feed_logo)) {
+            $favicon = trim($feed_logo);
+        }
+        
         ini_set('user_agent', 'NextCloud-News/1.0');
 
         $base_url = new Net_URL2($url);

--- a/lib/Utility/OPMLExporter.php
+++ b/lib/Utility/OPMLExporter.php
@@ -90,11 +90,21 @@ class OPMLExporter
     protected function createFeedOutline(Feed $feed, DOMDocument $document)
     {
         $feedOutline = $document->createElement('outline');
-        $feedOutline->setAttribute('title', $feed->getTitle());
-        $feedOutline->setAttribute('text', $feed->getTitle());
-        $feedOutline->setAttribute('type', 'rss');
-        $feedOutline->setAttribute('xmlUrl', $feed->getUrl());
-        $feedOutline->setAttribute('htmlUrl', $feed->getLink());
+        $attributes = [
+            ['title', $feed->getTitle()],
+            ['text', $feed->getTitle()],
+            ['type', 'rss'],
+            ['xmlUrl', $feed->getUrl()],
+            ['htmlUrl', $feed->getLink()],
+        ];
+
+        foreach ($attributes as $attribute) {
+            if (is_null($attribute[1])) {
+                $feedOutline->setAttribute($attribute[0], "");
+            } else {
+                $feedOutline->setAttribute($attribute[0], $attribute[1]);
+            }
+        }
 
         return $feedOutline;
     }

--- a/tests/Unit/Db/ItemTest.php
+++ b/tests/Unit/Db/ItemTest.php
@@ -317,6 +317,18 @@ class ItemTest extends TestCase
         $this->assertEquals($expected, $item->getSearchIndex());
     }
 
+    public function testSearchIndexNull()
+    {
+        $item = new Item();
+        $item->setBody('<a>somEth&auml;ng</a>');
+        $item->setUrl('http://link');
+        $item->setAuthor(null);
+        $item->setTitle('<a>t&auml;tle</a>');
+        $item->setCategories(['food', 'travel']);
+        $item->generateSearchIndex();
+        $expected = 'somethängtätlefoodtravelhttp://link';
+        $this->assertEquals($expected, $item->getSearchIndex());
+    }
 
     public function testFromImport()
     {


### PR DESCRIPTION
This is supposed to fix all the deprication warnings of php 8.1 that I can find. It seems like mainly to be that you can't pass null to a method that expects a string. Old behaviour of these methods was to interpret null as `""` which then is usually also the output.

This will change the api behavior same like the change for the author did. Even though it was never declared I think it is fair to put this into news 19.0.0 as major change.

To fix the docs gap I also checked which attributes of an item are exposed via the api sorted alphabetically and added default + type info. Most types default will probably be null. But I didn't want to put that because I wasn't sure.