### PR TITLE
Improve sql query performance by removing unused payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
+- Improve performance of item updates (#1322)
 
 # Releases
 ## [21.2.0-beta2] - 2023-04-05

--- a/lib/Db/ItemMapperV2.php
+++ b/lib/Db/ItemMapperV2.php
@@ -314,7 +314,7 @@ class ItemMapperV2 extends NewsMapperV2
     {
         $builder = $this->db->getQueryBuilder();
 
-        $builder->select('items.*')
+        $builder->select('items.id')
                 ->from($this->tableName, 'items')
                 ->innerJoin('items', FeedMapperV2::TABLE_NAME, 'feeds', 'items.feed_id = feeds.id')
                 ->where('feeds.user_id = :userId')

--- a/tests/Unit/Db/ItemMapperTest.php
+++ b/tests/Unit/Db/ItemMapperTest.php
@@ -419,7 +419,7 @@ class ItemMapperTest extends MapperTestUtility
 
         $this->builder->expects($this->once())
             ->method('select')
-            ->with('items.*')
+            ->with('items.id')
             ->will($this->returnSelf());
 
         $this->builder->expects($this->once())


### PR DESCRIPTION
## Summary

This is a quick-fix to Improve a specific SQL query from 22-37s to  <1s when refreshing news items.

Some details how I got to that solution:

Activate slow-queries
```sql
SET GLOBAL slow_query_log=1;
```
Revealed slow-query:
```sql
SELECT `items`.* FROM `oc_news_items` `items` INNER JOIN `oc_news_feeds` `feeds` ON items.feed_id = feeds.id WHERE feeds.user_id = 'xxx' ORDER BY `items`.`id` DESC LIMIT 1;
// 1 row in set (37.087 sec)

SELECT count(*) from oc_news_items;
// 156391
```
After reducing payload (`items.*` --> `items.id`) the query is way faster:
```sql
SELECT `items`.`id` FROM `oc_news_items` `items` INNER JOIN `oc_news_feeds` `feeds` ON items.feed_id = feeds.id WHERE feeds.user_id = 'xxx' ORDER BY `items`.`id` DESC LIMIT 1;
// 1 row in set (0.042 sec)
```

`newest()` now only returns an entity with an id and not a complete news item anymore. All usages that I found are only using the id so i guess we are fine at the moment but maybe we need to change the function name or at least the return description. 

This seams to be the first function that only returns parts of an item so I was unsure how to handle it. Feel free to change PR to fit your needs :-)

See also https://github.com/nextcloud/news/issues/1322#issuecomment-841656384
And maybe another valid approach is still https://github.com/nextcloud/news/issues/1322#issuecomment-830028742 (not tested)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
