### PR TITLE
Use app password, change setup method

### DIFF
--- a/.github/workflows/api-integration-tests.yml
+++ b/.github/workflows/api-integration-tests.yml
@@ -59,7 +59,7 @@ jobs:
           coverage: none
 
       - name: Setup BATS & httpie
-        run: sudo apt-get install -y bats httpie
+        run: sudo apt-get install -y httpie && npm install -g bats@1.7.0
 
       ### MySQL specific setup
       - name: Setup mysql

--- a/tests/api/feeds.bats
+++ b/tests/api/feeds.bats
@@ -1,76 +1,85 @@
 #!/usr/bin/env bats
 
-setup() {
-  load "../test_helper/bats-support/load"
-  load "../test_helper/bats-assert/load"
+setup_file(){
   load "helpers/settings"
-  
+
   if test -f "tests/api/helpers/settings-override.bash"; then
     load "helpers/settings-override"
   fi
+
+  export APP_PASSWORD=$(NC_PASS=${user} ./occ user:add-app-password ${user} --password-from-env | grep -Po '([A-Z|a-z|0-9]{72})')
+}
+
+teardown_file(){
+  http --ignore-stdin -b -a ${user}:${APP_PASSWORD} DELETE ${NC_HOST}/ocs/v2.php/core/apppassword OCS-APIRequest:true
+}
+
+setup() {
+  load "../test_helper/bats-support/load"
+  load "../test_helper/bats-assert/load"
 }
 
 TESTSUITE="Feeds"
 
 teardown() {
   # delete all feeds
-  ID_LIST=($(http --ignore-stdin -b -a ${user}:${user} GET ${BASE_URLv1}/feeds | grep -Po '"id":\K([0-9]+)' | tr '\n' ' '))
+  ID_LIST=($(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/feeds | grep -Po '"id":\K([0-9]+)' | tr '\n' ' '))
   for i in $ID_LIST; do
-    http --ignore-stdin -b -a ${user}:${user} DELETE ${BASE_URLv1}/feeds/$i > /dev/null
+    http --ignore-stdin -b -a ${user}:${APP_PASSWORD} DELETE ${BASE_URLv1}/feeds/$i > /dev/null
   done
 
   # delete all folders
-  ID_LIST=($(http --ignore-stdin -b -a ${user}:${user} GET ${BASE_URLv1}/folders | grep -Po '"id":\K([0-9]+)' | tr '\n' ' '))
+  ID_LIST=($(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/folders | grep -Po '"id":\K([0-9]+)' | tr '\n' ' '))
   for i in $ID_LIST; do
-    http --ignore-stdin -b -a ${user}:${user} DELETE ${BASE_URLv1}/folders/$i > /dev/null
+    http --ignore-stdin -b -a ${user}:${APP_PASSWORD} DELETE ${BASE_URLv1}/folders/$i > /dev/null
   done
 }
 
 @test "[$TESTSUITE] Read empty" {
-  run http --ignore-stdin -b -a ${user}:${user} GET ${BASE_URLv1}/feeds
-  
+  run http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/feeds
+
   assert_output --partial "\"feeds\":[]"
   assert_output --partial "\"starredCount\":0"
 }
 
 @test "[$TESTSUITE] Create new" {
   # run is not working here.
-  output=$(http --ignore-stdin -b -a ${user}:${user} POST ${BASE_URLv1}/feeds url=$NC_FEED | jq '.feeds | .[0].url')
+  output=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} POST ${BASE_URLv1}/feeds url=$NC_FEED | jq '.feeds | .[0].url')
   
   assert_output '"http://localhost:8090/Nextcloud.rss"'
 }
 
 @test "[$TESTSUITE] Create new inside folder" {
   # create folder and store id
-  ID=$(http --ignore-stdin -b -a ${user}:${user} POST ${BASE_URLv1}/folders name=news-${BATS_SUITE_TEST_NUMBER} | grep -Po '"id":\K([0-9]+)')
+  ID=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} POST ${BASE_URLv1}/folders name=news-${BATS_SUITE_TEST_NUMBER} | grep -Po '"id":\K([0-9]+)')
 
   # run is not working here.
