### PR TITLE
drop support for Nextcloud 25

### DIFF
--- a/.github/workflows/api-integration-tests.yml
+++ b/.github/workflows/api-integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.0', '8.1']
-        nextcloud: ['stable25', 'stable26', 'stable27']
+        nextcloud: ['stable26', 'stable27']
         database: ['sqlite', 'pgsql', 'mysql']
         experimental: [false]
         include:

--- a/.github/workflows/api-php-tests.yml
+++ b/.github/workflows/api-php-tests.yml
@@ -15,8 +15,8 @@ jobs:
         experimental: [false]
         codecoverage: [false]
         include:
-          - php-versions: 8.0
-            nextcloud: stable25
+          - php-versions: 8.2
+            nextcloud: stable27
             database: sqlite
             experimental: false
             codecoverage: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this project will be documented in this file.
 The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), older entries don't fully match.
 
 # Unreleased
-## [23.x.x]
+## [24.x.x]
 ### Changed
+- Drop support for Nextcloud 25, Supported: 26, 27
 
 ### Fixed
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>23.0.0</version>
+    <version>24.0.0</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>
@@ -55,7 +55,7 @@ Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
         <lib>json</lib>
 
         <owncloud max-version="0" min-version="0"/>
-        <nextcloud min-version="25" max-version="27"/>
+        <nextcloud min-version="26" max-version="27"/>
     </dependencies>
 
     <background-jobs>

--- a/lib/Service/StatusService.php
+++ b/lib/Service/StatusService.php
@@ -92,12 +92,8 @@ class StatusService
 
         $time = 0;
 
-        [$major, $minor, $micro] = Util::getVersion();
-        
-        if ($major >= 26) {
-            $myJobList = $this->jobList->getJobsIterator(UpdaterJob::class, 1, 0);
-            $time = $myJobList->current()->getLastRun();
-        }
+        $myJobList = $this->jobList->getJobsIterator(UpdaterJob::class, 1, 0);
+        $time = $myJobList->current()->getLastRun();
         
         return $time;
     }


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary
Drop support for Nextcloud 25

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
