### PR TITLE
fix readAll method fails due to missing parameter

### DIFF
--- a/lib/Db/ItemMapperV2.php
+++ b/lib/Db/ItemMapperV2.php
@@ -276,10 +276,10 @@ class ItemMapperV2 extends NewsMapperV2
             ->innerJoin('items', FeedMapperV2::TABLE_NAME, 'feeds', 'items.feed_id = feeds.id')
             ->andWhere('feeds.user_id = :userId')
             ->andWhere('items.id <= :maxItemId')
-            ->andWhere('items.unread != :unread')
+            ->andWhere('items.unread = :unread')
             ->setParameter('userId', $userId)
             ->setParameter('maxItemId', $maxItemId)
-            ->setParameter('unread', false, IQueryBuilder::PARAM_BOOL);
+            ->setParameter('unread', true, IQueryBuilder::PARAM_BOOL);
 
         $idList = array_map(function ($value): int {
             return intval($value['id']);
@@ -289,7 +289,8 @@ class ItemMapperV2 extends NewsMapperV2
         $builder->update(self::TABLE_NAME)
             ->set('unread', $builder->createParameter('unread'))
             ->andWhere('id IN (:idList)')
-            ->setParameter('idList', $idList, IQueryBuilder::PARAM_INT_ARRAY);
+            ->setParameter('idList', $idList, IQueryBuilder::PARAM_INT_ARRAY)
+            ->setParameter('unread', false, IQueryBuilder::PARAM_BOOL);
 
         return $this->db->executeStatement(
             $builder->getSQL(),

--- a/tests/Unit/Db/ItemMapperTest.php
+++ b/tests/Unit/Db/ItemMapperTest.php
@@ -499,12 +499,12 @@ class ItemMapperTest extends MapperTestUtility
 
         $selectbuilder->expects($this->exactly(3))
             ->method('andWhere')
-            ->withConsecutive(['feeds.user_id = :userId'], ['items.id <= :maxItemId'], ['items.unread != :unread'])
+            ->withConsecutive(['feeds.user_id = :userId'], ['items.id <= :maxItemId'], ['items.unread = :unread'])
             ->will($this->returnSelf());
 
         $selectbuilder->expects($this->exactly(3))
             ->method('setParameter')
-            ->withConsecutive(['userId', 'admin'], ['maxItemId', 4], ['unread', false])
+            ->withConsecutive(['userId', 'admin'], ['maxItemId', 4], ['unread', true])
             ->will($this->returnSelf());
 
         $selectbuilder->expects($this->exactly(1))
@@ -547,9 +547,9 @@ class ItemMapperTest extends MapperTestUtility
             ->withConsecutive(['id IN (:idList)'])
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->exactly(1))
+        $this->builder->expects($this->exactly(2))
             ->method('setParameter')
-            ->withConsecutive(['idList', [1, 2]])
+            ->withConsecutive(['idList', [1, 2]], ['unread', false])
             ->will($this->returnSelf());
 
         $this->builder->expects($this->exactly(1))


### PR DESCRIPTION
We overlooked that the parameter "unread" is actually needed in the update statement.

I also changed the first query to simplify the code.