-  output=$(http --ignore-stdin -b -a ${user}:${user} POST ${BASE_URLv1}/feeds url=$NC_FEED folderId=$ID | jq '.feeds | .[0].folderId')
+  output=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} POST ${BASE_URLv1}/feeds url=$NC_FEED folderId=$ID | jq '.feeds | .[0].folderId')
   
   # check if ID matches
   assert_output "$ID"
 }
 
 @test "[$TESTSUITE] Delete one" {
-  ID=$(http --ignore-stdin -b -a ${user}:${user} POST ${BASE_URLv1}/feeds url=$NC_FEED | grep -Po '"id":\K([0-9]+)')
+  ID=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} POST ${BASE_URLv1}/feeds url=$NC_FEED | grep -Po '"id":\K([0-9]+)')
   
-  run http --ignore-stdin -b -a ${user}:${user} DELETE ${BASE_URLv1}/feeds/$ID
+  run http --ignore-stdin -b -a ${user}:${APP_PASSWORD} DELETE ${BASE_URLv1}/feeds/$ID
   
   assert_output "[]"
 }
 
 @test "[$TESTSUITE] Move feed to different folder" {
   # create folders and store ids
-  FIRST_FOLDER_ID=$(http --ignore-stdin -b -a ${user}:${user} POST ${BASE_URLv1}/folders name=news-${BATS_SUITE_TEST_NUMBER} | grep -Po '"id":\K([0-9]+)')
-  SECCOND_FOLDER_ID=$(http --ignore-stdin -b -a ${user}:${user} POST ${BASE_URLv1}/folders name=news-${BATS_SUITE_TEST_NUMBER} | grep -Po '"id":\K([0-9]+)')
+  FIRST_FOLDER_ID=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} POST ${BASE_URLv1}/folders name=news-${BATS_SUITE_TEST_NUMBER} | grep -Po '"id":\K([0-9]+)')
+  SECCOND_FOLDER_ID=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} POST ${BASE_URLv1}/folders name=news-${BATS_SUITE_TEST_NUMBER} | grep -Po '"id":\K([0-9]+)')
   
-  FEEDID=$(http --ignore-stdin -b -a ${user}:${user} POST ${BASE_URLv1}/feeds url=$NC_FEED folderId=$FIRST_FOLDER_ID | grep -Po '"id":\K([0-9]+)')
+  FEEDID=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} POST ${BASE_URLv1}/feeds url=$NC_FEED folderId=$FIRST_FOLDER_ID | grep -Po '"id":\K([0-9]+)')
   
   # move feed, returns nothing
-  http --ignore-stdin -b -a ${user}:${user} PUT ${BASE_URLv1}/feeds/$FEEDID/move folderId=$SECCOND_FOLDER_ID
+  http --ignore-stdin -b -a ${user}:${APP_PASSWORD} PUT ${BASE_URLv1}/feeds/$FEEDID/move folderId=$SECCOND_FOLDER_ID
 
   # run is not working here.
-  output=$(http --ignore-stdin -b -a ${user}:${user} GET ${BASE_URLv1}/feeds | jq '.feeds | .[0].folderId')
+  output=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/feeds | jq '.feeds | .[0].folderId')
   
   # look for second folder id
   assert_output "$SECCOND_FOLDER_ID"
@@ -78,15 +87,15 @@ teardown() {
 
 @test "[$TESTSUITE] Move feed to root" {
   # create folder and store id
-  FOLDER_ID=$(http --ignore-stdin -b -a ${user}:${user} POST ${BASE_URLv1}/folders name=news-${BATS_SUITE_TEST_NUMBER} | grep -Po '"id":\K([0-9]+)')
+  FOLDER_ID=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} POST ${BASE_URLv1}/folders name=news-${BATS_SUITE_TEST_NUMBER} | grep -Po '"id":\K([0-9]+)')
 
-  FEEDID=$(http --ignore-stdin -b -a ${user}:${user} POST ${BASE_URLv1}/feeds url=$NC_FEED folderId=$FOLDER_ID | grep -Po '"id":\K([0-9]+)')
+  FEEDID=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} POST ${BASE_URLv1}/feeds url=$NC_FEED folderId=$FOLDER_ID | grep -Po '"id":\K([0-9]+)')
   
   # move feed to "null", returns nothing
-  http --ignore-stdin -b -a ${user}:${user} PUT ${BASE_URLv1}/feeds/$FEEDID/move folderId=null
+  http --ignore-stdin -b -a ${user}:${APP_PASSWORD} PUT ${BASE_URLv1}/feeds/$FEEDID/move folderId=null
 
   # run is not working here.
