### PR TITLE
[Vue Rewrite] Add Unit Tests for Admin Settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@nextcloud/l10n": "^1.6.0",
         "@nextcloud/router": "^2.0.0",
         "@nextcloud/vue": "^7.0.1",
-        "regenerator-runtime": "^0.13.11",
         "vue": "^2.6.14",
         "vue-router": "^3.5.3",
         "vuex": "^3.6.2"
@@ -64,6 +63,7 @@
         "md5": "^2.3.0",
         "node-gettext": "^3.0.0",
         "node-polyfill-webpack-plugin": "^2.0.1",
+        "regenerator-runtime": "^0.13.11",
         "regenerator-transform": "^0.15.0",
         "regexpu-core": "^5.2.1",
         "splitpanes": "^3.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@nextcloud/initial-state": "^2.0.0",
         "@nextcloud/router": "^2.0.0",
         "@nextcloud/vue": "^7.0.1",
+        "regenerator-runtime": "^0.13.11",
         "vue": "^2.6.14",
         "vue-router": "^3.5.3",
         "vuex": "^3.6.2"
@@ -297,16 +298,17 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.19.0",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.2.tgz",
+      "integrity": "sha512-k22GoYRAHPYr9I+Gvy2ZQlAe5mGy8BqWst2wRt8cwIufWTxrsVshhIBvYNqC80N0GSFWTsqRVexOtfzlgOEDvA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-member-expression-to-functions": "^7.18.9",
         "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/helper-replace-supers": "^7.18.9",
+        "@babel/helper-replace-supers": "^7.19.1",
         "@babel/helper-split-export-declaration": "^7.18.6"
       },
       "engines": {
@@ -450,9 +452,10 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.19.0",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1739,45 +1742,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
-      "integrity": "sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/compat-data": "^7.17.7",
-        "@babel/helper-define-polyfill-provider": "^0.3.3",
-        "semver": "^6.1.1"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.6.0.tgz",
-      "integrity": "sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.3.3",
-        "core-js-compat": "^3.25.1"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.1.tgz",
-      "integrity": "sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.3.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/preset-env/node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -1828,11 +1792,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
     },
     "node_modules/@babel/template": {
       "version": "7.18.10",
@@ -5601,6 +5560,54 @@
         "object.assign": "^4.1.0"
       }
     },
+    "node_modules/babel-plugin-polyfill-corejs2": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
+      "integrity": "sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.17.7",
+        "@babel/helper-define-polyfill-provider": "^0.3.3",
+        "semver": "^6.1.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.6.0.tgz",
+      "integrity": "sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.3.3",
+        "core-js-compat": "^3.25.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-polyfill-regenerator": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.1.tgz",
+      "integrity": "sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.3.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.26.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
@@ -5786,6 +5793,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/babel-plugin-transform-es2015-modules-commonjs/node_modules/regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "node_modules/babel-plugin-transform-es2015-modules-commonjs/node_modules/strip-ansi": {
@@ -13559,10 +13572,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.0",
@@ -16528,7 +16540,9 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.19.0",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.2.tgz",
+      "integrity": "sha512-k22GoYRAHPYr9I+Gvy2ZQlAe5mGy8BqWst2wRt8cwIufWTxrsVshhIBvYNqC80N0GSFWTsqRVexOtfzlgOEDvA==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
@@ -16536,7 +16550,7 @@
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-member-expression-to-functions": "^7.18.9",
         "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/helper-replace-supers": "^7.18.9",
+        "@babel/helper-replace-supers": "^7.19.1",
         "@babel/helper-split-export-declaration": "^7.18.6"
       }
     },
