### PR TITLE
Improve visibility of links in dark theme (#2215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 # Unreleased
 ## [21.x.x]
 ### Changed
-
+- Improve visibility of links in dark theme (#2215)
 ### Fixed
 
 

--- a/css/content.css
+++ b/css/content.css
@@ -714,6 +714,11 @@
     text-decoration: underline;
 }
 
+body.theme--dark #app-content .body a,   /* NC 24 */
+[data-theme-dark] #app-content .body a { /* NC 25 */
+    color: #9cc7ff;
+}
+
 #app-content .body ul {
     margin: 7px 0;
     padding-left: 14px;


### PR DESCRIPTION
* Resolves: #2215

## Summary

Increases brightness of links when using dark theme for better contrast. Includes support for <= NC 24, since 25 changed dark theme selectors.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