-  output=$(http --ignore-stdin -b -a ${user}:${user} GET ${BASE_URLv1}/feeds | jq '.feeds | .[0].folderId')
+  output=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/feeds | jq '.feeds | .[0].folderId')
   
   # new "folder" should be null
   assert_output null
@@ -94,13 +103,13 @@ teardown() {
 
 @test "[$TESTSUITE] Rename feed" {
   # create feed and store id
-  FEEDID=$(http --ignore-stdin -b -a ${user}:${user} POST ${BASE_URLv1}/feeds url=$NC_FEED | grep -Po '"id":\K([0-9]+)')
+  FEEDID=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} POST ${BASE_URLv1}/feeds url=$NC_FEED | grep -Po '"id":\K([0-9]+)')
   
   # rename feed, returns nothing
-  http --ignore-stdin -b -a ${user}:${user} PUT ${BASE_URLv1}/feeds/$FEEDID/rename feedTitle="Great Title"
+  http --ignore-stdin -b -a ${user}:${APP_PASSWORD} PUT ${BASE_URLv1}/feeds/$FEEDID/rename feedTitle="Great Title"
 
   # run is not working here.
-  output=$(http --ignore-stdin -b -a ${user}:${user} GET ${BASE_URLv1}/feeds | jq '.feeds | .[0].title')
+  output=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/feeds | jq '.feeds | .[0].title')
   
   # Check if title matches
   assert_output '"Great Title"'
@@ -108,9 +117,9 @@ teardown() {
 
 @test "[$TESTSUITE] Mark all items as read" {
   # create feed and store id
-  FEEDID=$(http --ignore-stdin -b -a ${user}:${user} POST ${BASE_URLv1}/feeds url=$NC_FEED | grep -Po '"id":\K([0-9]+)')
+  FEEDID=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} POST ${BASE_URLv1}/feeds url=$NC_FEED | grep -Po '"id":\K([0-9]+)')
   
-  ID_LIST=($(http --ignore-stdin -b -a ${user}:${user} GET ${BASE_URLv1}/items id=$FEEDID | grep -Po '"id":\K([0-9]+)' | tr '\n' ' '))
+  ID_LIST=($(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/items id=$FEEDID | grep -Po '"id":\K([0-9]+)' | tr '\n' ' '))
 
   # get biggest item ID
   max=${ID_LIST[0]}
@@ -119,10 +128,10 @@ teardown() {
   done
   
   # mark all items of feed as read, returns nothing
-  STATUS_CODE=$(http --ignore-stdin -hdo /tmp/body -a ${user}:${user} PUT ${BASE_URLv1}/feeds/$FEEDID/read newestItemId="$max" 2>&1| grep HTTP/)
+  STATUS_CODE=$(http --ignore-stdin -hdo /tmp/body -a ${user}:${APP_PASSWORD} PUT ${BASE_URLv1}/feeds/$FEEDID/read newestItemId="$max" 2>&1| grep HTTP/)
 
   # collect unread status
-  unread=$(http --ignore-stdin -b -a ${user}:${user} GET ${BASE_URLv1}/items id=$FEEDID | grep -Po '"unread":\K((true)|(false))' | tr '\n' ' ')
+  unread=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/items id=$FEEDID | grep -Po '"unread":\K((true)|(false))' | tr '\n' ' ')
   
   for n in "${unread[@]}" ; do
       if $n

--- a/tests/api/folders.bats
+++ b/tests/api/folders.bats
@@ -1,69 +1,77 @@
 #!/usr/bin/env bats
 
