### PR TITLE
Remove/nc24

### DIFF
--- a/.github/workflows/api-integration-tests.yml
+++ b/.github/workflows/api-integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.0', '8.1']
-        nextcloud: ['stable24', 'stable25', 'stable26']
+        nextcloud: ['stable25', 'stable26']
         database: ['sqlite', 'pgsql', 'mysql']
         experimental: [false]
         include:
@@ -42,7 +42,7 @@ jobs:
             database: sqlite
             experimental: true
           - php-versions: 7.4
-            nextcloud: stable24
+            nextcloud: stable25
             database: sqlite
             experimental: false
           - php-versions: 8.2

--- a/.github/workflows/api-php-static-code-check.yml
+++ b/.github/workflows/api-php-static-code-check.yml
@@ -16,7 +16,7 @@ jobs:
             database: sqlite
             experimental: true
           - php-versions: 7.4
-            nextcloud: stable24
+            nextcloud: stable25
             database: sqlite
             experimental: false
     name: "phpstan: Nextcloud ${{ matrix.nextcloud }} with ${{ matrix.php-versions }}"

--- a/.github/workflows/frontend-nodejs-tests.yml
+++ b/.github/workflows/frontend-nodejs-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.1']
-        nextcloud: ['stable24']
+        nextcloud: ['stable26']
         database: ['sqlite']
         experimental: [false]
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@ All notable changes to this project will be documented in this file.
 The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), older entries don't fully match.
 
 # Unreleased
-## [21.x.x]
+## [22.x.x]
 ### Changed
+- Drop support for Nextcloud 24
+- Add support for Nextcloud 27
 ### Fixed
-
 
 # Releases
 ## [21.2.0] - 2023-05-06

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -55,7 +55,7 @@ Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
         <lib>json</lib>
 
         <owncloud max-version="0" min-version="0"/>
-        <nextcloud min-version="24" max-version="26"/>
+        <nextcloud min-version="25" max-version="27"/>
     </dependencies>
 
     <background-jobs>


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Nextcloud 24 is no longer supported, at the same time Nextcloud 27 will be released soon.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
