### PR TITLE
Fix display issue in NC26+ (#2192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 
 # Unreleased
 ## [21.x.x]
+- Fix display issue in NC26+ (#2192)
 ### Changed
 
 ### Fixed

--- a/css/content.css
+++ b/css/content.css
@@ -236,7 +236,7 @@
     min-height: 43px;
 }
 
-#app-content.nc-major-version-25 .compact .utils {
+#app-content.nc-major-version-gte-25 .compact .utils {
     top: 0px;
 }
 

--- a/templates/index.php
+++ b/templates/index.php
@@ -70,7 +70,7 @@ foreach (Plugin::getScripts() as $appName => $fileName) {
     </div>
 
     <div id="app-content"
-        class="nc-major-version-<?= \OCP\Util::getVersion()[0]; ?>"
+        class="nc-major-version-<?= \OCP\Util::getVersion()[0]; ?><?= \OCP\Util::getVersion()[0] >= 25 ? ' nc-major-version-gte-25' : ''; ?>"
         data-nc-major-version="<?= \OCP\Util::getVersion()[0]; ?>"
         ng-class="{
             'loading-content': App.loading.isLoading('content') &&


### PR DESCRIPTION
* Resolves: #2192 

## Summary

Add CSS class `nc-major-version-gte-25` to `div#app-content` when NC major version is >= 25 to fix this issue for all upcoming NC versions.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