-setup() {
-  load "../test_helper/bats-support/load"
-  load "../test_helper/bats-assert/load"
+setup_file(){
   load "helpers/settings"
 
   if test -f "tests/api/helpers/settings-override.bash"; then
     load "helpers/settings-override"
   fi
-  
+
+  export APP_PASSWORD=$(NC_PASS=${user} ./occ user:add-app-password ${user} --password-from-env | grep -Po '([A-Z|a-z|0-9]{72})')
+}
+
+teardown_file(){
+  http --ignore-stdin -b -a ${user}:${APP_PASSWORD} DELETE ${NC_HOST}/ocs/v2.php/core/apppassword OCS-APIRequest:true
+}
+
+setup() {
+  load "../test_helper/bats-support/load"
+  load "../test_helper/bats-assert/load"
 }
 
 TESTSUITE="Folders"
 
 teardown() {
   # delete all feeds
-  FEED_IDS=($(http --ignore-stdin -b -a ${user}:${user} GET ${BASE_URLv1}/feeds | grep -Po '"id":\K([0-9]+)' | tr '\n' ' '))
+  FEED_IDS=($(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/feeds | grep -Po '"id":\K([0-9]+)' | tr '\n' ' '))
   for i in $FEED_IDS; do
-    http --ignore-stdin -b -a ${user}:${user} DELETE ${BASE_URLv1}/feeds/$i > /dev/null
+    http --ignore-stdin -b -a ${user}:${APP_PASSWORD} DELETE ${BASE_URLv1}/feeds/$i > /dev/null
   done
 
   # delete all folders
-  FOLDER_IDS=($(http --ignore-stdin -b -a ${user}:${user} GET ${BASE_URLv1}/folders | grep -Po '"id":\K([0-9]+)' | tr '\n' ' '))
+  FOLDER_IDS=($(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/folders | grep -Po '"id":\K([0-9]+)' | tr '\n' ' '))
   for i in $FOLDER_IDS; do
-    http --ignore-stdin -b -a ${user}:${user} DELETE ${BASE_URLv1}/folders/$i > /dev/null
+    http --ignore-stdin -b -a ${user}:${APP_PASSWORD} DELETE ${BASE_URLv1}/folders/$i > /dev/null
   done
 }
 
 @test "[$TESTSUITE] Read empty" {
-  run http --ignore-stdin -b -a ${user}:${user} GET ${BASE_URLv1}/folders
+  run http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/folders
   
   assert_output --partial "\"folders\":[]"
 }
 
 @test "[$TESTSUITE] Create new" {
-  run http --ignore-stdin -b -a ${user}:${user} POST ${BASE_URLv1}/folders name=news-${BATS_SUITE_TEST_NUMBER}
+  run http --ignore-stdin -b -a ${user}:${APP_PASSWORD} POST ${BASE_URLv1}/folders name=news-${BATS_SUITE_TEST_NUMBER}
   
   assert_output --partial "\"name\":\"news-${BATS_SUITE_TEST_NUMBER}\","
 }
 
 @test "[$TESTSUITE] Delete folder" {
-  ID=$(http --ignore-stdin -b -a ${user}:${user} POST ${BASE_URLv1}/folders name=news-${BATS_SUITE_TEST_NUMBER} | grep -Po '"id":\K([0-9]+)')
+  ID=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} POST ${BASE_URLv1}/folders name=news-${BATS_SUITE_TEST_NUMBER} | grep -Po '"id":\K([0-9]+)')
 
-  run http --ignore-stdin -b -a ${user}:${user} DELETE ${BASE_URLv1}/folders/$ID
+  run http --ignore-stdin -b -a ${user}:${APP_PASSWORD} DELETE ${BASE_URLv1}/folders/$ID
   
   assert_output "[]"
 }
 
 @test "[$TESTSUITE] Rename folder" {
-  ID=$(http --ignore-stdin -b -a ${user}:${user} POST ${BASE_URLv1}/folders name=news-${BATS_SUITE_TEST_NUMBER} | grep -Po '"id":\K([0-9]+)')
+  ID=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} POST ${BASE_URLv1}/folders name=news-${BATS_SUITE_TEST_NUMBER} | grep -Po '"id":\K([0-9]+)')
 
   # Rename folder
-  http --ignore-stdin -b -a ${user}:${user} PUT ${BASE_URLv1}/folders/$ID name=rename-${BATS_SUITE_TEST_NUMBER}
+  http --ignore-stdin -b -a ${user}:${APP_PASSWORD} PUT ${BASE_URLv1}/folders/$ID name=rename-${BATS_SUITE_TEST_NUMBER}
   
