### PR TITLE
[Vue Rewrite] Start More Routes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
 	<NcContent app-name="news">
 		<Sidebar />
 		<NcAppContent>
-			<router-view />
+			<RouterView />
 		</NcAppContent>
 	</NcContent>
 </template>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -27,7 +27,7 @@
 					</ActionButton>
 				</template>
 			</NcAppNavigationItem>
-			<NcAppNavigationItem :title="t('news', 'Starred')" icon="icon-starred">
+			<NcAppNavigationItem :title="t('news', 'Starred')" icon="icon-starred" :to="{ name: ROUTES.STARRED }">
 				<template #counter>
 					<NcCounterBubble>35</NcCounterBubble>
 				</template>
@@ -118,7 +118,7 @@
 
 			<NcAppNavigationItem :title="t('news', 'Explore')"
 				icon="icon-link"
-				:to="{ name: 'explore' }">
+				:to="{ name: ROUTES.EXPLORE }">
 				<template #counter>
 					<NcCounterBubble>35</NcCounterBubble>
 				</template>
@@ -140,7 +140,7 @@ import NcAppNavigationNewItem from '@nextcloud/vue/dist/Components/NcAppNavigati
 import NcCounterBubble from '@nextcloud/vue/dist/Components/NcCounterBubble.js'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 
-// import { ROUTES } from '../routes.js'
+import { ROUTES } from '../routes'
 import { ACTIONS, AppState } from '../store'
 
 import AddFeed from './AddFeed.vue'
@@ -174,7 +174,7 @@ export default Vue.extend({
 	data: () => {
 		return {
 			showAddFeed: false,
-			// ROUTES
+			ROUTES,
 		}
 	},
 	computed: {

--- a/src/components/Starred.vue
+++ b/src/components/Starred.vue
@@ -1,0 +1,25 @@
+<template>
+	<div id="starred">
+		Starred Items Here
+	</div>
+</template>
+
+<script>
+// import axios from "@nextcloud/axios";
+// import { generateUrl } from "@nextcloud/router";
+export default {
+	components: {
+	},
+	props: {
+
+	},
+	created() {
+		// this.fetchStarred();
+	},
+	methods: {
+		async fetchStarred() {
+			// TODO
+		},
+	},
+}
+</script>

--- a/src/main.js
+++ b/src/main.js
@@ -1,11 +1,10 @@
 
 import Vue from 'vue'
-import App from './App.vue'
 import VueRouter from 'vue-router'
-import Explore from './components/Explore.vue'
-import { generateUrl } from '@nextcloud/router'
 import Vuex, { Store } from 'vuex'
 
+import App from './App.vue'
+import router from './routes'
 import mainStore from './store'
 
 import { Tooltip } from '@nextcloud/vue'
@@ -19,20 +18,6 @@ Vue.use(Vuex)
 Vue.use(VueRouter)
 
 Vue.directive('tooltip', Tooltip)
-
-const routes = [
-	{
-		name: 'explore',
-		path: '#explore',
-		component: Explore,
-	},
-]
-
-const router = new VueRouter({
-	mode: 'history',
-	base: generateUrl('apps/news'),
-	routes,
-})
 
 const store = new Store(mainStore)
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,0 +1,44 @@
+import Vue from 'vue'
+import VueRouter from 'vue-router'
+
+import ExplorePanel from '../components/Explore'
+import StarredPanel from '../components/Starred'
+
+export const ROUTES = {
+	EXPLORE: 'explore',
+	STARRED: 'starred',
+}
+
+const getInitialRoute = function() {
+	// TODO: Fetch Recent route from Browser Session?
+	return ROUTES.EXPLORE
+}
+
+const routes = [
+	// using
+	// { path: '/collections/all', component: CollectionGeneral, alias: '/' },
+	// instead of
+	{ path: '/', redirect: getInitialRoute() },
+	// would also be an option, but it currently does not work
+	// reliably with router-link due to
+	// https://github.com/vuejs/vue-router/issues/419
+	{
+		name: ROUTES.EXPLORE,
+		path: '/explore',
+		component: ExplorePanel,
+		props: true,
+	},
+	{
+		name: ROUTES.STARRED,
+		path: '/starred',
+		component: StarredPanel,
+		props: true,
+	},
+]
+
+Vue.use(VueRouter)
+
+export default new VueRouter({
+	linkActiveClass: 'active',
+	routes, // short for `routes: routes`
+})

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,8 +1,7 @@
-import Vue from 'vue'
 import VueRouter from 'vue-router'
 
-import ExplorePanel from '../components/Explore'
-import StarredPanel from '../components/Starred'
+import ExplorePanel from '../components/Explore.vue'
+import StarredPanel from '../components/Starred.vue'
 
 export const ROUTES = {
 	EXPLORE: 'explore',
@@ -35,8 +34,6 @@ const routes = [
 		props: true,
 	},
 ]
-
-Vue.use(VueRouter)
 
 export default new VueRouter({
 	linkActiveClass: 'active',


### PR DESCRIPTION
Related to https://github.com/nextcloud/news/pull/748

Follows #2010

# Start Adding More Routes
 - Add separate file for Routing Config
 - Add New Route and `StarredPanel` Component

## Testing Completed
- Verified that App Builds with `make`
  - Verified that Admin Settings Page Loads on localhost (NC 25)
  - Verified that App loads on localhost (NC 25)
- Verified that Jest Unit Tests Pass (`npm run test`)
- Verified that linting passes (`npm run lint/stylelint`) 
- Verified that New Route can be loaded
![routes](https://user-images.githubusercontent.com/1504590/207785629-bbe5a224-cff2-4ee0-8743-9da2de19de03.gif)


## Up Next
- TBD: Template Testing??
   - WIP at https://github.com/devlinjunker/news/compare/vuex-store...devlinjunker:vue-template-tests
   - TBH I'm not really sure this is worth it... I have looked at other nextcloud repos and do not see this in-depth of testing
- Look into Three Panel Layout ([Bookmarks App](https://github.com/nextcloud/bookmarks/blob/master/src/components/BookmarksList.vue#L32) seems like Good Example...)
- **We are almost here!!** 🥳 🎉 : More UI Components to match current features!
  - Some Ideas:
    - Explore Items from API
    - Connect All SideBar Actions
      - Add Feed 
      - Feed: Mark Read
      - Feed: Pin to Top?
      - Feed: Sort (Newest/Oldest)
      - Feed: Enable Full Text?
      - Feed: Unread Updated?
      - Feed: Open Feed URL
      - Feed: Rename
      - Feed: Delete 
      - Folder: Mark Read
      - Folder: Rename
      - Folder: Delete
    - Starred Items Component
    - FeedItem Component
    - Feed Component
    - Folder Component
    - News Sidebar Settings