### PR TITLE
Release 21.0.0-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,18 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 # Unreleased
 ## [21.x.x]
 ### Changed
+
+### Fixed
+
+# Releases
+## [21.0.0-beta1] - 2023-02-14
+### Changed
 - Drop support for Nextcloud 23 (#2077 )
 - Make the "open" keyboard shortcut work faster (#2080)
 - Implemented search for articles, results can only link to the feed. (#2075)
-
 ### Fixed
-- Stop errors from the favicon library over empty values
+- Stop errors from the favicon library over empty values (#2096)
 
-# Releases
 ## [20.0.1] - 2023-01-19
 ### Fixed
 - SyntaxError triggered when full-text is enabled with some items. (#2048, #2053)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>21.0.0</version>
+    <version>21.0.0-beta1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
## Summary

Release Notes:

Changed
- Drop support for Nextcloud 23 (#2077 )
- Make the "open" keyboard shortcut work faster (#2080)
- Implemented search for articles, results can only link to the feed. (#2075)

Fixed
- Stop errors from the favicon library over empty values (#2096)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
