### PR TITLE
Release 23.0.0-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,15 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 # Unreleased
 ## [23.x.x]
 ### Changed
-- Drop support for PHP 7.4 new min. version is php 8.0
-- Upgrade feed-io to v5.1.3
-### Fixed
-
-## [22.x.x]
 
 ### Fixed
 
 # Releases
+## [23.0.0-beta1] - 2023-08-09
+### Changed
+- Drop support for PHP 7.4 new min. version is php 8.0 (#2237)
+- Upgrade feed-io to v5.1.3 (#2238)
+
 ## [22.0.0] - 2023-07-23
 ### Changed
 - Support deflate and gzip compression for HTTP response bodies (#2269)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>22.0.0</version>
+    <version>23.0.0-beta1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
## Summary

One step forward in modernizing news, we have to drop PHP 7.4 since our main library feed-io does not support 7.4 in newer versions. News users will benefit from the improvements in the library, fewer issues when adding, updating feeds.

This will be not the last step. The next major feed-io version doesn't support PHP 8.0 so when we upgrade to that we will also drop support for PHP 8.0 and 8.1 will be the minimum.

Changed
- Drop support for PHP 7.4 new min. version is php 8.0 (#2237)
- Upgrade feed-io to v5.1.3 (#2238)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
