### PR TITLE
Release 21.2.0-beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
-- Fix last_modified not updated when all items are marked as read #2183
 
 # Releases
+## [21.2.0-beta2] - 2023-04-05
+### Fixed
+- Fix last_modified not updated when all items are marked as read (#2183)
+
 ## [21.2.0-beta1] - 2023-03-23
 ### Changed
 - Use httpLastModified field for If-Modified-Since header when fetching feed updates (#2119)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>21.2.0-beta1</version>
+    <version>21.2.0-beta2</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
## Summary

Fixed
- Fix last_modified not updated when all items are marked as read (#2183)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
