### PR TITLE
allowEvalScript set to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 # Unreleased
 ## [22.x.x]
 ### Changed
+-  allowEvalScript set to true (#2262)
 
 ### Fixed
 

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -96,6 +96,7 @@ class PageController extends Controller
         $csp->addAllowedImageDomain('*')
             ->addAllowedMediaDomain('*')
             ->addAllowedConnectDomain('*')// chrome breaks on audio elements
+            ->allowEvalScript(true)
             ->addAllowedFrameDomain('https://youtube.com')
             ->addAllowedFrameDomain('https://www.youtube.com')
             ->addAllowedFrameDomain('https://player.vimeo.com')


### PR DESCRIPTION
* Resolves: Nothing
* 
## Summary

related to #2242

Removes the error message of the browser but buttons still don't work.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
