### PR TITLE
Fix deprecation warnings from Nextcloud.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Fixed
 - fix PHP 8.1 deprecations (#1861)
 - document api item types (#1861)
+- Fix deprecation warnings from Nextcloud server (#1869)
 
 # Releases
 ## [18.1.1] - 2022-08-12

--- a/lib/Cron/UpdaterJob.php
+++ b/lib/Cron/UpdaterJob.php
@@ -11,7 +11,8 @@
 
 namespace OCA\News\Cron;
 
-use OC\BackgroundJob\TimedJob;
+use OCP\BackgroundJob\TimedJob;
+use OCP\AppFramework\Utility\ITimeFactory;
 
 use OCA\News\AppInfo\Application;
 use OCA\News\Service\StatusService;
@@ -35,10 +36,12 @@ class UpdaterJob extends TimedJob
     private $updaterService;
 
     public function __construct(
+        ITimeFactory $time,
         IConfig $config,
         StatusService $status,
         UpdaterService $updaterService
     ) {
+        parent::__construct($time);
         $this->config = $config;
         $this->statusService = $status;
         $this->updaterService = $updaterService;
@@ -49,7 +52,7 @@ class UpdaterJob extends TimedJob
             Application::DEFAULT_SETTINGS['updateInterval']
         );
 
-        parent::setInterval($interval);
+        $this->setInterval($interval);
     }
 
     /**

--- a/lib/Db/NewsMapperV2.php
+++ b/lib/Db/NewsMapperV2.php
@@ -100,7 +100,7 @@ abstract class NewsMapperV2 extends QBMapper
                     ->setParameter('deleted_at', $oldestDelete);
         }
 
-        $builder->execute();
+        $builder->executeStatement();
     }
 
     /**

--- a/lib/Migration/Version150005Date20201009192341.php
+++ b/lib/Migration/Version150005Date20201009192341.php
@@ -36,7 +36,7 @@ class Version150005Date20201009192341 extends SimpleMigrationStep {
         $qb->update('news_feeds')
             ->set('folder_id', $qb->createPositionalParameter(null, IQueryBuilder::PARAM_NULL))
             ->where('folder_id = 0')
-            ->execute();
+            ->executeStatement();
 
         $feed_name = $this->connection->getQueryBuilder()->getTableName('news_feeds');
         $folder_name = $this->connection->getQueryBuilder()->getTableName('news_folders');

--- a/tests/Unit/Db/NewsMapperTest.php
+++ b/tests/Unit/Db/NewsMapperTest.php
@@ -169,7 +169,7 @@ class NewsMapperTest extends TestCase
             ->will($this->returnSelf());
 
         $qb->expects($this->once())
-            ->method('execute');
+            ->method('executeStatement');
 
         $result = $this->class->purgeDeleted(null, null);
     }
@@ -202,7 +202,7 @@ class NewsMapperTest extends TestCase
             ->will($this->returnSelf());
 
         $qb->expects($this->once())
-            ->method('execute');
+            ->method('executeStatement');
 
         $result = $this->class->purgeDeleted('jack', null);
     }
@@ -235,7 +235,7 @@ class NewsMapperTest extends TestCase
             ->will($this->returnSelf());
 
         $qb->expects($this->once())
-            ->method('execute');
+            ->method('executeStatement');
 
         $result = $this->class->purgeDeleted(null, 1);
     }
@@ -268,7 +268,7 @@ class NewsMapperTest extends TestCase
             ->will($this->returnSelf());
 
         $qb->expects($this->once())
-            ->method('execute');
+            ->method('executeStatement');
 
         $result = $this->class->purgeDeleted('jack', 1);
     }


### PR DESCRIPTION
We were using the OC\ Namespace so I changed that and also checked the docs again and adjusted the code.

the execute() command is deprecated, I also changed it in the migration I think that is not problematic as it doesn't change the content only the method that is used.