### PR TITLE
Make the "open" keyboard shortcut work faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 # Unreleased
 ## [21.x.x]
 ### Changed
-- Drop support for Nextcloud 23
+- Drop support for Nextcloud 23 (#2077 )
+-  Make the "open" keyboard shortcut work faster (#2080)
 
 ### Fixed
 

--- a/js/gui/KeyboardShortcuts.js
+++ b/js/gui/KeyboardShortcuts.js
@@ -259,10 +259,10 @@
 
     var openLink = function () {
         onActiveItem(function (item) {
-            item.trigger('click');  // mark read
             var url = item.find('.external:visible').attr('href');
             var newWindow = window.open(url, '_blank');
             newWindow.opener = null;
+            setTimeout(()=>item.trigger('click'), 0);  // mark read
         });
     };
 


### PR DESCRIPTION
Previously when pressing the `O` key on article list, the handler for that keypress first simulated a click on that event in order to mark it as read, and only then opened the website that item links to in another tab. When having a lot of items on screen this caused a huge delay between pressing `O` and opening the linked article in a new tab. The delay was sometimes 5, even 10 whole seconds. This simple fix makes it so the article opens first, and then the click simulation happens afterwards.