### PR TITLE
Fix/docs

### DIFF
--- a/docs/features/plugins.md
+++ b/docs/features/plugins.md
@@ -200,11 +200,3 @@ class Application extends App {
 
 Using automatic container assembly you can then use it from your code by simply adding the type to your constructors.
 
-
-### Examples
-Client-side plugins:
-
-* [Mail Share](https://github.com/cosenal/mailsharenewsplugin): Client-side plugin to share articles by email
-Server-side plugins:
-
-* [Feed Central](https://github.com/Raydiation/feedcentral): Publish your feeds as RSS

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,8 +11,9 @@ nav:
   - clients.md
   - admin.md
   - developer.md
-  - faq.md
+  - troubleshooting.md
   - Features:
+    - Integration: features/integration.md
     - Custom CSS: features/customCSS.md
     - Plugins: features/plugins.md
     - Themes: features/themes.md


### PR DESCRIPTION
## Summary

We forgot to update the navigation menu for the docs, when the faq was split.

I also removed the example plugins, on link was dead the other plugin was active 8 years ago and references to owncloud...

If somone develops a plugin and maintains it, we can list it in the docs. I'm not aware of any working, maintained plugin in years.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
