### PR TITLE
use stable26

### DIFF
--- a/.github/workflows/api-integration-tests.yml
+++ b/.github/workflows/api-integration-tests.yml
@@ -28,21 +28,25 @@ jobs:
           - 5432:5432 # Maps tcp port 5432 on service container to the host
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0']
-        nextcloud: ['stable24', 'stable25']
+        php-versions: ['8.0', '8.1']
+        nextcloud: ['stable24', 'stable25', 'stable26']
         database: ['sqlite', 'pgsql', 'mysql']
         experimental: [false]
         include:
-          - php-versions: '8.0'
-            nextcloud: pre-release
-            database: sqlite
-            experimental: true
-          - php-versions: '8.2'
-            nextcloud: pre-release
-            database: sqlite
-            experimental: true
           - php-versions: 8.1
-            nextcloud: stable25
+            nextcloud: pre-release
+            database: sqlite
+            experimental: true
+          - php-versions: 8.2
+            nextcloud: pre-release
+            database: sqlite
+            experimental: true
+          - php-versions: 7.4
+            nextcloud: stable24
+            database: sqlite
+            experimental: false
+          - php-versions: 8.2
+            nextcloud: stable26
             database: sqlite
             experimental: false
     steps:

--- a/.github/workflows/api-php-static-code-check.yml
+++ b/.github/workflows/api-php-static-code-check.yml
@@ -7,14 +7,18 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        php-versions: [ '7.4', '8.0', '8.1' ]
-        nextcloud: [ 'stable25' ]
+        php-versions: ['8.0', '8.1', '8.2' ]
+        nextcloud: [ 'stable26' ]
         database: [ 'sqlite' ]
         include:
-          - php-versions: '8.2'
+          - php-versions: 8.2
             nextcloud: pre-release
             database: sqlite
             experimental: true
+          - php-versions: 7.4
+            nextcloud: stable24
+            database: sqlite
+            experimental: false
     name: "phpstan: Nextcloud ${{ matrix.nextcloud }} with ${{ matrix.php-versions }}"
     steps:
       - name: Checkout

--- a/.github/workflows/api-php-tests.yml
+++ b/.github/workflows/api-php-tests.yml
@@ -10,13 +10,13 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.1']
-        nextcloud: ['stable25']
+        nextcloud: ['stable26']
         database: ['sqlite']
         experimental: [false]
         codecoverage: [false]
         include:
           - php-versions: 8.0
-            nextcloud: stable24
+            nextcloud: stable25
             database: sqlite
             experimental: false
             codecoverage: true

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.1']
-        nextcloud: ['stable25']
+        nextcloud: ['stable26']
         database: ['sqlite']
     steps:
       - name: Checkout

--- a/.github/workflows/post-merge-tasks.yml
+++ b/.github/workflows/post-merge-tasks.yml
@@ -10,7 +10,7 @@ jobs:
     name: "Coverage: Nextcloud PHP ${{ matrix.php-versions }}"
     strategy:
       matrix:
-        nextcloud: ['stable25']
+        nextcloud: ['stable26']
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
* Resolves: n/a

## Summary
Updates the CI to use stable26.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
