### PR TITLE
Fix french translation for "Auto discover Feed"

### DIFF
--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -87,7 +87,7 @@ OC.L10N.register(
     "Credentials" : "Informations d'identification",
     "HTTP Basic Auth credentials must be stored unencrypted! Everyone with access to the server or database will be able to access them!" : "Les informations d'identification HTTP Basic Auth doivent être stocké en clair ! Toute personne ayant accès au serveur ou à la base de données y aura accès !",
     "Password" : "Mot de passe",
-    "Auto discover Feed" : "Flux de découverte automatique",
+    "Auto discover Feed" : "Découverte automatique du flux",
     "New Folder" : "Nouveau dossier",
     "Create" : "Créer",
     "Explore" : "Explorer",

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -85,7 +85,7 @@
     "Credentials" : "Informations d'identification",
     "HTTP Basic Auth credentials must be stored unencrypted! Everyone with access to the server or database will be able to access them!" : "Les informations d'identification HTTP Basic Auth doivent être stocké en clair ! Toute personne ayant accès au serveur ou à la base de données y aura accès !",
     "Password" : "Mot de passe",
-    "Auto discover Feed" : "Flux de découverte automatique",
+    "Auto discover Feed" : "Découverte automatique du flux",
     "New Folder" : "Nouveau dossier",
     "Create" : "Créer",
     "Explore" : "Explorer",


### PR DESCRIPTION
## Summary

Fix french translation for string "Auto discover Feed" (the existing text means nothing in french).
Only the relevant lines were changed in `l10n/fr.js` and `l10n/fr.json`

## Checklist

- [x] Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [ ] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Changelog entry added for all important changes.
