### PR TITLE
Drop support for PHP 7.4 new min. version is php 8.0

### DIFF
--- a/.github/workflows/api-integration-tests.yml
+++ b/.github/workflows/api-integration-tests.yml
@@ -41,10 +41,6 @@ jobs:
             nextcloud: pre-release
             database: sqlite
             experimental: true
-          - php-versions: 7.4
-            nextcloud: stable25
-            database: sqlite
-            experimental: false
           - php-versions: 8.2
             nextcloud: stable26
             database: sqlite

--- a/.github/workflows/api-php-static-code-check.yml
+++ b/.github/workflows/api-php-static-code-check.yml
@@ -15,10 +15,6 @@ jobs:
             nextcloud: pre-release
             database: sqlite
             experimental: true
-          - php-versions: 7.4
-            nextcloud: stable25
-            database: sqlite
-            experimental: false
     name: "phpstan: Nextcloud ${{ matrix.nextcloud }} with ${{ matrix.php-versions }}"
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), older entries don't fully match.
 
 # Unreleased
+## [23.x.x]
+### Changed
+- Drop support for PHP 7.4 new min. version is php 8.0
+### Fixed
+
 ## [22.x.x]
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -43,7 +43,7 @@ Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     <screenshot small-thumbnail="https://raw.githubusercontent.com/nextcloud/news/master/screenshots/2-small.png">https://raw.githubusercontent.com/nextcloud/news/master/screenshots/2.png</screenshot>
     <screenshot small-thumbnail="https://raw.githubusercontent.com/nextcloud/news/master/screenshots/3-small.png">https://raw.githubusercontent.com/nextcloud/news/master/screenshots/3.png</screenshot>
     <dependencies>
-        <php min-version="7.4" min-int-size="64"/>
+        <php min-version="8.0" min-int-size="64"/>
         <database min-version="10">pgsql</database>
         <database>sqlite</database>
         <database min-version="8.0">mysql</database>

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,8 +2,8 @@
 
 ## Dependencies
 * 64bit OS (starting with News 16.0.0)
-* PHP >= 7.3
-* Nextcloud 22
+* PHP >= 8.0
+* Nextcloud (current stable version)
 * libxml >= 2.7.8
 
 You also need some PHP extensions:


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Drop support for PHP 7.4 new min. version is php 8.0

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
