### PR TITLE
Workaround for #2048

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
+- SyntaxError triggered when full-text is enabled with some items. (#2048, #2053)
 
 # Releases
 ## [20.0.0] - 2022-12-14

--- a/lib/Scraper/Scraper.php
+++ b/lib/Scraper/Scraper.php
@@ -14,6 +14,7 @@ namespace OCA\News\Scraper;
 use fivefilters\Readability\Readability;
 use fivefilters\Readability\Configuration;
 use fivefilters\Readability\ParseException;
+use League\Uri\Exceptions\SyntaxError;
 use Psr\Log\LoggerInterface;
 
 class Scraper implements IScraper
@@ -74,9 +75,13 @@ class Scraper implements IScraper
 
         try {
             $this->readability->parse($content);
-        } catch (ParseException $e) {
+        } catch (ParseException | SyntaxError $e) {
             $this->logger->error('Unable to parse content from {url}', [
                  'url' => $url,
+            ]);
+            $this->logger->debug('Error during parsing of {url} ran into {error}', [
+                'url' => $url,
+                'error' => $e,
             ]);
         }
         return true;


### PR DESCRIPTION
The league/uri version that we inherit in Nextcloud is a bit outdated. That version can't handle certain uris.

Example log output:

```
{"reqId":"1b1RWb0wI5WE9YePk6DC","level":3,"time":"2023-01-10T12:48:17+00:00","remoteAddr":"","user":"--","app":"news","method":"","url":"--","message":"Unable to parse content from https://matrix.org/blog/2022/11/25/this-week-in-matrix-2022-11-25","userAgent":"--","version":"25.0.0.18","data":{"app":"news"}}
{"reqId":"1b1RWb0wI5WE9YePk6DC","level":0,"time":"2023-01-10T12:48:17+00:00","remoteAddr":"","user":"--","app":"news","method":"","url":"--","message":"Error during parsing of https://matrix.org/blog/2022/11/25/this-week-in-matrix-2022-11-25 ran into {\"class\":\"League\\Uri\\Exceptions\\SyntaxError\",\"message\":\"The uri `@yan:datanauten.de` contains an invalid scheme\",\"code\":0,\"file\":\"/var/www/nextcloud/apps/news/vendor/league/uri/src/UriString.php:313\",\"trace\":\"#0 /var/www/nextcloud/apps/news/vendor/league/uri/src/Uri.php(468): League\\Uri\\UriString::parse()\\n#1 /var/www/nextcloud/apps/news/vendor/league/uri/src/Http.php(68): League\\Uri\\Uri::createFromString()\\n#2 /var/www/nextcloud/apps/news/vendor/fivefilters/readability.php/src/Readability.php(812): League\\Uri\\Http::createFromString()\\n#3 /var/www/nextcloud/apps/news/vendor/fivefilters/readability.php/src/Readability.php(2211): fivefilters\\Readability\\Readability->toAbsoluteURI()\\n#4 /var/www/nextcloud/apps/news/vendor/fivefilters/readability.php/src/Readability.php(258): fivefilters\\Readability\\Readability->postProcessContent()\\n#5 /var/www/nextcloud/apps/news/lib/Scraper/Scraper.php(77): fivefilters\\Readability\\Readability->parse()\\n#6 /var/www/nextcloud/apps/news/lib/Fetcher/FeedFetcher.php(153): OCA\\News\\Scraper\\Scraper->scrape()\\n#7 /var/www/nextcloud/apps/news/lib/Service/FeedServiceV2.php(270): OCA\\News\\Fetcher\\FeedFetcher->fetch()\\n#8 /var/www/nextcloud/apps/news/lib/Command/Updater/UpdateUser.php(52): OCA\\News\\Service\\FeedServiceV2->fetch()\\n#9 /var/www/nextcloud/3rdparty/symfony/console/Command/Command.php(255): OCA\\News\\Command\\Updater\\UpdateUser->execute()\\n#10 /var/www/nextcloud/3rdparty/symfony/console/Application.php(1009): Symfony\\Component\\Console\\Command\\Command->run()\\n#11 /var/www/nextcloud/3rdparty/symfony/console/Application.php(273): Symfony\\Component\\Console\\Application->doRunCommand()\\n#12 /var/www/nextcloud/3rdparty/symfony/console/Application.php(149): Symfony\\Component\\Console\\Application->doRun()\\n#13 /var/www/nextcloud/lib/private/Console/Application.php(213): Symfony\\Component\\Console\\Application->run()\\n#14 /var/www/nextcloud/console.php(100): OC\\Console\\Application->run()\\n#15 /var/www/nextcloud/occ(11): require_once('...')\\n#16 {main}\"}","userAgent":"--","version":"25.0.0.18","data":{"app":"news"}}
```