### PR TITLE
feature: add ability to repost starred items to a feed

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -21,6 +21,9 @@ return ['routes' => [
 ['name' => 'page#manifest', 'url' => '/manifest.webapp', 'verb' => 'GET'],
 ['name' => 'page#explore', 'url' => '/explore/feeds.{lang}.json', 'verb' => 'GET'],
 
+// public feeds
+['name' => 'rss#starred', 'url' => '/rss/{userId}/starred', 'verb' => 'GET'],
+
 // admin
 ['name' => 'admin#update', 'url' => '/admin', 'verb' => 'PUT'],
 ['name' => 'admin#migrate', 'url' => '/admin/migrate', 'verb' => 'POST'],

--- a/lib/Controller/RssController.php
+++ b/lib/Controller/RssController.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Nextcloud - News
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author    Paul Tirk <paultirk@paultirk.com>
+ * @copyright 2020 Paul Tirk
+ */
+
+namespace OCA\News\Controller;
+
+use FeedIo\Feed;
+use FeedIo\FeedIo;
+use OCA\News\Service\ItemServiceV2;
+use OCA\News\Utility\XMLResponse;
+use OCP\AppFramework\Http;
+use \OCP\IRequest;
+use OCP\IUserManager;
+use \OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+
+/**
+ * This controller is in charge of exposing RSS feeds from
+ * gathered feed items.
+ */
+class RssController extends Controller
+{
+    use JSONHttpErrorTrait;
+
+    /**
+     * @var ItemServiceV2
+     */
+    private $itemService;
+
+    /**
+     * @var IUserManager
+     */
+    private $userManager;
+
+    /**
+     * @var FeedIo
+     */
+    private $feedIo;
+
+    public function __construct(
+        IRequest      $request,
+        IUserSession  $userSession,
+        IUserManager  $userManager,
+        ItemServiceV2 $itemService,
+        FeedIo        $feedIo
+    ) {
+        parent::__construct($request, $userSession);
+
+        $this->userManager = $userManager;
+        $this->itemService = $itemService;
+        $this->feedIo = $feedIo;
+    }
+
+    /**
+     * @NoCSRFRequired
+     * @PublicPage
+     *
+     * @param string $name
+     * @return array|mixed|\OCP\AppFramework\Http\JSONResponse
+     */
+    public function starred($userId)
+    {
+        $user = $this->userManager->get($userId);
+        if ($user === null) {
+            return $this->errorResponseWithExceptionV2(
+                new \Exception("User not found"),
+                Http::STATUS_NOT_FOUND
+            );
+        }
+
+        $starredItems = $this->itemService->starred($user->getUID());
+
+        $feed = new Feed();
+        $feed->setTitle("{$user->getDisplayName()}'s starred items");
+
+        foreach ($starredItems as $starredItem) {
+            $author = new Feed\Item\Author();
+            $author->setName($starredItem->getAuthor());
+
+            $item = new Feed\Item();
+            $item->setTitle(
+                $starredItem->getTitle())
+                    ->setAuthor($author)
+                    ->setDescription($starredItem->getBody())
+                    ->setLink($starredItem->getUrl());
+
+            $feed->add($item);
+        }
+
+        $response = new XMLResponse($this->feedIo->toAtom($feed), Http::STATUS_OK, [
+            "Content-Type" => "application/atom+xml"
+        ]);
+
+        return $response;
+    }
+}

--- a/lib/Utility/XMLResponse.php
+++ b/lib/Utility/XMLResponse.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ *
+ * @author Bernhard Posselt <dev@bernhard-posselt.com>
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author Lukas Reschke <lukas@statuscode.ch>
+ * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Thomas Tanghus <thomas@tanghus.net>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\News\Utility;
+
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Response;
+
+/**
+ * A renderer for JSON calls
+ * @since 6.0.0
+ */
+class XMLResponse extends Response {
+    /**
+     * response data
+     * @var string
+     */
+    protected $data;
+
+
+    public function __construct($data, $statusCode = Http::STATUS_OK, $headers = []) {
+        parent::__construct();
+
+        $this->data = $data;
+        $this->setStatus($statusCode);
+        $this->addHeader('Content-Type', 'application/xml; charset=utf-8');
+
+        foreach ($headers as $headerName => $headerValue) {
+            $this->addHeader($headerName, $headerValue);
+        }
+    }
+
+
+    public function render() {
+        return $this->data;
+    }
+}


### PR DESCRIPTION
## Summary

Hello! While this is still a draft, I would be interested to have some early feedback and guidance on the feature implementation before committing more energy into it.

This pull request adds the ability to expose starred items as an RSS feed, as it can be done with Tiny Tiny RSS. It can then be used as a simple sharing mechanism. I believe this could be improved a lot, for instance by being able to have repost channels, so you can have multiple RSS feeds, but this implementation is simple and provides a simple MVP.

The main advantage of not using an internal sharing mechanism is that you can push some feed items to some other aggregators. Usage examples:
- sharing articles to a Slack channel
- sharing articles to another Nextcloud user, if they subscribe to yours
- enabling automation when an article is starred
- maybe some others!

Screens:

If you star an item:
![image](https://user-images.githubusercontent.com/8060564/232065295-6690a568-bf01-49fd-b227-9b4556298f6f.png)

And subscribe to your own starred RSS feed (of course, this is a bit dumb here):
![image](https://user-images.githubusercontent.com/8060564/232066259-b12ad3ad-141e-48b4-ab01-e8389ca5e183.png)

Then you can see your reposted item.

Would you be interested in this feature being integrated into this project? If yes do you see some core changes that should be applied? Otherwise, I will continue with the checklist below.

## Checklist

- [ ] Limit the number of results in generated feed (likely 20)
- [ ] Add tests
- [ ] Add configuration entry from the frontend
- [ ] Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [ ] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Changelog entry added for all important changes.
