### PR TITLE
Release 18.2.0-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 # Unreleased
 ## [18.x.x]
 ### Changed
+
+### Fixed
+
+# Releases
+## [18.2.0-beta1] - 2022-08-30
+### Changed
 - Ported the admin settings to vue (#2353)
 
 ### Fixed
@@ -14,7 +20,6 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 - Fix when marking all items as read, all items of the user are used in the sql query (#1873)
 - Fix adding feed via the web-ui that was just deleted causing an error (#1872)
 
-# Releases
 ## [18.1.1] - 2022-08-12
 ### Changed
 - Change autodiscover to only run after fetching the given url has failed (#1860)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>18.1.1</version>
+    <version>18.2.0-beta1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
Changed
- Ported the admin settings to vue (#2353)

Fixed
- Fix PHP 8.1 deprecations (#1861)
- Document api item types (#1861)
- Fix deprecation warnings from Nextcloud server (#1869)
- Fix when marking all items as read, all items of the user are used in the sql query (#1873)
- Fix adding feed via the web-ui that was just deleted causing an error (#1872)