### PR TITLE
Chore remove unused News job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 # Unreleased
 ## [21.x.x]
 ### Changed
-
+- Remove unused background job OCA\News\Cron\Updater
 ### Fixed
 
 # Releases

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -62,6 +62,12 @@ Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
         <job>OCA\News\Cron\UpdaterJob</job>
     </background-jobs>
 
+    <repair-steps>
+        <post-migration>
+                <step>OCA\News\Migration\RemoveUnusedJob</step>
+        </post-migration>
+    </repair-steps>
+
     <commands>
         <command>OCA\News\Command\ExploreGenerator</command>
         <command>OCA\News\Command\ShowFeed</command>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -59,6 +59,10 @@ Feeds can be updated using Nextcloud's system cron or an [external updater](http
 
 You will get two rows where column `class`will be `OCA\News\Cron\Updater` and `OCA\News\Cron\UpdaterJob`.
 
+!!! info
+
+    In newer versions of News (21.x.x) the old job OCA\News\Cron\Updater was removed from the DB.
+
  Reset the `reserved_at` by executing
 
   ```sql

--- a/lib/Migration/RemoveUnusedJob.php
+++ b/lib/Migration/RemoveUnusedJob.php
@@ -1,0 +1,51 @@
+<?php
+namespace OCA\News\Migration;
+
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+use OCP\BackgroundJob\IJobList;
+
+class RemoveUnusedJob implements IRepairStep
+{
+    
+    /**
+     * @var LoggerInterface 
+     */
+    protected $logger;
+    
+    /**
+     * @var IJobList 
+     */
+    protected $joblist;
+    
+    public function __construct(LoggerInterface $logger, IJobList $jobList)
+    {
+        
+        $this->logger = $logger;
+        $this->joblist = $jobList;
+    }
+    
+    /**
+     * Returns the step's name
+     */
+    public function getName()
+    {
+        return 'Remove the unused News update job';
+    }
+    
+    /**
+     * @param IOutput $output
+     */
+    public function run(IOutput $output)
+    {
+        if($this->joblist->has("OCA\News\Cron\Updater", null)){
+            $output->info("Job exists, attempting to remove");
+            $this->joblist->remove("OCA\News\Cron\Updater");
+            $output->info("Job removed");
+        } else {
+            $output->info("Job does not exist, all good");
+        }
+        
+    }
+}

--- a/lib/Migration/RemoveUnusedJob.php
+++ b/lib/Migration/RemoveUnusedJob.php
@@ -10,12 +10,12 @@ class RemoveUnusedJob implements IRepairStep
 {
     
     /**
-     * @var LoggerInterface 
+     * @var LoggerInterface
      */
     protected $logger;
     
     /**
-     * @var IJobList 
+     * @var IJobList
      */
     protected $joblist;
     
@@ -39,13 +39,12 @@ class RemoveUnusedJob implements IRepairStep
      */
     public function run(IOutput $output)
     {
-        if($this->joblist->has("OCA\News\Cron\Updater", null)){
+        if ($this->joblist->has("OCA\News\Cron\Updater", null)) {
             $output->info("Job exists, attempting to remove");
             $this->joblist->remove("OCA\News\Cron\Updater");
             $output->info("Job removed");
         } else {
             $output->info("Job does not exist, all good");
         }
-        
     }
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,8 @@ theme:
     - navigation.expand
     - navigation.sections
 
+markdown_extensions:
+  - admonition
 
 # extra:
 #   version:


### PR DESCRIPTION
## Summary

Long time ago we changed the job name for our background job.
That left the old job in the db of many installations it also confuses some people when one job gets stuck.

This repair step which is run after the upgrade of the app or anytime the repair steps are triggered from occ, removes the job.

Example output, tested on dev environment.
```
...
 - Set existing shares as accepted
 - Remove the unused News update job
     - Job exists, attempting to remove
     - Job removed
 - Update OAuth token expiration times

...

 - Set existing shares as accepted
 - Remove the unused News update job
     - Job does not exist, all good
 - Update OAuth token expiration times
 - Initialize migration of background images 
 ...
```
## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
