### PR TITLE
Fix nested scroll bars in navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Fixed
 - Fixed various keyboard navigation issues (#1953)
 - Fix cron job warning notification layout on NC25 (#1953)
+- Fix nested scrollbars in navigation (#411)
 
 ## [19.0.0-beta1] - 2022-10-22
 ### Changed

--- a/css/navigation.css
+++ b/css/navigation.css
@@ -7,6 +7,9 @@
  * @author Bernhard Posselt <dev@bernhard-posselt.com>
  * @copyright Bernhard Posselt 2014
  */
+#app-navigation {
+    overflow-y: hidden !important;
+}
 
 /* add new feed or folder */
 /* button */


### PR DESCRIPTION
Fix the doubled/nested scroll bars in the navigation menu. Easy to reproduce if you have a couple of folders and open the settings menu. 

https://github.com/nextcloud/news/issues/411

Tested in Firefox and Edge.