### PR TITLE
Fix when marking all items as read, all items of the user are used in the sql query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
-- fix PHP 8.1 deprecations (#1861)
-- document api item types (#1861)
+- Fix PHP 8.1 deprecations (#1861)
+- Document api item types (#1861)
 - Fix deprecation warnings from Nextcloud server (#1869)
+- Fix when marking all items as read, all items of the user are used in the sql query (#1873)
 
 # Releases
 ## [18.1.1] - 2022-08-12

--- a/lib/Db/ItemMapperV2.php
+++ b/lib/Db/ItemMapperV2.php
@@ -276,8 +276,10 @@ class ItemMapperV2 extends NewsMapperV2
             ->innerJoin('items', FeedMapperV2::TABLE_NAME, 'feeds', 'items.feed_id = feeds.id')
             ->andWhere('feeds.user_id = :userId')
             ->andWhere('items.id <= :maxItemId')
+            ->andWhere('items.unread != :unread')
             ->setParameter('userId', $userId)
-            ->setParameter('maxItemId', $maxItemId);
+            ->setParameter('maxItemId', $maxItemId)
+            ->setParameter('unread', false, IQueryBuilder::PARAM_BOOL);
 
         $idList = array_map(function ($value): int {
             return intval($value['id']);
@@ -287,8 +289,6 @@ class ItemMapperV2 extends NewsMapperV2
         $builder->update(self::TABLE_NAME)
             ->set('unread', $builder->createParameter('unread'))
             ->andWhere('id IN (:idList)')
-            ->andWhere('unread != :unread')
-            ->setParameter('unread', false, IQueryBuilder::PARAM_BOOL)
             ->setParameter('idList', $idList, IQueryBuilder::PARAM_INT_ARRAY);
 
         return $this->db->executeStatement(

--- a/tests/Unit/Db/ItemMapperTest.php
+++ b/tests/Unit/Db/ItemMapperTest.php
@@ -497,14 +497,14 @@ class ItemMapperTest extends MapperTestUtility
             ->with('items', 'news_feeds', 'feeds', 'items.feed_id = feeds.id')
             ->will($this->returnSelf());
 
-        $selectbuilder->expects($this->exactly(2))
+        $selectbuilder->expects($this->exactly(3))
             ->method('andWhere')
-            ->withConsecutive(['feeds.user_id = :userId'], ['items.id <= :maxItemId'])
+            ->withConsecutive(['feeds.user_id = :userId'], ['items.id <= :maxItemId'], ['items.unread != :unread'])
             ->will($this->returnSelf());
 
-        $selectbuilder->expects($this->exactly(2))
+        $selectbuilder->expects($this->exactly(3))
             ->method('setParameter')
-            ->withConsecutive(['userId', 'admin'], ['maxItemId', 4])
+            ->withConsecutive(['userId', 'admin'], ['maxItemId', 4], ['unread', false])
             ->will($this->returnSelf());
 
         $selectbuilder->expects($this->exactly(1))
@@ -542,14 +542,14 @@ class ItemMapperTest extends MapperTestUtility
             ->with('unread', 'unread')
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->exactly(2))
+        $this->builder->expects($this->exactly(1))
             ->method('andWhere')
-            ->withConsecutive(['id IN (:idList)'], ['unread != :unread'])
+            ->withConsecutive(['id IN (:idList)'])
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->exactly(2))
+        $this->builder->expects($this->exactly(1))
             ->method('setParameter')
-            ->withConsecutive(['unread', false], ['idList', [1, 2]])
+            ->withConsecutive(['idList', [1, 2]])
             ->will($this->returnSelf());
 
         $this->builder->expects($this->exactly(1))


### PR DESCRIPTION
This doesn't fix all issues of the readAll function but makes it more predictable.
If you have a huge amount of unread feeds this function might still fail.