### PR TITLE
Use HTTP compression for downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 # Unreleased
 ## [22.x.x]
 ### Changed
+- Support deflate and gzip compression for HTTP response bodies (#2269)
 
 ### Fixed
 

--- a/lib/Config/FetcherConfig.php
+++ b/lib/Config/FetcherConfig.php
@@ -103,7 +103,11 @@ class FetcherConfig
     {
         $config = [
             'timeout' => $this->client_timeout,
-            'headers' =>  ['User-Agent' => static::DEFAULT_USER_AGENT, 'Accept' => static::DEFAULT_ACCEPT],
+            'headers' =>  [
+                'User-Agent' => static::DEFAULT_USER_AGENT,
+                'Accept' => static::DEFAULT_ACCEPT,
+                'Accept-Encoding' => 'gzip, deflate',
+            ],
         ];
 
         if (!is_null($this->proxy)) {


### PR DESCRIPTION
## Summary

As long as we use Feed-io < 6, we always use Guzzle (with Feed-io 6, we need to choose a [HTTPlug](https://httplug.io/) library ourselves). Guzzle [supports](https://docs.guzzlephp.org/en/stable/request-options.html#decode-content) transparently decompressing gzip or deflate compressed responses, which is enabled by default.

Feed-io does this [by default](https://github.com/alexdebril/feed-io/pull/311/commits/ffef9eaabefcfc66bca3bb598b952d13842f14b5), but as we override the headers, we have to add a fitting `Accept-Encoding` header as well.

Previously, my feed collection caused up to 45.9 MB download traffic per cronjob, with this commit it is as low as 23.6 MB.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