-  run http --ignore-stdin -b -a ${user}:${user} GET ${BASE_URLv1}/folders
+  run http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/folders
 
   assert_output --partial "\"name\":\"rename-${BATS_SUITE_TEST_NUMBER}\","
 }
 
 @test "[$TESTSUITE] Mark all items as read" {
   # create folder and feed in folder
-  FOLDER_ID=$(http --ignore-stdin -b -a ${user}:${user} POST ${BASE_URLv1}/folders name=news-${BATS_SUITE_TEST_NUMBER} | grep -Po '"id":\K([0-9]+)')
-  FEED_ID=$(http --ignore-stdin -b -a ${user}:${user} POST ${BASE_URLv1}/feeds url=$NC_FEED folderId=$FOLDER_ID | grep -Po '"id":\K([0-9]+)')
+  FOLDER_ID=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} POST ${BASE_URLv1}/folders name=news-${BATS_SUITE_TEST_NUMBER} | grep -Po '"id":\K([0-9]+)')
+  FEED_ID=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} POST ${BASE_URLv1}/feeds url=$NC_FEED folderId=$FOLDER_ID | grep -Po '"id":\K([0-9]+)')
   
-  ID_LIST=($(http --ignore-stdin -b -a ${user}:${user} GET ${BASE_URLv1}/items id=$FEEDID | grep -Po '"id":\K([0-9]+)' | tr '\n' ' '))
+  ID_LIST=($(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/items id=$FEEDID | grep -Po '"id":\K([0-9]+)' | tr '\n' ' '))
 
   # get biggest item ID
   max=${ID_LIST[0]}
@@ -72,10 +80,10 @@ teardown() {
   done
   
   # mark all items of feed as read, returns nothing
-  STATUS_CODE=$(http --ignore-stdin -hdo /tmp/body -a ${user}:${user} PUT ${BASE_URLv1}/folders/$FOLDER_ID/read newestItemId="$max" 2>&1| grep HTTP/)
+  STATUS_CODE=$(http --ignore-stdin -hdo /tmp/body -a ${user}:${APP_PASSWORD} PUT ${BASE_URLv1}/folders/$FOLDER_ID/read newestItemId="$max" 2>&1| grep HTTP/)
 
   # collect unread status
-  unread=$(http --ignore-stdin -b -a ${user}:${user} GET ${BASE_URLv1}/items id=$FEEDID | grep -Po '"unread":\K((true)|(false))' | tr '\n' ' ')
+  unread=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/items id=$FEEDID | grep -Po '"unread":\K((true)|(false))' | tr '\n' ' ')
   
   for n in "${unread[@]}" ; do
       if $n

--- a/tests/api/helpers/settings.bash
+++ b/tests/api/helpers/settings.bash
@@ -1,4 +1,5 @@
-user=admin
-NC_FEED="http://localhost:8090/Nextcloud.rss"
-HEISE_FEED="http://localhost:8090/heise.xml"
-BASE_URLv1="http://localhost:8080/index.php/apps/news/api/v1-2"
+export user=admin
+export NC_FEED="http://localhost:8090/Nextcloud.rss"
+export HEISE_FEED="http://localhost:8090/heise.xml"
+export BASE_URLv1="http://localhost:8080/index.php/apps/news/api/v1-2"
+export NC_HOST="http://localhost:8080"

--- a/tests/test_helper/feeds/Nextcloud.rss
+++ b/tests/test_helper/feeds/Nextcloud.rss
@@ -9,7 +9,7 @@
 
 <channel>
 	<title>Nextcloud</title>
-	<atom:link href="https://nextcloud.com/feed/" rel="self" type="application/rss+xml" />
+	<atom:link href="http://localhost:8090/Nextcloud.rss" rel="self" type="application/rss+xml" />
 	<link>https://nextcloud.com/</link>
 	<description></description>
 	<lastBuildDate>Tue, 16 Aug 2022 10:17:13 +0000</lastBuildDate>

--- a/tests/test_helper/feeds/heise.xml
+++ b/tests/test_helper/feeds/heise.xml
@@ -7,7 +7,7 @@
         <name>heise online</name><uri>https://www.heise.de</uri>
     </author>
     
-    <link rel="self" type="application/atom+xml" href="https://www.heise.de/rss/heise-atom.xml"/>
+    <link rel="self" type="application/atom+xml" href="http://localhost:8090/heise.xml"/>
     <link rel="alternate" type="text/html" href="https://www.heise.de/"/>
     <rights>Copyright (c) 2022 Heise Medien</rights>
     


### PR DESCRIPTION
The app password is nice in local testing, since Nextcloud logs too much data if you use the user password. Setup_file and teardown_file are only executed once instead of running before and after every job.