### PR TITLE
Release 20.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
-- SyntaxError triggered when full-text is enabled with some items. (#2048, #2053)
 
 # Releases
+## [20.0.1] - 2023-01-19
+### Fixed
+- SyntaxError triggered when full-text is enabled with some items. (#2048, #2053)
+
 ## [20.0.0] - 2022-12-14
 ### Changed
 - Drop support for PHP 7.3 (#2008)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>20.0.0</version>
+    <version>20.0.1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
Fixed
- SyntaxError triggered when full-text is enabled with some items. (#2048, #2053)