### PR TITLE
store useragent in one place

### DIFF
--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -31,6 +31,7 @@ use OCA\News\Db\Item;
 use OCA\News\Db\Feed;
 use OCA\News\Utility\Time;
 use OCA\News\Scraper\Scraper;
+use OCA\News\Config\FetcherConfig;
 use Psr\Log\LoggerInterface;
 use SimpleXMLElement;
 
@@ -364,7 +365,7 @@ class FeedFetcher implements IFeedFetcher
             $favicon = trim($feed_logo);
         }
         
-        ini_set('user_agent', 'NextCloud-News/1.0');
+        ini_set('user_agent', FetcherConfig::DEFAULT_USER_AGENT);
 
         $base_url = new Net_URL2($url);
         $base_url->setPath("");
@@ -400,7 +401,7 @@ class FeedFetcher implements IFeedFetcher
                 [
                     'sink' => $favicon_path,
                     'headers' => [
-                        'User-Agent'        => 'NextCloud-News/1.0',
+                        'User-Agent'        => FetcherConfig::DEFAULT_USER_AGENT,
                         'Accept'            => 'image/*',
                         'If-Modified-Since' => date(DateTime::RFC7231, $last_modified)
                     ]


### PR DESCRIPTION
* Resolves: # n/a

## Summary

Currently the user agent is hardcoded in multiple places, it makes sense to have it in one place instead.

We could also consider to provide the version of Nextcloud news in the useragent instead of the fixed 1.0

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
