### PR TITLE
Fix: set lastmodified in items->readAll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
+- Fix last_modified not updated when all items are marked as read #2183
 
 # Releases
 ## [21.2.0-beta1] - 2023-03-23

--- a/lib/Db/ItemMapperV2.php
+++ b/lib/Db/ItemMapperV2.php
@@ -285,12 +285,15 @@ class ItemMapperV2 extends NewsMapperV2
             return intval($value['id']);
         }, $this->db->executeQuery($idBuilder->getSQL(), $idBuilder->getParameters())->fetchAll());
 
+        $time = new Time();
         $builder = $this->db->getQueryBuilder();
         $builder->update(self::TABLE_NAME)
             ->set('unread', $builder->createParameter('unread'))
+            ->set('last_modified', $builder->createParameter('last_modified'))
             ->andWhere('id IN (:idList)')
             ->setParameter('idList', $idList, IQueryBuilder::PARAM_INT_ARRAY)
-            ->setParameter('unread', false, IQueryBuilder::PARAM_BOOL);
+            ->setParameter('unread', false, IQueryBuilder::PARAM_BOOL)
+            ->setParameter('last_modified', $time->getMicroTime(), IQueryBuilder::PARAM_STR);
 
         return $this->db->executeStatement(
             $builder->getSQL(),

--- a/tests/Unit/Db/ItemMapperTest.php
+++ b/tests/Unit/Db/ItemMapperTest.php
@@ -528,7 +528,7 @@ class ItemMapperTest extends MapperTestUtility
             ->with('SQL QUERY')
             ->willReturn($result);
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->exactly(2))
             ->method('createParameter')
             ->will($this->returnArgument(0));
 
@@ -537,9 +537,9 @@ class ItemMapperTest extends MapperTestUtility
             ->with('news_items')
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->once())
+        $this->builder->expects($this->exactly(2))
             ->method('set')
-            ->with('unread', 'unread')
+            ->withConsecutive(['unread', 'unread'], ['last_modified', 'last_modified'])
             ->will($this->returnSelf());
 
         $this->builder->expects($this->exactly(1))
@@ -547,9 +547,9 @@ class ItemMapperTest extends MapperTestUtility
             ->withConsecutive(['id IN (:idList)'])
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->exactly(2))
+        $this->builder->expects($this->exactly(3))
             ->method('setParameter')
-            ->withConsecutive(['idList', [1, 2]], ['unread', false])
+            ->withConsecutive(['idList', [1, 2]], ['unread', false], ['last_modified'])
             ->will($this->returnSelf());
 
         $this->builder->expects($this->exactly(1))

--- a/tests/api/items.bats
+++ b/tests/api/items.bats
@@ -67,7 +67,7 @@ teardown() {
   SYNC_TIME=$(date +%s)
 
   # mark all items of feed as read, returns nothing (other client marks items as read)
-  STATUS_CODE=$(http --ignore-stdin -hdo /tmp/body -a ${user}:${APP_PASSWORD} PUT ${BASE_URLv1}/feeds/$FEEDID/read newestItemId="$max" 2>&1| grep HTTP/)
+  STATUS_CODE=$(http --ignore-stdin -hdo /tmp/body -a ${user}:${APP_PASSWORD} PUT ${BASE_URLv1}/items/read newestItemId="$max" 2>&1| grep HTTP/)
 
   # client 2 checks for updates since last sync
   UPDATED_ITEMS=($(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/items/updated id=$FEEDID lastModified=$SYNC_TIME | grep -Po '"id":\K([0-9]+)' | tr '\n' ' '))


### PR DESCRIPTION
if this is not updated the API won't work correctly and we get sync errors.


* Resolves: https://github.com/nextcloud/news-android/issues/1105 https://github.com/nextcloud/news-android/issues/1117
## Summary

Mark feeds on the server as read - timestamp not updated
If android app already had the item it won't see a change
-> items on android still marked as unread

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
