### PR TITLE
Fix sorting of folder names in select when adding subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
+- Fix sorting of folder names in select when adding subscription (#2090)
 
 
 # Releases

--- a/templates/part.navigation.addfeed.php
+++ b/templates/part.navigation.addfeed.php
@@ -36,7 +36,7 @@
                     ng-if="!Navigation.showNewFolder"
                     ng-model="Navigation.feed.existingFolder"
                     ng-options="folder.name for folder in
-                        Navigation.getFolders() track by folder.name">
+                        Navigation.getFolders() | orderBy:'name.toLowerCase()':false:localeComparator track by folder.name">
                     <option value=""
                         >-- <?php p($l->t('No folder')); ?> --</option>
                 </select>


### PR DESCRIPTION
* Resolves: #2090

## Summary

Fixed sorting of folder names in select when adding subscription.
Using the same orderBy filter as for the folder list below to get the same order.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