@@ -16630,7 +16644,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.19.0",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
       "dev": true
     },
     "@babel/helper-remap-async-to-generator": {
@@ -17399,36 +17415,6 @@
         "semver": "^6.3.0"
       },
       "dependencies": {
-        "babel-plugin-polyfill-corejs2": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
-          "integrity": "sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==",
-          "dev": true,
-          "requires": {
-            "@babel/compat-data": "^7.17.7",
-            "@babel/helper-define-polyfill-provider": "^0.3.3",
-            "semver": "^6.1.1"
-          }
-        },
-        "babel-plugin-polyfill-corejs3": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.6.0.tgz",
-          "integrity": "sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-define-polyfill-provider": "^0.3.3",
-            "core-js-compat": "^3.25.1"
-          }
-        },
-        "babel-plugin-polyfill-regenerator": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.1.tgz",
-          "integrity": "sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-define-polyfill-provider": "^0.3.3"
-          }
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -17463,13 +17449,6 @@
       "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
       "requires": {
         "regenerator-runtime": "^0.13.10"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.13.10",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-          "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
-        }
       }
     },
     "@babel/template": {
@@ -20292,6 +20271,44 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-polyfill-corejs2": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
+      "integrity": "sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.17.7",
+        "@babel/helper-define-polyfill-provider": "^0.3.3",
+        "semver": "^6.1.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "babel-plugin-polyfill-corejs3": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.6.0.tgz",
+      "integrity": "sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-define-polyfill-provider": "^0.3.3",
+        "core-js-compat": "^3.25.1"
+      }
+    },
+    "babel-plugin-polyfill-regenerator": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.1.tgz",
+      "integrity": "sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-define-polyfill-provider": "^0.3.3"
+      }
+    },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.26.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
@@ -20457,6 +20474,12 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
           "dev": true
         },
         "strip-ansi": {
@@ -26409,10 +26432,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regenerator-transform": {
       "version": "0.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@nextcloud/axios": "^1.11.0",
         "@nextcloud/dialogs": "^3.1.2",
         "@nextcloud/initial-state": "^2.0.0",
+        "@nextcloud/l10n": "^1.6.0",
         "@nextcloud/router": "^2.0.0",
         "@nextcloud/vue": "^7.0.1",
         "regenerator-runtime": "^0.13.11",
@@ -3307,7 +3308,8 @@
     },
     "node_modules/@nextcloud/l10n": {
       "version": "1.6.0",
-      "license": "GPL-3.0-or-later",
+      "resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-1.6.0.tgz",
+      "integrity": "sha512-aKGlgrwN9OiafN791sYus0shfwNeU3PlrH6Oi9ISma6iJSvN6a8aJM8WGKCJ9pqBaTR5PrDuckuM/WnybBWb6A==",
       "dependencies": {
         "core-js": "^3.6.4",
         "node-gettext": "^3.0.0"
@@ -18596,6 +18598,8 @@
     },
     "@nextcloud/l10n": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-1.6.0.tgz",
+      "integrity": "sha512-aKGlgrwN9OiafN791sYus0shfwNeU3PlrH6Oi9ISma6iJSvN6a8aJM8WGKCJ9pqBaTR5PrDuckuM/WnybBWb6A==",
       "requires": {
         "core-js": "^3.6.4",
         "node-gettext": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "nextcloud-news",
       "license": "AGPL-3.0",
       "dependencies": {
+        "@nextcloud/auth": "^2.0.0",
         "@nextcloud/axios": "^1.11.0",
         "@nextcloud/dialogs": "^3.1.2",
         "@nextcloud/initial-state": "^2.0.0",
@@ -3141,12 +3142,11 @@
       "peer": true
     },
     "node_modules/@nextcloud/auth": {
-      "version": "1.3.0",
-      "license": "GPL-3.0-or-later",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.0.0.tgz",
+      "integrity": "sha512-v8K8tvjkOsGt1+gKydVeMiEwWLXlfPWSptXnMqP21Xd6pFAQxNuNNCY679XKU4MNaKzpZqLstCCxv/KrjeQv8A==",
       "dependencies": {
-        "@nextcloud/event-bus": "^1.1.3",
-        "@nextcloud/typings": "^0.2.2",
-        "core-js": "^3.6.4"
+        "@nextcloud/event-bus": "^3.0.0"
       }
     },
     "node_modules/@nextcloud/axios": {
@@ -3160,6 +3160,26 @@
       "engines": {
         "node": "^16.0.0",
         "npm": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@nextcloud/axios/node_modules/@nextcloud/auth": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-1.3.0.tgz",
+      "integrity": "sha512-GfwRM9W7hat4psNdAt74UHEV+drEXQ53klCVp6JpON66ZLPeK5eJ1LQuiQDkpUxZpqNeaumXjiB98h5cug/uQw==",
+      "dependencies": {
+        "@nextcloud/event-bus": "^1.1.3",
+        "@nextcloud/typings": "^0.2.2",
+        "core-js": "^3.6.4"
+      }
+    },
+    "node_modules/@nextcloud/axios/node_modules/@nextcloud/event-bus": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-1.3.0.tgz",
+      "integrity": "sha512-+U5MnCvfnNWvf0lvdqJg8F+Nm8wN+s9ayuBjtiEQxTAcootv7lOnlMgfreqF3l2T0Wet2uZh4JbFVUWf8l3w7g==",
+      "dependencies": {
+        "@types/semver": "^7.3.5",
+        "core-js": "^3.11.2",
+        "semver": "^7.3.5"
       }
     },
     "node_modules/@nextcloud/axios/node_modules/axios": {
@@ -3299,12 +3319,15 @@
       }
     },
     "node_modules/@nextcloud/event-bus": {
-      "version": "1.3.0",
-      "license": "GPL-3.0-or-later",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.0.2.tgz",
+      "integrity": "sha512-svXCZa4UkoZKsBiGzTi0cVcbPFUOhCm7pMKjGumRwBvHywX+8by478IQ8Grw75PFHxajMJZ0KrOTTM8WnzzEAw==",
       "dependencies": {
-        "@types/semver": "^7.3.5",
-        "core-js": "^3.11.2",
-        "semver": "^7.3.5"
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^16.0.0",
+        "npm": "^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@nextcloud/focus-trap": {
@@ -3343,6 +3366,26 @@
         "npm": "^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@nextcloud/logger/node_modules/@nextcloud/auth": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-1.3.0.tgz",
+      "integrity": "sha512-GfwRM9W7hat4psNdAt74UHEV+drEXQ53klCVp6JpON66ZLPeK5eJ1LQuiQDkpUxZpqNeaumXjiB98h5cug/uQw==",
+      "dependencies": {
+        "@nextcloud/event-bus": "^1.1.3",
+        "@nextcloud/typings": "^0.2.2",
+        "core-js": "^3.6.4"
+      }
+    },
+    "node_modules/@nextcloud/logger/node_modules/@nextcloud/event-bus": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-1.3.0.tgz",
+      "integrity": "sha512-+U5MnCvfnNWvf0lvdqJg8F+Nm8wN+s9ayuBjtiEQxTAcootv7lOnlMgfreqF3l2T0Wet2uZh4JbFVUWf8l3w7g==",
+      "dependencies": {
+        "@types/semver": "^7.3.5",
+        "core-js": "^3.11.2",
+        "semver": "^7.3.5"
+      }
+    },
     "node_modules/@nextcloud/password-confirmation": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@nextcloud/password-confirmation/-/password-confirmation-4.0.2.tgz",
@@ -3360,15 +3403,6 @@
         "npm": "^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@nextcloud/password-confirmation/node_modules/@nextcloud/auth": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.0.0.tgz",
-      "integrity": "sha512-v8K8tvjkOsGt1+gKydVeMiEwWLXlfPWSptXnMqP21Xd6pFAQxNuNNCY679XKU4MNaKzpZqLstCCxv/KrjeQv8A==",
-      "dev": true,
-      "dependencies": {
-        "@nextcloud/event-bus": "^3.0.0"
-      }
-    },
     "node_modules/@nextcloud/password-confirmation/node_modules/@nextcloud/axios": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.1.0.tgz",
@@ -3379,19 +3413,6 @@
         "@nextcloud/router": "^2.0.0",
         "axios": "^0.27.2",
         "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": "^16.0.0",
-        "npm": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@nextcloud/password-confirmation/node_modules/@nextcloud/event-bus": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.0.2.tgz",
-      "integrity": "sha512-svXCZa4UkoZKsBiGzTi0cVcbPFUOhCm7pMKjGumRwBvHywX+8by478IQ8Grw75PFHxajMJZ0KrOTTM8WnzzEAw==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^7.3.7"
       },
       "engines": {
         "node": "^16.0.0",
@@ -3431,7 +3452,8 @@
     },
     "node_modules/@nextcloud/typings": {
       "version": "0.2.4",
-      "license": "GPL-3.0-or-later",
+      "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-0.2.4.tgz",
+      "integrity": "sha512-49M8XUDQH27VIQE+13KrqSOYcyOsDUk6Yfw17jbBVtXFoDJ3YBSYYq8YaKeAM3Lz2JVbEpqQW9suAT+EyYSb6g==",
       "dependencies": {
         "@types/jquery": "2.0.54"
       }
@@ -3475,13 +3497,6 @@
         "npm": "^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@nextcloud/vue/node_modules/@nextcloud/auth": {
-      "version": "2.0.0",
-      "license": "GPL-3.0-or-later",
-      "dependencies": {
-        "@nextcloud/event-bus": "^3.0.0"
-      }
-    },
     "node_modules/@nextcloud/vue/node_modules/@nextcloud/axios": {
       "version": "2.1.0",
       "license": "GPL-3.0",
@@ -3490,17 +3505,6 @@
         "@nextcloud/router": "^2.0.0",
         "axios": "^0.27.2",
         "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": "^16.0.0",
-        "npm": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@nextcloud/vue/node_modules/@nextcloud/event-bus": {
-      "version": "3.0.2",
-      "license": "GPL-3.0-or-later",
-      "dependencies": {
-        "semver": "^7.3.7"
       },
       "engines": {
         "node": "^16.0.0",
@@ -3805,7 +3809,8 @@
     },
     "node_modules/@types/jquery": {
       "version": "2.0.54",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.54.tgz",
+      "integrity": "sha512-D/PomKwNkDfSKD13DEVQT/pq2TUjN54c6uB341fEZanIzkjfGe7UaFuuaLZbpEiS5j7Wk2MUHAZqZIoECw29lg=="
     },
     "node_modules/@types/jsdom": {
       "version": "20.0.0",
@@ -3881,8 +3886,9 @@
       "peer": true
     },
     "node_modules/@types/semver": {
-      "version": "7.3.12",
-      "license": "MIT"
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw=="
     },
     "node_modules/@types/serve-index": {
       "version": "1.9.1",
@@ -18471,11 +18477,11 @@
       "peer": true
     },
     "@nextcloud/auth": {
-      "version": "1.3.0",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.0.0.tgz",
+      "integrity": "sha512-v8K8tvjkOsGt1+gKydVeMiEwWLXlfPWSptXnMqP21Xd6pFAQxNuNNCY679XKU4MNaKzpZqLstCCxv/KrjeQv8A==",
       "requires": {
-        "@nextcloud/event-bus": "^1.1.3",
-        "@nextcloud/typings": "^0.2.2",
-        "core-js": "^3.6.4"
+        "@nextcloud/event-bus": "^3.0.0"
       }
     },
     "@nextcloud/axios": {
@@ -18486,6 +18492,26 @@
         "core-js": "^3.6.4"
       },
       "dependencies": {
+        "@nextcloud/auth": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-1.3.0.tgz",
+          "integrity": "sha512-GfwRM9W7hat4psNdAt74UHEV+drEXQ53klCVp6JpON66ZLPeK5eJ1LQuiQDkpUxZpqNeaumXjiB98h5cug/uQw==",
+          "requires": {
+            "@nextcloud/event-bus": "^1.1.3",
+            "@nextcloud/typings": "^0.2.2",
+            "core-js": "^3.6.4"
+          }
+        },
+        "@nextcloud/event-bus": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-1.3.0.tgz",
+          "integrity": "sha512-+U5MnCvfnNWvf0lvdqJg8F+Nm8wN+s9ayuBjtiEQxTAcootv7lOnlMgfreqF3l2T0Wet2uZh4JbFVUWf8l3w7g==",
+          "requires": {
+            "@types/semver": "^7.3.5",
+            "core-js": "^3.11.2",
+            "semver": "^7.3.5"
+          }
+        },
         "axios": {
           "version": "0.27.2",
           "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
@@ -18571,11 +18597,11 @@
       }
     },
     "@nextcloud/event-bus": {
-      "version": "1.3.0",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.0.2.tgz",
+      "integrity": "sha512-svXCZa4UkoZKsBiGzTi0cVcbPFUOhCm7pMKjGumRwBvHywX+8by478IQ8Grw75PFHxajMJZ0KrOTTM8WnzzEAw==",
       "requires": {
-        "@types/semver": "^7.3.5",
-        "core-js": "^3.11.2",
-        "semver": "^7.3.5"
+        "semver": "^7.3.7"
       }
     },
     "@nextcloud/focus-trap": {
@@ -18601,6 +18627,28 @@
       "requires": {
         "@nextcloud/auth": "^1.2.2",
         "core-js": "^3.6.4"
+      },
+      "dependencies": {
+        "@nextcloud/auth": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-1.3.0.tgz",
+          "integrity": "sha512-GfwRM9W7hat4psNdAt74UHEV+drEXQ53klCVp6JpON66ZLPeK5eJ1LQuiQDkpUxZpqNeaumXjiB98h5cug/uQw==",
+          "requires": {
+            "@nextcloud/event-bus": "^1.1.3",
+            "@nextcloud/typings": "^0.2.2",
+            "core-js": "^3.6.4"
+          }
+        },
+        "@nextcloud/event-bus": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-1.3.0.tgz",
+          "integrity": "sha512-+U5MnCvfnNWvf0lvdqJg8F+Nm8wN+s9ayuBjtiEQxTAcootv7lOnlMgfreqF3l2T0Wet2uZh4JbFVUWf8l3w7g==",
+          "requires": {
+            "@types/semver": "^7.3.5",
+            "core-js": "^3.11.2",
+            "semver": "^7.3.5"
+          }
+        }
       }
     },
     "@nextcloud/password-confirmation": {
@@ -18616,15 +18664,6 @@
         "vue": "^2.7.10"
       },
       "dependencies": {
-        "@nextcloud/auth": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.0.0.tgz",
-          "integrity": "sha512-v8K8tvjkOsGt1+gKydVeMiEwWLXlfPWSptXnMqP21Xd6pFAQxNuNNCY679XKU4MNaKzpZqLstCCxv/KrjeQv8A==",
-          "dev": true,
-          "requires": {
-            "@nextcloud/event-bus": "^3.0.0"
-          }
-        },
         "@nextcloud/axios": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-2.1.0.tgz",
