### PR TITLE
fix wording to articles

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -29,9 +29,9 @@ SPDX-Licence-Identifier: AGPL-3.0-or-later
 		<NcCheckboxRadioSwitch type="switch"
 			:checked.sync="purgeUnread"
 			@update:checked="update('purgeUnread', purgeUnread)">
-			{{ t('news', 'Delete unread items automatically') }}
+			{{ t('news', 'Delete unread articles automatically') }}
 		</NcCheckboxRadioSwitch>
-		<p><em>{{ t('news', 'Enable this if you also want to delete unread items.') }}</em></p>
+		<p><em>{{ t('news', 'Enable this if you also want to delete unread articles.') }}</em></p>
 
 		<NcTextField :value.sync="maxRedirects"
 			:label="t('news', 'Maximum redirects')"


### PR DESCRIPTION
Any Ideas how to explain how explain how the number of autoPurgeCount is applied when purgeUnread is enabled.
I think that it is not obvious enough.

In the docs we have this https://nextcloud.github.io/news/faq/#database-table-grows-too-big