### PR TITLE
fix: do not request favicon for empty base URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ## [21.x.x]
 ### Changed
 - Drop support for Nextcloud 23 (#2077 )
--  Make the "open" keyboard shortcut work faster (#2080)
+- Make the "open" keyboard shortcut work faster (#2080)
 
 ### Fixed
+- Stop errors from the favicon library over empty values
 
 # Releases
 ## [20.0.1] - 2023-01-19

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -352,9 +352,9 @@ class FeedFetcher implements IFeedFetcher
      * @param FeedInterface $feed Feed to check for a logo
      * @param string        $url  Original URL for the feed
      *
-     * @return string|mixed|bool
+     * @return string|null
      */
-    protected function getFavicon(FeedInterface $feed, string $url)
+    protected function getFavicon(FeedInterface $feed, string $url): ?string
     {
         $favicon = null;
         // trim the string because authors do funny things
@@ -370,9 +370,15 @@ class FeedFetcher implements IFeedFetcher
         $base_url->setPath("");
         $base_url = $base_url->getNormalizedURL();
 
+        // Return if the URL is empty
+        if ($base_url === null || trim($base_url) === '') {
+            return null;
+        }
+
         // check if feed has a logo entry
-        if (is_null($favicon) || $favicon === '') {
-            return $this->faviconFactory->get($base_url);
+        if ($favicon === null || $favicon === '') {
+            $return = $this->faviconFactory->get($base_url);
+            return is_string($return) ? $return : null;
         }
 
         // logo will be saved in the tmp folder provided by Nextcloud, file is named as md5 of the url
@@ -424,16 +430,18 @@ class FeedFetcher implements IFeedFetcher
 
         // check if file is actually an image
         if (!$is_image) {
-            return $this->faviconFactory->get($base_url);
+            $return = $this->faviconFactory->get($base_url);
+            return is_string($return) ? $return : null;
         }
 
         list($width, $height, $type, $attr) = getimagesize($favicon_path);
         // check if image is square else fall back to favicon
         if ($width !== $height) {
-            return $this->faviconFactory->get($base_url);
+            $return = $this->faviconFactory->get($base_url);
+            return is_string($return) ? $return : null;
         }
 
-        return $favicon;
+        return is_string($favicon) ? $favicon : null;
     }
 
     /**


### PR DESCRIPTION
* Resolves: #2054

## Summary

This is an alternate solution since I believe the core issue is empty URLs being sent to the favicon library.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