@@ -18635,15 +18674,6 @@
             "@nextcloud/router": "^2.0.0",
             "axios": "^0.27.2",
             "tslib": "^2.4.0"
-          }
-        },
-        "@nextcloud/event-bus": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.0.2.tgz",
-          "integrity": "sha512-svXCZa4UkoZKsBiGzTi0cVcbPFUOhCm7pMKjGumRwBvHywX+8by478IQ8Grw75PFHxajMJZ0KrOTTM8WnzzEAw==",
-          "dev": true,
-          "requires": {
-            "semver": "^7.3.7"
           }
         },
         "axios": {
@@ -18671,6 +18701,8 @@
     },
     "@nextcloud/typings": {
       "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-0.2.4.tgz",
+      "integrity": "sha512-49M8XUDQH27VIQE+13KrqSOYcyOsDUk6Yfw17jbBVtXFoDJ3YBSYYq8YaKeAM3Lz2JVbEpqQW9suAT+EyYSb6g==",
       "requires": {
         "@types/jquery": "2.0.54"
       }
@@ -18709,12 +18741,6 @@
         "vue2-datepicker": "^3.11.0"
       },
       "dependencies": {
-        "@nextcloud/auth": {
-          "version": "2.0.0",
-          "requires": {
-            "@nextcloud/event-bus": "^3.0.0"
-          }
-        },
         "@nextcloud/axios": {
           "version": "2.1.0",
           "requires": {
@@ -18722,12 +18748,6 @@
             "@nextcloud/router": "^2.0.0",
             "axios": "^0.27.2",
             "tslib": "^2.4.0"
-          }
-        },
-        "@nextcloud/event-bus": {
-          "version": "3.0.2",
-          "requires": {
-            "semver": "^7.3.7"
           }
         },
         "axios": {
@@ -18977,7 +18997,9 @@
       }
     },
     "@types/jquery": {
-      "version": "2.0.54"
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.54.tgz",
+      "integrity": "sha512-D/PomKwNkDfSKD13DEVQT/pq2TUjN54c6uB341fEZanIzkjfGe7UaFuuaLZbpEiS5j7Wk2MUHAZqZIoECw29lg=="
     },
     "@types/jsdom": {
       "version": "20.0.0",
@@ -19045,7 +19067,9 @@
       "peer": true
     },
     "@types/semver": {
-      "version": "7.3.12"
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw=="
     },
     "@types/serve-index": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@nextcloud/l10n": "^1.6.0",
     "@nextcloud/router": "^2.0.0",
     "@nextcloud/vue": "^7.0.1",
