### PR TITLE
Add some documentation about the integration tests

### DIFF
--- a/.github/workflows/api-integration-tests.yml
+++ b/.github/workflows/api-integration-tests.yml
@@ -145,6 +145,8 @@ jobs:
                   
           bats apps/news/tests/command
 
+          kill %1
+
       - name: Prep PHP tests
         working-directory: ../server/apps/news
         run: make php-test-dependencies

--- a/Makefile
+++ b/Makefile
@@ -221,3 +221,11 @@ test: php-test-dependencies
 .PHONY: feed-test
 feed-test:
 	./bin/tools/check_feeds.sh
+
+.PHONY: feed-server
+feed-server:
+	php -S 127.0.0.1:8090 -t $(CURDIR)/tests/test_helper/feeds
+
+.PHONY: nextcloud-server
+nextcloud-server:
+	php -S 127.0.0.1:8080 -t $(CURDIR)/../../.

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -41,15 +41,13 @@ You also need to pull the submodules of the news repo.
 git submodules update --init
 ```
 
-The cli tests expect that the feeds are reachable at `http://localhost:8090`, to achieve that you can use the [builtin php server](https://www.php.net/manual/en/features.commandline.webserver.php).
-
-Change into the `tests/test_helpers/feeds` directory and execute `php -S localhost:8090` you can also run it in the background like this `php -S localhost:8090 &`.
+The cli tests expect that the feeds are reachable at `http://localhost:8090`, to achieve that you can use `make feed-server &` the `&` means it'll run in the background.
 
 Now the test feeds will be reachable for bats.
 Run the tests by executing `bats tests/command` you can also only run specific tests for example `bats tests/command/feeds.bats`.
 
 For the API tests you need to run a second php server or have another web server that provides Nextcloud and the News App.
 The tests expect to find Nextcloud at `http://localhost:8080`
-You can do this by running `php -S localhost:8080` in the Nextcloud server repository.
+You can do this by running `make nextcloud-server`.
 
 The bats tests can be executed like this `bats tests/api`.

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -21,3 +21,35 @@ The PHP code should all adhere to [PSR-2](https://www.php-fig.org/psr/psr-2/).
 To test the codestyle you can run `make phpcs`.
 
 For linting JavaScript, a [jshint file](https://github.com/nextcloud/news/blob/master/js/.jshintrc) is used that is run before compiling the JavaScript.
+
+## General Developer setup
+Check the Nextcloud [documentation](https://docs.nextcloud.com/server/latest/developer_manual/getting_started/devenv.html) to learn how to setup a developer environment, alternatively to a proper web server you can also use the [builtin php server](https://www.php.net/manual/en/features.commandline.webserver.php) on demand, it is enough for development purposes.
+
+When your setup is running, clone the news repository in the `apps/` directory inside the server.
+
+Change into the news directory and run make to build the app, you will need php, composer, node, npm and maybe more.
+
+Now you can basically use the news app and test your changes.
+
+## Running Integration tests locally
+We use [bats](https://bats-core.readthedocs.io/en/stable/) to run integration tests against the API and the cli.
+
+Check how to install bats on your system in the [official documentation](https://bats-core.readthedocs.io/en/stable/installation.html).
+
+You also need to pull the submodules of the news repo.
+```bash
+git submodules update --init
+```
+
+The cli tests expect that the feeds are reachable at `http://localhost:8090`, to achieve that you can use the [builtin php server](https://www.php.net/manual/en/features.commandline.webserver.php).
+
+Change into the `tests/test_helpers/feeds` directory and execute `php -S localhost:8090` you can also run it in the background like this `php -S localhost:8090 &`.
+
+Now the test feeds will be reachable for bats.
+Run the tests by executing `bats tests/command` you can also only run specific tests for example `bats tests/command/feeds.bats`.
+
+For the API tests you need to run a second php server or have another web server that provides Nextcloud and the News App.
+The tests expect to find Nextcloud at `http://localhost:8080`
+You can do this by running `php -S localhost:8080` in the Nextcloud server repository.
+
+The bats tests can be executed like this `bats tests/api`.


### PR DESCRIPTION
I wrote down some documentation on how to run the integration tests to make it a bit easier for new people.

Also added the missing kill command to the workflow.