### PR TITLE
Fix audio player floating when scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
-
+- Fix audio player floating when scrolling in NC25+ (#2142)
 
 # Releases
 ## [21.2.0-beta3] - 2023-04-16

--- a/css/content.css
+++ b/css/content.css
@@ -66,6 +66,10 @@
     align-items: center;
 }
 
+#app-content.nc-major-version-gte-25 .podcast {
+    top: 0;
+}
+
 #app-content .podcast audio {
     display: block;
     width: calc(100% - 60px);
@@ -106,6 +110,17 @@
     position: absolute;
     right: 0;
     left: 0;
+}
+
+#app-content.nc-major-version-gte-25 .podcast {
+    position: sticky;
+}
+
+@media only screen and (width < 1024px) {
+    #app-content.nc-major-version-gte-25 .podcast {
+        left: 35px;
+        width: calc(100% - 35px);
+    }
 }
 
 #notification a {

--- a/js/directive/NewsStickyMenu.js
+++ b/js/directive/NewsStickyMenu.js
@@ -7,7 +7,7 @@
  * @author Bernhard Posselt <dev@bernhard-posselt.com>
  * @copyright Bernhard Posselt 2014
  */
-app.directive('newsStickyMenu', function () {
+app.directive('newsStickyMenu', function (NC_MAJOR_VERSION) {
     'use strict';
 
     return function (scope, elem, attr) {
@@ -18,7 +18,9 @@ app.directive('newsStickyMenu', function () {
 
             if (scrollHeight > height) {
                 elem.addClass('fixed');
-                elem.css('top', scrollHeight);
+                if (NC_MAJOR_VERSION < 25) {
+                    elem.css('top', scrollHeight);
+                }
             } else {
                 elem.removeClass('fixed');
             }


### PR DESCRIPTION
* Resolves: #2142

## Summary

Fix audio player floating when scrolling in NC25+.

Using the #app-content.nc-major-version-gte-25 class introduced in #2196 in CSS and  the NC_MAJOR_VERSION constant in JavaScript to apply (and limit) changes to NC versions >= 25.

Currently there are no changes regarding the overlapping navigation toggle icon on screens < 1024 pixels width as the expected behavior should be discussed before.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