-    "regenerator-runtime": "^0.13.11",
     "vue": "^2.6.14",
     "vue-router": "^3.5.3",
     "vuex": "^3.6.2"
@@ -100,6 +99,7 @@
     "md5": "^2.3.0",
     "node-gettext": "^3.0.0",
     "node-polyfill-webpack-plugin": "^2.0.1",
+    "regenerator-runtime": "^0.13.11",
     "regenerator-transform": "^0.15.0",
     "regexpu-core": "^5.2.1",
     "splitpanes": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "private": true,
   "homepage": "https://github.com/nextcloud/news",
   "dependencies": {
+    "@nextcloud/auth": "^2.0.0",
     "@nextcloud/axios": "^1.11.0",
     "@nextcloud/dialogs": "^3.1.2",
     "@nextcloud/initial-state": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@nextcloud/axios": "^1.11.0",
     "@nextcloud/dialogs": "^3.1.2",
     "@nextcloud/initial-state": "^2.0.0",
+    "@nextcloud/l10n": "^1.6.0",
     "@nextcloud/router": "^2.0.0",
     "@nextcloud/vue": "^7.0.1",
     "regenerator-runtime": "^0.13.11",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@nextcloud/initial-state": "^2.0.0",
     "@nextcloud/router": "^2.0.0",
     "@nextcloud/vue": "^7.0.1",
+    "regenerator-runtime": "^0.13.11",
     "vue": "^2.6.14",
     "vue-router": "^3.5.3",
     "vuex": "^3.6.2"
@@ -141,7 +142,8 @@
       "^.+\\.ts?$": "ts-jest"
     },
     "transformIgnorePatterns": [
-      "/node_modules/(?!(@nextcloud)|(vue-material-design-icons))"
+      "/node_modules/(?!(@nextcloud)|(vue-material-design-icons))",
+      "/node_modules/@nextcloud/password-confirmation"
     ],
     "snapshotSerializers": [
       "jest-serializer-vue"

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -104,7 +104,7 @@ import { loadState } from '@nextcloud/initial-state'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
-import confirmPassword from '@nextcloud/password-confirmation'
+import { confirmPassword } from '@nextcloud/password-confirmation' // TODO: throws 'invariant' error with jest?
 
 /**
  *

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -104,7 +104,7 @@ import { loadState } from '@nextcloud/initial-state'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
-import { confirmPassword } from '@nextcloud/password-confirmation' // TODO: throws 'invariant' error with jest?
+import { confirmPassword } from '@nextcloud/password-confirmation'
 
 /**
  *
@@ -172,7 +172,7 @@ export default {
 				})
 			}
 		},
-		async handleResponse({ status, errorMessage, error }) {
+		handleResponse({ status, errorMessage, error }) {
 			if (status !== 'ok') {
 				showError(errorMessage)
 				console.error(errorMessage, error)

--- a/src/main-admin.js
+++ b/src/main-admin.js
@@ -3,7 +3,7 @@
 
 import Vue from 'vue'
 import { getRequestToken } from '@nextcloud/auth'
-// import { translate as t } from '@nextcloud/l10n'
+import { translate as t } from '@nextcloud/l10n'
 
 import AdminSettings from './components/AdminSettings.vue'
 

--- a/src/main-admin.js
+++ b/src/main-admin.js
@@ -2,7 +2,7 @@
 // SPDX-Licence-Identifier: AGPL-3.0-or-later
 
 import Vue from 'vue'
-// import { getRequestToken } from '@nextcloud/auth'
+import { getRequestToken } from '@nextcloud/auth'
 // import { translate as t } from '@nextcloud/l10n'
 
 import AdminSettings from './components/AdminSettings.vue'

--- a/tests/javascript/unit/components/AdminSettings.spec.ts
+++ b/tests/javascript/unit/components/AdminSettings.spec.ts
@@ -4,7 +4,9 @@ import { store, localVue } from "../setupStore";
 import { showError, showSuccess } from "@nextcloud/dialogs";
 import { loadState } from "@nextcloud/initial-state";
 
+import 'regenerator-runtime/runtime' // NOTE: Required for testing password-confirmation?
 import AdminSettings from "Components/AdminSettings.vue";
+
 
 jest.mock("@nextcloud/axios");
 jest.mock("@nextcloud/initial-state");
@@ -17,40 +19,47 @@ describe("AdminSettings.vue", () => {
 	let wrapper: Wrapper<AdminSettings>;
 
 	beforeAll(() => {
-		wrapper = shallowMount(AdminSettings, { localVue, store });
+		jest.useFakeTimers();
+		(loadState as any).mockReturnValue('');
+		wrapper = shallowMount(AdminSettings, { localVue, store});
 	});
 
 	it("should initialize and fetch settings from state", () => {
 		expect(loadState).toBeCalledTimes(7);
 	});
 
-	it("should send post with updated settings", () => {
+	it("should send post with updated settings", async () => {
 		jest.spyOn(axios, "post").mockResolvedValue({ data: {} });
+		(wrapper.vm as any).handleResponse = jest.fn()
 
-		wrapper.vm.$options?.methods?.update.call(wrapper.vm);
+		await wrapper.vm.$options?.methods?.update.call(wrapper.vm, 'key', 'val');
 
-		expect(axios.post).toBeCalled;
+		expect(axios.post).toBeCalledTimes(1);
 	});
 
 	it("should handle bad response", () => {
+		(showError as any).mockClear();
 		console.error = jest.fn();
 		wrapper.vm.$options?.methods?.handleResponse.call(wrapper.vm, {
 			error: true,
 			errorMessage: "FAIL",
 		});
 
-		expect(showError).toBeCalled;
+		expect(showError).toBeCalledTimes(1);
 	});
 
 	it("should handle success response", () => {
 		wrapper.vm.$options?.methods?.handleResponse.call(wrapper.vm, {
-			success: "ok",
+			status: "ok",
 		});
+		(global as any).t = jest.fn();
+		jest.runAllTimers();
 
-		expect(showSuccess).toBeCalled;
+		expect(showSuccess).toBeCalledTimes(1);
 	});
 
 	afterAll(() => {
 		jest.clearAllMocks();
+		jest.useRealTimers();
 	});
 });

--- a/tests/javascript/unit/components/AdminSettings.spec.ts
+++ b/tests/javascript/unit/components/AdminSettings.spec.ts
@@ -1,20 +1,20 @@
-import axios from "@nextcloud/axios";
-import { shallowMount, Wrapper } from "@vue/test-utils";
-import { store, localVue } from "../setupStore";
-import { showError, showSuccess } from "@nextcloud/dialogs";
-import { loadState } from "@nextcloud/initial-state";
+import axios from '@nextcloud/axios';
+import { shallowMount, Wrapper } from '@vue/test-utils';
+import { store, localVue } from '../setupStore';
+import { showError, showSuccess } from '@nextcloud/dialogs';
+import { loadState } from '@nextcloud/initial-state';
 
 import 'regenerator-runtime/runtime' // NOTE: Required for testing password-confirmation?
-import AdminSettings from "Components/AdminSettings.vue";
+import AdminSettings from 'Components/AdminSettings.vue';
 
 
-jest.mock("@nextcloud/axios");
-jest.mock("@nextcloud/initial-state");
-jest.mock("@nextcloud/router");
-jest.mock("@nextcloud/dialogs");
+jest.mock('@nextcloud/axios');
+jest.mock('@nextcloud/initial-state');
+jest.mock('@nextcloud/router');
+jest.mock('@nextcloud/dialogs');
 
-describe("AdminSettings.vue", () => {
-	"use strict";
+describe('AdminSettings.vue', () => {
+	'use strict';
 
 	let wrapper: Wrapper<AdminSettings>;
 
@@ -24,12 +24,12 @@ describe("AdminSettings.vue", () => {
 		wrapper = shallowMount(AdminSettings, { localVue, store});
 	});
 
-	it("should initialize and fetch settings from state", () => {
+	it('should initialize and fetch settings from state', () => {
 		expect(loadState).toBeCalledTimes(7);
 	});
 
-	it("should send post with updated settings", async () => {
-		jest.spyOn(axios, "post").mockResolvedValue({ data: {} });
+	it('should send post with updated settings', async () => {
+		jest.spyOn(axios, 'post').mockResolvedValue({ data: {} });
 		(wrapper.vm as any).handleResponse = jest.fn()
 
 		await wrapper.vm.$options?.methods?.update.call(wrapper.vm, 'key', 'val');
@@ -37,20 +37,20 @@ describe("AdminSettings.vue", () => {
 		expect(axios.post).toBeCalledTimes(1);
 	});
 
-	it("should handle bad response", () => {
+	it('should handle bad response', () => {
 		(showError as any).mockClear();
 		console.error = jest.fn();
 		wrapper.vm.$options?.methods?.handleResponse.call(wrapper.vm, {
 			error: true,
-			errorMessage: "FAIL",
+			errorMessage: 'FAIL',
 		});
 
 		expect(showError).toBeCalledTimes(1);
 	});
 
-	it("should handle success response", () => {
+	it('should handle success response', () => {
 		wrapper.vm.$options?.methods?.handleResponse.call(wrapper.vm, {
-			status: "ok",
+			status: 'ok',
 		});
 		(global as any).t = jest.fn();
 		jest.runAllTimers();

--- a/tests/javascript/unit/components/AdminSettings.spec.ts
+++ b/tests/javascript/unit/components/AdminSettings.spec.ts
@@ -1,0 +1,56 @@
+import axios from "@nextcloud/axios";
+import { shallowMount, Wrapper } from "@vue/test-utils";
+import { store, localVue } from "../setupStore";
+import { showError, showSuccess } from "@nextcloud/dialogs";
+import { loadState } from "@nextcloud/initial-state";
+
+import AdminSettings from "Components/AdminSettings.vue";
+
+jest.mock("@nextcloud/axios");
+jest.mock("@nextcloud/initial-state");
+jest.mock("@nextcloud/router");
+jest.mock("@nextcloud/dialogs");
+
+describe("AdminSettings.vue", () => {
+	"use strict";
+
+	let wrapper: Wrapper<AdminSettings>;
+
+	beforeAll(() => {
+		wrapper = shallowMount(AdminSettings, { localVue, store });
+	});
+
+	it("should initialize and fetch settings from state", () => {
+		expect(loadState).toBeCalledTimes(7);
+	});
+
+	it("should send post with updated settings", () => {
+		jest.spyOn(axios, "post").mockResolvedValue({ data: {} });
+
+		wrapper.vm.$options?.methods?.update.call(wrapper.vm);
+
+		expect(axios.post).toBeCalled;
+	});
+
+	it("should handle bad response", () => {
+		console.error = jest.fn();
+		wrapper.vm.$options?.methods?.handleResponse.call(wrapper.vm, {
+			error: true,
+			errorMessage: "FAIL",
+		});
+
+		expect(showError).toBeCalled;
+	});
+
+	it("should handle success response", () => {
+		wrapper.vm.$options?.methods?.handleResponse.call(wrapper.vm, {
+			success: "ok",
+		});
+
+		expect(showSuccess).toBeCalled;
+	});
+
+	afterAll(() => {
+		jest.clearAllMocks();
+	});
+});

--- a/tests/javascript/unit/components/Explore.spec.ts
+++ b/tests/javascript/unit/components/Explore.spec.ts
@@ -1,19 +1,19 @@
-import axios from "@nextcloud/axios";
-import { shallowMount } from "@vue/test-utils";
-import { store, localVue } from "../setupStore";
+import axios from '@nextcloud/axios';
+import { shallowMount } from '@vue/test-utils';
+import { store, localVue } from '../setupStore';
 
-import * as router from "@nextcloud/router";
+import * as router from '@nextcloud/router';
 
-import Explore from "Components/Explore.vue";
+import Explore from 'Components/Explore.vue';
 
-jest.mock("@nextcloud/axios");
+jest.mock('@nextcloud/axios');
 
-describe("Explore.vue", () => {
-	"use strict";
+describe('Explore.vue', () => {
+	'use strict';
 
-	it("should initialize without showing AddFeed Component", () => {
+	it('should initialize without showing AddFeed Component', () => {
 		(axios as any).get.mockResolvedValue({ data: {} });
-		(router as any).generateUrl = jest.fn().mockReturnValue("");
+		(router as any).generateUrl = jest.fn().mockReturnValue('');
 
 		jest.fn().mockReturnValue
 		const wrapper = shallowMount(Explore, { localVue, store });

--- a/tests/javascript/unit/components/Explore.spec.ts
+++ b/tests/javascript/unit/components/Explore.spec.ts
@@ -1,24 +1,23 @@
-import axios from '@nextcloud/axios'
-import { shallowMount } from '@vue/test-utils'
-import { store, localVue } from '../setupStore'
+import axios from "@nextcloud/axios";
+import { shallowMount } from "@vue/test-utils";
+import { store, localVue } from "../setupStore";
 
-import * as router from '@nextcloud/router'
+import * as router from "@nextcloud/router";
 
-import Explore from 'Components/Explore.vue'
+import Explore from "Components/Explore.vue";
 
-jest.mock('@nextcloud/axios')
+jest.mock("@nextcloud/axios");
 
-describe('Explore.vue', () => {
-	'use strict'
-	
-	
+describe("Explore.vue", () => {
+	"use strict";
 
-	it('should initialize without showing AddFeed Component', () => {
-		(axios as any).get.mockResolvedValue({ data: { } })
-    (router as any).generateUrl = jest.fn().mockReturnValue('');
-    
-		const wrapper = shallowMount(Explore, { localVue, store })
+	it("should initialize without showing AddFeed Component", () => {
+		(axios as any).get.mockResolvedValue({ data: {} });
+		(router as any).generateUrl = jest.fn().mockReturnValue("");
 
-		expect(wrapper.vm.$data.showAddFeed).toBeFalsy
+		jest.fn().mockReturnValue
+		const wrapper = shallowMount(Explore, { localVue, store });
+
+		expect(wrapper.vm.$data.showAddFeed).toBeFalsy;
 	});
 });

--- a/tests/javascript/unit/components/Explore.spec.ts
+++ b/tests/javascript/unit/components/Explore.spec.ts
@@ -15,7 +15,6 @@ describe('Explore.vue', () => {
 		(axios as any).get.mockResolvedValue({ data: {} });
 		(router as any).generateUrl = jest.fn().mockReturnValue('');
 
-		jest.fn().mockReturnValue
 		const wrapper = shallowMount(Explore, { localVue, store });
 
 		expect(wrapper.vm.$data.showAddFeed).toBeFalsy;


### PR DESCRIPTION
Related to https://github.com/nextcloud/news/pull/748

Follows #1982

# Add Unit Tests for Admin Settings
 - Plus a little bit of cleanup found while testing

## Testing Completed
- Verified that App Builds with `make`
- Verified that Admin Settings Page Loads on localhost (NC 25)
- Verified that App loads on localhost (NC 25)
- Verified that Jest Unit Tests Pass

## Up Next
- Add Vuex Store (see https://github.com/nextcloud/news/commit/58a196b548e8bf25896ee7db159dbecf88724635 for preview)
- Add Proper Routing (see https://github.com/devlinjunker/news/compare/vue-version...devlinjunker:vue-routes for preview)
- More UI Components to match current features!
- Eventually... Clean up old code