### PR TITLE
Release 19.0.0-beta1

### DIFF
--- a/.github/workflows/api-integration-tests.yml
+++ b/.github/workflows/api-integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['7.4', '8.0']
-        nextcloud: ['stable22', 'stable23']
+        nextcloud: ['stable23', 'stable24', 'stable25']
         database: ['sqlite', 'pgsql', 'mysql']
         experimental: [false]
         include:
@@ -37,12 +37,12 @@ jobs:
             nextcloud: pre-release
             database: sqlite
             experimental: true
-          - php-versions: '8.1'
+          - php-versions: '8.2'
             nextcloud: pre-release
             database: sqlite
             experimental: true
           - php-versions: 8.1
-            nextcloud: stable24
+            nextcloud: stable25
             database: sqlite
             experimental: false
     steps:

--- a/.github/workflows/api-php-static-code-check.yml
+++ b/.github/workflows/api-php-static-code-check.yml
@@ -7,15 +7,11 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        php-versions: [ '7.4', '8.0' ]
-        nextcloud: [ 'stable24' ]
+        php-versions: [ '7.4', '8.0', '8.1' ]
+        nextcloud: [ 'stable25' ]
         database: [ 'sqlite' ]
         include:
-          - php-versions: 8.1
-            nextcloud: stable24
-            database: sqlite
-            experimental: false
-          - php-versions: 8.1
+          - php-versions: '8.2'
             nextcloud: pre-release
             database: sqlite
             experimental: true

--- a/.github/workflows/api-php-tests.yml
+++ b/.github/workflows/api-php-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.1']
-        nextcloud: ['stable24']
+        nextcloud: ['stable25']
         database: ['sqlite']
         experimental: [false]
         codecoverage: [false]

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.1']
-        nextcloud: ['stable24']
+        nextcloud: ['stable25']
         database: ['sqlite']
     steps:
       - name: Checkout

--- a/.github/workflows/post-merge-tasks.yml
+++ b/.github/workflows/post-merge-tasks.yml
@@ -10,7 +10,7 @@ jobs:
     name: "Coverage: Nextcloud PHP ${{ matrix.php-versions }}"
     strategy:
       matrix:
-        nextcloud: ['stable24']
+        nextcloud: ['stable25']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,23 @@ All notable changes to this project will be documented in this file.
 The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), older entries don't fully match.
 
 # Unreleased
-## [18.x.x]
+## [19.x.x]
 ### Changed
 
 ### Fixed
-- Corrected article compact title bar position in NC25 
-- Fixed "Mark read through scrolling" in NC25 and NC24
 
 # Releases
-## [18.3.0] - 2022-10-10
+## [19.0.0-beta1] - 2022-10-22
+### Changed
+- Drop support for Nextcloud 22, NC 22 has reached it's end of life. (#1950)
+- Add support for Nextcloud 25 (#1950)
 ### Fixed
-- Remove setting for minimum purge interval since it is not used.
+- Corrected article compact title bar position in NC25 (#1944)
+- Fixed "Mark read through scrolling" in NC25 and NC24 (#1944)
+
+## [18.3.0] - 2022-10-21
+### Fixed
+- Remove setting for minimum purge interval since it is not used. (#1935)
 
 ## [18.3.0-beta1] - 2022-10-10
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>18.3.0</version>
+    <version>19.0.0-beta1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>
@@ -55,7 +55,7 @@ Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
         <lib>json</lib>
 
         <owncloud max-version="0" min-version="0"/>
-        <nextcloud min-version="22" max-version="24"/>
+        <nextcloud min-version="23" max-version="25"/>
     </dependencies>
 
     <background-jobs>


### PR DESCRIPTION
### Changed
- Drop support for Nextcloud 22, NC 22 has reached it's end of life.
- Add support for Nextcloud 25 
### Fixed
- Corrected article compact title bar position in NC25 (#1944)
- Fixed "Mark read through scrolling" in NC25 and NC24 (#1944)

Signed-off-by: Benjamin Brahmer <info@b-brahmer.de>