### PR TITLE
[Vue Rewrite] Only Enforce Changelog update on PR to `master` branch

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -2,6 +2,8 @@ name: "Changelog Enforcer"
 on:
   pull_request:
       types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+      branches:
+        - master # so we can break down vue-rewrite into smaller PRs?
 
 jobs:
   # Enforces the update of a changelog file on every pull request


### PR DESCRIPTION
Annoying that the builds fail on changelog workflow while doing the vue-rewrite with smaller PRs.. doesn't seem like the changelog should be updated with each 10 file change in my opinion

We can revert this change before we make the merge of `vue-rewrite` branch to `master` if this isn't a desired long term change, but I think committing the change to `vue-rewrite` for now will stop that workflow from running on the smaller PRs against `vue-rewrite`