### PR TITLE
Use httpLastModified field for If-Modified-Since header on feed updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
+- Use httpLastModified field for If-Modified-Since header when fetching feed updates
 
 # Releases
 ## [21.1.0] - 2023-03-20

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>21.1.0</version>
+    <version>21.2.0-beta1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -113,15 +113,21 @@ class FeedFetcher implements IFeedFetcher
         string $url,
         bool $fullTextEnabled,
         ?string $user,
-        ?string $password
+        ?string $password,
+        ?string $httpLastModified
     ): array {
         $url2 = new Net_URL2($url);
         if (!is_null($user) && trim($user) !== '') {
             $url2->setUserinfo(rawurlencode($user), rawurlencode($password));
         }
+        if (!is_null($httpLastModified) && trim($httpLastModified) !== '') {
+            $lastModified = new DateTime($httpLastModified);
+        } else {
+            $lastModified = null;
+        }
         $url = $url2->getNormalizedURL();
         $this->reader->resetFilters();
-        $resource = $this->reader->read($url);
+        $resource = $this->reader->read($url, null, $lastModified);
 
         $location     = $resource->getUrl();
         $parsedFeed   = $resource->getFeed();

--- a/lib/Fetcher/Fetcher.php
+++ b/lib/Fetcher/Fetcher.php
@@ -47,6 +47,7 @@ class Fetcher
      * @param  bool        $fullTextEnabled   If true use a scraper to download the full article
      * @param  string|null $user              if given, basic auth is set for this feed
      * @param  string|null $password          if given, basic auth is set for this feed. Ignored if user is empty
+     * @param  string|null $httpLastModified  if given, will be used when sending a request to servers
      *
      * @throws ReadErrorException if FeedIO fails
      * @return array an array containing the new feed and its items, first
@@ -56,7 +57,8 @@ class Fetcher
         string $url,
         bool $fullTextEnabled = false,
         ?string $user = null,
-        ?string $password = null
+        ?string $password = null,
+        ?string $httpLastModified = null
     ): array {
         foreach ($this->fetchers as $fetcher) {
             if (!$fetcher->canHandle($url)) {
@@ -66,7 +68,8 @@ class Fetcher
                 $url,
                 $fullTextEnabled,
                 $user,
-                $password
+                $password,
+                $httpLastModified
             );
         }
 

--- a/lib/Fetcher/IFeedFetcher.php
+++ b/lib/Fetcher/IFeedFetcher.php
@@ -37,7 +37,8 @@ interface IFeedFetcher
         string $url,
         bool $fullTextEnabled,
         ?string $user,
-        ?string $password
+        ?string $password,
+        ?string $httpLastModified
     ): array;
 
     /**

--- a/lib/Fetcher/IFeedFetcher.php
+++ b/lib/Fetcher/IFeedFetcher.php
@@ -27,6 +27,7 @@ interface IFeedFetcher
      * @param  bool        $fullTextEnabled If true use a scraper to download the full article
      * @param  string|null $user          if given, basic auth is set for this feed
      * @param  string|null $password      if given, basic auth is set for this feed. Ignored if user is empty
+     * @param  string|null $httpLastModified if given, will be used when sending a request to servers
      *
      * @return array<Feed, Item[]> an array containing the new feed and its items, first
      * element being the Feed and second element being an array of Items

--- a/lib/Service/FeedServiceV2.php
+++ b/lib/Service/FeedServiceV2.php
@@ -267,7 +267,8 @@ class FeedServiceV2 extends Service
                 $location,
                 $feed->getFullTextEnabled(),
                 $feed->getBasicAuthUser(),
-                $feed->getBasicAuthPassword()
+                $feed->getBasicAuthPassword(),
+                $feed->getHttpLastModified()
             );
         } catch (ReadErrorException $ex) {
             $feed->setUpdateErrorCount($feed->getUpdateErrorCount() + 1);

--- a/tests/Unit/Fetcher/FeedFetcherTest.php
+++ b/tests/Unit/Fetcher/FeedFetcherTest.php
@@ -326,7 +326,7 @@ class FeedFetcherTest extends TestCase
         $item = $this->createItem();
         $feed = $this->createFeed();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        $result = $this->fetcher->fetch($this->url, false, null, null);
+        $result = $this->fetcher->fetch($this->url, false, null, null, null);
 
         $this->assertEquals([$feed, [$item]], $result);
     }
@@ -344,7 +344,8 @@ class FeedFetcherTest extends TestCase
             $this->url,
             false,
             'account@email.com',
-            'F9sEU*Rt%:KFK8HMHT&'
+            'F9sEU*Rt%:KFK8HMHT&',
+            $this->modified->format(DateTime::RSS)
         );
 
         $this->assertEquals([$feed, [$item]], $result);
@@ -359,7 +360,7 @@ class FeedFetcherTest extends TestCase
         $item = $this->createItem('audio/ogg');
         $feed = $this->createFeed();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        $result = $this->fetcher->fetch($this->url, false, null, null);
+        $result = $this->fetcher->fetch($this->url, false, null, null, null);
 
         $this->assertEquals([$feed, [$item]], $result);
     }
@@ -373,7 +374,7 @@ class FeedFetcherTest extends TestCase
         $item = $this->createItem('video/ogg');
         $feed = $this->createFeed();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        $result = $this->fetcher->fetch($this->url, false, null, null);
+        $result = $this->fetcher->fetch($this->url, false, null, null, null);
 
         $this->assertEquals([$feed, [$item]], $result);
     }
@@ -388,7 +389,7 @@ class FeedFetcherTest extends TestCase
         $feed = $this->createFeed('de-DE');
         $item = $this->createItem();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        $result = $this->fetcher->fetch($this->url, false, null, null);
+        $result = $this->fetcher->fetch($this->url, false, null, null, null);
 
         $this->assertEquals([$feed, [$item]], $result);
     }
@@ -402,7 +403,7 @@ class FeedFetcherTest extends TestCase
         $this->createFeed('he-IL');
         $this->createItem();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        list($_, $items) = $this->fetcher->fetch($this->url, false, null, null);
+        list($_, $items) = $this->fetcher->fetch($this->url, false, null, null, null);
         $this->assertTrue($items[0]->getRtl());
     }
 
@@ -428,7 +429,7 @@ class FeedFetcherTest extends TestCase
 
 
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        list($feed, $items) = $this->fetcher->fetch($this->url, false, null, null);
+        list($feed, $items) = $this->fetcher->fetch($this->url, false, null, null, null);
         $this->assertSame($items[0]->getPubDate(), 1522180229);
     }
 
@@ -454,7 +455,7 @@ class FeedFetcherTest extends TestCase
 
 
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        list($feed, $items) = $this->fetcher->fetch($this->url, false, null, null);
+        list($feed, $items) = $this->fetcher->fetch($this->url, false, null, null, null);
         $this->assertSame($items[0]->getPubDate(), 1519761029);
     }
 
@@ -467,7 +468,7 @@ class FeedFetcherTest extends TestCase
         $this->createItem();
         $feed = $this->createFeed();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        $result = $this->fetcher->fetch($this->url, false, null, null);
+        $result = $this->fetcher->fetch($this->url, false, null, null. null, null);
         //Explicitly assert GUID value
         $this->assertEquals(2, count($result));
         $this->assertEquals(1, count($result[1]));
@@ -485,7 +486,7 @@ class FeedFetcherTest extends TestCase
         $this->createItem();
         $feed = $this->createFeed();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        $result = $this->fetcher->fetch($this->url, false, null, null);
+        $result = $this->fetcher->fetch($this->url, false, null, null, null);
         //Explicitly assert GUID value
         $this->assertEquals(2, count($result));
         $this->assertEquals(1, count($result[1]));


### PR DESCRIPTION
* Resolves: #2118  <!-- related github issue -->

## Summary

Hand httpLastModified database field to FeedIo for setting If-Modified-Since header

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
