### PR TITLE
implement item/article search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 - Drop support for Nextcloud 23 (#2077 )
 - Make the "open" keyboard shortcut work faster (#2080)
+- Implemented search for articles, results can only link to the feed. (#2075)
 
 ### Fixed
 - Stop errors from the favicon library over empty values

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -23,6 +23,7 @@ use OCA\News\Config\FetcherConfig;
 use OCA\News\Hooks\UserDeleteHook;
 use OCA\News\Search\FeedSearchProvider;
 use OCA\News\Search\FolderSearchProvider;
+use OCA\News\Search\ItemSearchProvider;
 
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -82,6 +83,8 @@ class Application extends App implements IBootstrap
 
         $context->registerSearchProvider(FolderSearchProvider::class);
         $context->registerSearchProvider(FeedSearchProvider::class);
+        $context->registerSearchProvider(ItemSearchProvider::class);
+
 
         $context->registerEventListener(BeforeUserDeletedEvent::class, UserDeleteHook::class);
 

--- a/lib/Search/FeedSearchProvider.php
+++ b/lib/Search/FeedSearchProvider.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace OCA\News\Search;
 
 use OCA\News\Service\FeedServiceV2;
-use OCA\News\Service\FolderServiceV2;
+use OCA\News\AppInfo\Application;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
@@ -48,7 +48,7 @@ class FeedSearchProvider implements IProvider
 
     public function getOrder(string $route, array $routeParameters): int
     {
-        if ($route === 'news.page.index') {
+        if (strpos($route, Application::NAME . '.') === 0) {
             // Active app, prefer my results
             return -1;
         }
@@ -67,7 +67,7 @@ class FeedSearchProvider implements IProvider
             }
 
             $list[] = new SearchResultEntry(
-                $this->urlGenerator->imagePath('core', 'filetypes/text.svg'),
+                $this->urlGenerator->imagePath('core', 'rss.svg'),
                 $feed->getTitle(),
                 $this->l10n->t('Unread articles') . ': ' . $feed->getUnreadCount(),
                 $this->urlGenerator->linkToRoute('news.page.index') . '#/items/feeds/' . $feed->getId()

--- a/lib/Search/FolderSearchProvider.php
+++ b/lib/Search/FolderSearchProvider.php
@@ -49,9 +49,9 @@ class FolderSearchProvider implements IProvider
 
     public function getOrder(string $route, array $routeParameters): int
     {
-        if ($route === 'news.page.index') {
+        if (strpos($route, Application::NAME . '.') === 0) {
             // Active app, prefer my results
-            return -1;
+            return 0;
         }
 
         return 55;

--- a/lib/Search/ItemSearchProvider.php
+++ b/lib/Search/ItemSearchProvider.php
@@ -1,0 +1,109 @@
+<?php
+declare(strict_types=1);
+
+namespace OCA\News\Search;
+
+use OCA\News\Service\ItemServiceV2;
+use OCA\News\AppInfo\Application;
+use OCA\News\Db\ListType;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\Search\IProvider;
+use OCP\Search\ISearchQuery;
+use OCP\Search\SearchResult;
+use OCP\Search\SearchResultEntry;
+
+/**
+ * Class ItemSearchProvider
+ *
+ * @package OCA\News\Search
+ */
+class ItemSearchProvider implements IProvider
+{
+    /** @var IL10N */
+    private $l10n;
+
+    /** @var IURLGenerator */
+    private $urlGenerator;
+
+    /** @var ItemServiceV2 */
+    private $service;
+
+    public function __construct(IL10N $l10n, IURLGenerator $urlGenerator, ItemServiceV2 $service)
+    {
+        $this->l10n = $l10n;
+        $this->urlGenerator = $urlGenerator;
+        $this->service = $service;
+    }
+
+    public function getId(): string
+    {
+        return 'news_item';
+    }
+
+    public function getName(): string
+    {
+        return $this->l10n->t('News articles');
+    }
+
+    public function getOrder(string $route, array $routeParameters): int
+    {
+        if (strpos($route, Application::NAME . '.') === 0) {
+            // Active app, prefer my results
+            return 1;
+        }
+
+        return 65;
+    }
+
+    private function stripTruncate(string $string, int $length = 50): string
+    {
+        $string = strip_tags(trim($string));
+      
+        if (strlen($string) > $length) {
+            $string = wordwrap($string, $length);
+            $string = explode("\n", $string, 2);
+            $string = $string[0];
+        }
+      
+        return $string;
+    }
+
+    public function search(IUser $user, ISearchQuery $query): SearchResult
+    {
+        $list = [];
+        $offset = (int) ($query->getCursor() ?? 0);
+        $limit = $query->getLimit();
+
+        $search_result = $this->service->findAllWithFilters(
+            $user->getUID(),
+            ListType::ALL_ITEMS,
+            $limit,
+            $offset,
+            false,
+            [$query->getTerm()]
+        );
+
+        $last = end($search_result);
+        if ($last === false) {
+            return SearchResult::complete(
+                $this->l10n->t('News'),
+                []
+            );
+        }
+
+        $icon = $this->urlGenerator->imagePath('core', 'filetypes/text.svg');
+        
+        foreach ($search_result as $item) {
+            $list[] = new SearchResultEntry(
+                $icon,
+                $item->getTitle(),
+                $this->stripTruncate($item->getBody(), 50),
+                $this->urlGenerator->linkToRoute('news.page.index') . '#/items/feeds/' . $item->getFeedId()
+            );
+        }
+
+        return SearchResult::paginated($this->l10n->t('News'), $list, $last->getId());
+    }
+}

--- a/tests/Unit/Search/FeedSearchProviderTest.php
+++ b/tests/Unit/Search/FeedSearchProviderTest.php
@@ -110,7 +110,7 @@ class FeedSearchProviderTest extends TestCase
 
         $this->generator->expects($this->once())
                         ->method('imagePath')
-                        ->with('core', 'filetypes/text.svg')
+                        ->with('core', 'rss.svg')
                         ->willReturn('folderpath.svg');
 
         $this->generator->expects($this->once())


### PR DESCRIPTION
I was motivated to look into article search.

Current implementation works as is but has potential for improvement.

Pagination should be used since there might be a lot of items that requires adjustments to the DB layer.
https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/search.html#pagination

As far as I could see and know we do not have a view for a single item, therefore there is no link to go to that item within news. Implementing that on the current frontend seems to me like it's not worth the effort.
For now I put the url to the external website for that item/article in there.
If we don't want this we could link to the feed, which would at least identify in which feed the information is found.

![news](https://user-images.githubusercontent.com/5429298/214850801-71517a01-75c7-40c4-a4ca-3a69a478dcff.jpg)
