### PR TITLE
Fix the highlighted item in reversed order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
+- Fix the highlithed item when reverse ordering is selected (#1838)
 
 # Releases
 ## [18.2.0-beta2] - 2022-09-07

--- a/js/controller/ContentController.js
+++ b/js/controller/ContentController.js
@@ -36,11 +36,6 @@ app.controller('ContentController', function (Publisher, FeedResource, ItemResou
     this.getFirstItem = function () {
         var orderedItems = this.getItems();
         var item = orderedItems[0];
-        var lastItem = orderedItems[orderedItems.length - 1];
-        // If isOldestFirst is set, item should be the last item
-        if (isOldestFirst()) {
-            item = lastItem;
-        }
         if (item === undefined) {
             return undefined;
         }


### PR DESCRIPTION
The items returned by the backend is already sorted with the user's preferred order, so the first item should be just the first item of the returned list.
Should fix https://github.com/nextcloud/news/issues/1838