### PR TITLE
Fix keyboard navigation + cron job notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
+- Fixed various keyboard navigation issues
+- Fix cron job warning notification layout on NC25
 
 # Releases
 ## [19.0.0-beta1] - 2022-10-22

--- a/js/app/Config.js
+++ b/js/app/Config.js
@@ -34,6 +34,10 @@ app.config(function ($routeProvider, $provide, $httpProvider, $locationProvider)
     $provide.constant('MARK_READ_TIMEOUT', 0.5);
     $provide.constant('SCROLL_TIMEOUT', 0.1);
 
+    const majorVersion = parseInt($('#app-content').data('nc-major-version') || 0, 10);
+    $provide.constant('NC_MAJOR_VERSION', majorVersion);
+    window.NEWS_NC_MAJOR_VERSION = majorVersion;
+
     // make sure that the CSRF header is only sent to the Nextcloud domain
     $provide.factory('CSRFInterceptor', function ($q, BASE_URL, $window) {
         return {

--- a/js/directive/NewsScroll.js
+++ b/js/directive/NewsScroll.js
@@ -8,21 +8,17 @@
  * @copyright Bernhard Posselt 2014
  */
 app.directive('newsScroll', function ($timeout, ITEM_AUTO_PAGE_SIZE,
-    MARK_READ_TIMEOUT, SCROLL_TIMEOUT) {
+    MARK_READ_TIMEOUT, SCROLL_TIMEOUT, NC_MAJOR_VERSION) {
     'use strict';
     var timer;
 
 
     var scrollElement = function() {
-        const appContentElem = $('#app-content');
-        const majorVersion = parseInt($('#app-content').data('nc-major-version') || 0, 10);
-        if (majorVersion >= 25) {
-            return appContentElem;
+        // This should be in sync with the same function in js/gui/KeyboardShortcuts.js
+        if (NC_MAJOR_VERSION >= 25) {
+            return  $('#app-content');
         }
-        if (majorVersion === 24) {
-            return $(window);
-        }
-        return $('html');
+        return $(window);
     };
 
     // autopaging

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -86,6 +86,7 @@ class PageController extends Controller
             $this->appName,
             'index',
             [
+                'nc_major_version' => \OCP\Util::getVersion()[0],
                 'warnings' => $status['warnings'],
                 'url_generator' => $this->urlGenerator
             ]

--- a/templates/part.content.warnings.php
+++ b/templates/part.content.warnings.php
@@ -1,25 +1,27 @@
 <?php if ($_['warnings']['improperlyConfiguredCron']) { ?>
     <news-instant-notification id="cron-warning">
-        <p><?php p($l->t('Ajax or webcron mode detected! Your feeds will not be updated!')); ?></p>
-        <ul>
-            <li>
-                <a href="https://docs.nextcloud.org/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron"
-                   target="_blank"
-                   rel="noreferrer">
-                    <?php
-                    p($l->t('How to set up the operating system cron'));
-                    ?>
-                </a>
-            </li>
-            <li>
-                <a href="https://github.com/nextcloud/news-updater"
-                   target="_blank"
-                   rel="noreferrer">
-                    <?php
-                    p($l->t('Install and set up a faster parallel updater that uses the News app\'s update API'));
-                    ?>
-                </a>
-            </li>
-        </ul>
+        <div style="<?= $_['nc_major_version'] >= 25 ? 'padding: 12px;' : ''; ?>">
+            <p><?php p($l->t('Ajax or webcron mode detected! Your feeds will not be updated!')); ?></p>
+            <ul>
+                <li>
+                    <a href="https://docs.nextcloud.org/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron"
+                    target="_blank"
+                    rel="noreferrer">
+                        <?php
+                        p($l->t('How to set up the operating system cron'));
+                        ?>
+                    </a>
+                </li>
+                <li>
+                    <a href="https://github.com/nextcloud/news-updater"
+                    target="_blank"
+                    rel="noreferrer">
+                        <?php
+                        p($l->t('Install and set up a faster parallel updater that uses the News app\'s update API'));
+                        ?>
+                    </a>
+                </li>
+            </ul>
+        </div>
     </news-instant-notification>
 <?php }; ?>


### PR DESCRIPTION
Keyboard navigation through items was not working correctly in NC25 and highlighting active item  on scroll was not working in NC25, NC24, NC23 (I think) so I have attempted to fix this.

The cronjob warning notification layout was messed up on NC25 as well so also attempted a quick fix for that.

Also tidied up the version number stuff a bit. I feel like the Nextcloud JS globals (the `window.OC` object) should have that info but I couldn't find it anywhere 🤷. Dumping the version number from PHP into a data attribute feels wrong 🤠 