### PR TITLE
Use Github Actions function instead of bash script

### DIFF
--- a/.github/workflows/api-php-tests.yml
+++ b/.github/workflows/api-php-tests.yml
@@ -53,12 +53,17 @@ jobs:
       - name: Prep PHP tests
         working-directory: ../server/apps/news
         run: make php-test-dependencies
+      
       - name: Unittests
         working-directory: ../server/apps/news
         run: make unit-test
         env:
           CODECOVERAGE: ${{ matrix.codecoverage }}
-      - name: Upload codecoverage
+      
+      - name: Upload codecoverage to codecov
         if: ${{ matrix.codecoverage }}
-        working-directory: ../server/apps/news
-        run: bash <(curl -s https://codecov.io/bash) -f build/php-unit.clover -N ${{ github.sha }}
+        uses: codecov/codecov-action@v3
+        with:
+          files: ../server/apps/news/build/php-unit.clover
+          flags: unittests 
+          verbose: true

--- a/.github/workflows/api-php-tests.yml
+++ b/.github/workflows/api-php-tests.yml
@@ -62,8 +62,5 @@ jobs:
       
       - name: Upload codecoverage to codecov
         if: ${{ matrix.codecoverage }}
-        uses: codecov/codecov-action@v3
-        with:
-          files: ../server/apps/news/build/php-unit.clover
-          flags: unittests 
-          verbose: true
+        working-directory: ../server/apps/news
+        run: bash <(curl -s https://codecov.io/bash) -f build/php-unit.clover

--- a/.github/workflows/post-merge-tasks.yml
+++ b/.github/workflows/post-merge-tasks.yml
@@ -47,5 +47,9 @@ jobs:
         env:
           CODECOVERAGE: ${{ matrix.codecoverage }}
       
-      - name: Upload codecoverage
-        run: cd ../server/apps/news && bash <(curl -s https://codecov.io/bash) -f build/php-unit.clover
+      - name: Upload codecoverage to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ../server/apps/news/build/php-unit.clover
+          flags: unittests 
+          verbose: true

--- a/.github/workflows/post-merge-tasks.yml
+++ b/.github/workflows/post-merge-tasks.yml
@@ -48,8 +48,5 @@ jobs:
           CODECOVERAGE: ${{ matrix.codecoverage }}
       
       - name: Upload codecoverage to codecov
-        uses: codecov/codecov-action@v3
-        with:
-          files: ../server/apps/news/build/php-unit.clover
-          flags: unittests 
-          verbose: true
+        working-directory: ../server/apps/news
+        run: bash <(curl -s https://codecov.io/bash) -f build/php-unit.clover


### PR DESCRIPTION
## Summary

Investigating why the codecoverage does not really work on pull requests.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
