### PR TITLE
[Vue Rewrite] Move Component Files to Typescript

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,12 +7,14 @@
 	</Content>
 </template>
 
-<script>
+<script lang="ts">
+
+import Vue from 'vue'
 import Content from '@nextcloud/vue/dist/Components/Content'
 import AppContent from '@nextcloud/vue/dist/Components/AppContent'
 import Sidebar from './components/Sidebar.vue'
 
-export default {
+export default Vue.extend({
 	components: {
 		Content,
 		Sidebar,
@@ -21,5 +23,5 @@ export default {
 	created() {
 		this.$store.dispatch('loadFolder')
 	},
-}
+})
 </script>

--- a/src/components/AddFeed.vue
+++ b/src/components/AddFeed.vue
@@ -111,15 +111,17 @@ import Modal from '@nextcloud/vue/dist/Components/Modal'
 import CheckboxRadioSwitch from '@nextcloud/vue/dist/Components/CheckboxRadioSwitch'
 import Button from '@nextcloud/vue/dist/Components/Button'
 import Multiselect from '@nextcloud/vue/dist/Components/Multiselect'
+import { Folder } from '../types/Folder.vue'
+import { Feed } from '../types/Feed.vue'
 
 type AddFeedState = {
-	folder: any;
+	folder: Folder;
 	autoDiscover: boolean;
 	createNewFolder: boolean;
 	withBasicAuth: boolean;
 
 	// from props
-	feed?: any;
+	feed?: Feed;
 };
 
 export default Vue.extend({
@@ -137,7 +139,7 @@ export default Vue.extend({
 	},
 	data: (): AddFeedState => {
 		return {
-			folder: {},
+			folder: { name: '' },
 			autoDiscover: true,
 			createNewFolder: false,
 			withBasicAuth: false,

--- a/src/components/AddFeed.vue
+++ b/src/components/AddFeed.vue
@@ -104,15 +104,25 @@
 	</Modal>
 </template>
 
-<script>
-/* eslint-disable vue/require-prop-type-constructor */
+<script lang="ts">
 
+import Vue from 'vue'
 import Modal from '@nextcloud/vue/dist/Components/Modal'
 import CheckboxRadioSwitch from '@nextcloud/vue/dist/Components/CheckboxRadioSwitch'
 import Button from '@nextcloud/vue/dist/Components/Button'
 import Multiselect from '@nextcloud/vue/dist/Components/Multiselect'
 
-export default {
+type AddFeedState = {
+	folder: any;
+	autoDiscover: boolean;
+	createNewFolder: boolean;
+	withBasicAuth: boolean;
+
+	// from props
+	feed?: any;
+};
+
+export default Vue.extend({
 	components: {
 		Modal,
 		CheckboxRadioSwitch,
@@ -125,8 +135,7 @@ export default {
 			default: '',
 		},
 	},
-	emits: ['close'],
-	data() {
+	data: (): AddFeedState => {
 		return {
 			folder: {},
 			autoDiscover: true,
@@ -156,7 +165,8 @@ export default {
 			})
 		},
 	},
-}
+})
+
 </script>
 
 <style scoped>

--- a/src/components/Explore.vue
+++ b/src/components/Explore.vue
@@ -37,19 +37,8 @@ import Button from '@nextcloud/vue/dist/Components/Button'
 import axios from '@nextcloud/axios'
 import AddFeed from './AddFeed.vue'
 import { generateUrl } from '@nextcloud/router'
-
-type ExploreSite = {
-	title: string;
-	favicon: string;
-	url: string;
-	feed: string;
-	description: string;
-	votes: number;
-}
-
-type Feed = {
-	url?: string;
-};
+import { ExploreSite } from '../types/ExploreSite.vue'
+import { Feed } from '../types/Feed.vue'
 
 const ExploreComponent = Vue.extend({
 	components: {

--- a/src/components/Explore.vue
+++ b/src/components/Explore.vue
@@ -31,6 +31,7 @@
 </template>
 
 <script lang="ts">
+
 import Vue from 'vue'
 import Button from '@nextcloud/vue/dist/Components/Button'
 import axios from '@nextcloud/axios'

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -135,6 +135,7 @@ import AppNavigationNewItem from '@nextcloud/vue/dist/Components/AppNavigationNe
 import CounterBubble from '@nextcloud/vue/dist/Components/CounterBubble'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 import AddFeed from './AddFeed.vue'
+import { Folder } from '../types/Folder.vue'
 
 export default Vue.extend({
 	components: {
@@ -166,7 +167,7 @@ export default Vue.extend({
 			const folder = { name: folderName }
 			this.$store.dispatch('addFolder', { folder })
 		},
-		deleteFolder(folder: any) {
+		deleteFolder(folder: Folder) {
 			this.$store.dispatch('deleteFolder', { folder })
 			window.location.reload()
 		},

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -124,8 +124,9 @@
 	</AppNavigation>
 </template>
 
-<script>
+<script lang="ts">
 
+import Vue from 'vue'
 import AppNavigation from '@nextcloud/vue/dist/Components/AppNavigation'
 import AppNavigationNew from '@nextcloud/vue/dist/Components/AppNavigationNew'
 import AppNavigationItem from '@nextcloud/vue/dist/Components/AppNavigationItem'
@@ -135,7 +136,7 @@ import CounterBubble from '@nextcloud/vue/dist/Components/CounterBubble'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 import AddFeed from './AddFeed.vue'
 
-export default {
+export default Vue.extend({
 	components: {
 		AppNavigation,
 		AppNavigationNew,
@@ -160,14 +161,14 @@ export default {
 		// TODO?
 	},
 	methods: {
-		newFolder(value) {
+		newFolder(value: string) {
 			const folderName = value.trim()
 			const folder = { name: folderName }
 			this.$store.dispatch('addFolder', { folder })
 		},
-		deleteFolder(folder) {
+		deleteFolder(folder: any) {
 			this.$store.dispatch('deleteFolder', { folder })
-			window.location.reload(true)
+			window.location.reload()
 		},
 		showShowAddFeed() {
 			this.showAddFeed = true
@@ -175,9 +176,10 @@ export default {
 		closeShowAddFeed() {
 			this.showAddFeed = false
 		},
-		alert(msg) {
+		alert(msg: string) {
 			window.alert(msg)
 		},
 	},
-}
+})
+
 </script>

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -6,6 +6,7 @@ declare module '*.vue' {
   export default Vue;
 };
 
-declare module '@nextcloud/vue/dist/Components/Button' {
+// Necessary for All Nextcloud Vue components
+declare module '@nextcloud/vue/dist/Components/*' {
 
 };

--- a/src/types/ExploreSite.vue
+++ b/src/types/ExploreSite.vue
@@ -1,0 +1,10 @@
+<script lang="ts">
+export type ExploreSite = {
+	title: string;
+	favicon: string;
+	url: string;
+	feed: string;
+	description: string;
+	votes: number;
+}
+</script>

--- a/src/types/Feed.vue
+++ b/src/types/Feed.vue
@@ -1,0 +1,5 @@
+<script lang="ts">
+export type Feed = {
+	url?: string;
+}
+</script>

--- a/src/types/Folder.vue
+++ b/src/types/Folder.vue
@@ -1,0 +1,5 @@
+<script lang="ts">
+export type Folder = {
+  name: string;
+}
+</script>


### PR DESCRIPTION
PR for Making all Component files use Typescript
----
Moved out of https://github.com/nextcloud/news/pull/1907 

(File changes in this PR contains the updates from #1907 until it is merged)

[Commits with actual changes](https://github.com/nextcloud/news/pull/1922/files/7ad99102534e48789ccc811dba001dc78c1a2202..2709767e2de83d353688a0ab3f9780d2627a95b5):
- a1b0d5878ad3ee287a7e9f368d67fd914d9eca86
- 2709767e2de83d353688a0ab3f9780d2627a95b5


## Steps
 - Move all components use `Vue.extend({ ... `
 - Add `types/` directory with `.vue` files containing type definitions used throughout app

## Up Next
- Add Unit Tests to run with npm run test (see https://github.com/devlinjunker/news/pull/56 for WIP)
- Add Vuex Store (see https://github.com/nextcloud/news/commit/58a196b548e8bf25896ee7db159dbecf88724635 for preview)
- Add Proper Routing (see https://github.com/devlinjunker/news/compare/vue-version...devlinjunker:vue-routes for preview)
- Finally start on UI Component Rewrites