### PR TITLE
use unique name for cache folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 - Drop support for Nextcloud 25, Supported: 26, 27 (#2316)
 - Add a new command for occ `./occ news:updater:job` allows to check and reset the update job (#2166)
 - Check for available http(s) compression options and use them (gzip, deflate, brotli) (#2328)
+- Change and unify [cache](https://nextcloud.github.io/news/install/#cache) to use the instance ID of Nextcloud (#2331)
 ### Fixed
 
 # Releases

--- a/docs/install.md
+++ b/docs/install.md
@@ -27,10 +27,19 @@ Also see the [Nextcloud documentation](https://docs.nextcloud.com/server/stable/
 * Use MySQL/MariaDB or PostgreSQL for better database performance
 * Use the [updater script to thread and speed up the update](https://github.com/nextcloud/news-updater)
 
+## Cache
+News and it's libraries require a writeable temporary directory used as cache. The base directory depends on your system.
+You can [configure a custom directory](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html?highlight=temp#tempdirectory) if you want.
+
+In most cases the base directory will be `/tmp`. News will create a folder `news-$instanceID` the [instance ID is defined by Nextcloud](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html?highlight=temp#instanceid).
+
+Inside that folder a subfolder `cache` is created, inside this cache folder news and libraries will try to create cache directories for caching images, html and more.
+
+You need to ensure that your web-server user can write to that directory.
+
 ## Before you install/update the News app
 Before you install the app do the following:
 
-* Check that your **nextcloud/data/** directory is owned by your web server user and that it is write/readable
 * Check that your installation fulfills the [requirements listed above](#dependencies)
 * [Set up Nextcloud Background Jobs](https://docs.nextcloud.org/server/latest/admin_manual/configuration_server/background_jobs_configuration.html#cron) to enable feed updates.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -56,7 +56,9 @@ Feeds can be updated using Nextcloud's system cron or an external updater via th
 Follow this checklist:
 
 - Check admin settings of Nextcloud, was the last cron execution ok.
-- Check the News admin settings, system cron is used to update news
+- Check the logs for errors.
+- Does your [cache configuration](install.md#cache) work? 
+- Check the News admin settings, system cron is used to update news.
 - You should see a info card at the top, which will tell you when the last job execution was.
     - If the card is red it is very likely that the update job is stuck.
     - If it is green then maybe only some feeds are failing to update, check the Nextcloud logs.

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -24,11 +24,11 @@ use OCA\News\Hooks\UserDeleteHook;
 use OCA\News\Search\FeedSearchProvider;
 use OCA\News\Search\FolderSearchProvider;
 use OCA\News\Search\ItemSearchProvider;
+use OCA\News\Utility\Cache;
 
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
-use OCP\ITempManager;
 use OCP\AppFramework\App;
 
 use OCA\News\Fetcher\FeedFetcher;
@@ -92,15 +92,9 @@ class Application extends App implements IBootstrap
         $context->registerParameter('exploreDir', __DIR__ . '/../Explore/feeds');
 
         $context->registerService(HTMLPurifier::class, function (ContainerInterface $c): HTMLPurifier {
-            $directory = $c->get(ITempManager::class)->getTempBaseDir() . '/news/cache/purifier';
-
-            if (!is_dir($directory)) {
-                mkdir($directory, 0770, true);
-            }
-
             $config = HTMLPurifier_Config::createDefault();
             $config->set('HTML.ForbiddenAttributes', 'class');
-            $config->set('Cache.SerializerPath', $directory);
+            $config->set('Cache.SerializerPath', $c->get(Cache::class)->getCache("purifier"));
             $config->set('HTML.SafeIframe', true);
             $config->set(
                 'URI.SafeIframeRegexp',
@@ -140,7 +134,7 @@ class Application extends App implements IBootstrap
 
         $context->registerService(Favicon::class, function (ContainerInterface $c): Favicon {
             $favicon = new Favicon();
-            $favicon->cache(['dir' => $c->get(ITempManager::class)->getTempBaseDir()]);
+            $favicon->cache(['dir' => $c->get(Cache::class)->getCache("feedFavicon")]);
             return $favicon;
         });
     }

--- a/lib/Utility/Cache.php
+++ b/lib/Utility/Cache.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Nextcloud - News
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author    Benjamin Brahmer <info@b-brahmer.de>
+ * @copyright 2023 Benjamin Brahmer
+ */
+namespace OCA\News\Utility;
+
+use OCP\ITempManager;
+use OCP\IConfig;
+
+class Cache
+{
+   
+
+    /**
+     * @var ITempManager
+     */
+    private $ITempManager;
+
+    /**
+     * @var IConfig
+     */
+    private $IConfig;
+
+
+    public function __construct(
+        ITempManager $ITempManager,
+        IConfig $IConfig
+    ) {
+        $this->ITempManager   = $ITempManager;
+        $this->IConfig        = $IConfig;
+    }
+
+    /**
+     * Get a news app cache directory
+     *
+     * @param String $name for the sub-directory, is created if not existing
+     *
+     * @return String $directory The path for the cache
+     */
+    public function getCache(String $name): String
+    {
+        $baseDir = $this->ITempManager->getTempBaseDir();
+        $instanceID = $this->IConfig->getSystemValue('instanceid');
+
+        $directory = join(DIRECTORY_SEPARATOR, [$baseDir, "news-" . $instanceID, 'cache', $name]);
+
+        if (!is_dir($directory)) {
+            mkdir($directory, 0770, true);
+        }
+
+        return $directory;
+    }
+}

--- a/tests/Unit/Fetcher/FeedFetcherTest.php
+++ b/tests/Unit/Fetcher/FeedFetcherTest.php
@@ -31,6 +31,7 @@ use OCA\News\Fetcher\FeedFetcher;
 use OCA\News\Config\FetcherConfig;
 
 use OCA\News\Utility\Time;
+use OCA\News\Utility\Cache;
 use OCP\IL10N;
 use OCP\ITempManager;
 
@@ -84,11 +85,6 @@ class FeedFetcherTest extends TestCase
     private $l10n;
 
     /**
-     * @var MockObject|ITempManager
-     */
-    private $ITempManager;
-
-    /**
      * @var MockObject|ItemInterface
      */
     private $item_mock;
@@ -112,6 +108,11 @@ class FeedFetcherTest extends TestCase
      * @var MockObject|FetcherConfig
      */
     private $fetcherConfig;
+
+    /**
+     * @var MockObject|Cache
+     */
+    private $cache;
 
     //metadata
     /**
@@ -159,9 +160,6 @@ class FeedFetcherTest extends TestCase
         $this->l10n = $this->getMockBuilder(IL10N::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->ITempManager = $this->getMockBuilder(ITempManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
         $this->reader = $this->getMockBuilder(FeedIo::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -198,15 +196,18 @@ class FeedFetcherTest extends TestCase
         $this->fetcherConfig = $this->getMockBuilder(FetcherConfig::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $this->cache = $this->getMockBuilder(Cache::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->fetcher = new FeedFetcher(
             $this->reader,
             $this->favicon,
             $this->scraper,
             $this->l10n,
-            $this->ITempManager,
             $timeFactory,
             $this->logger,
-            $this->fetcherConfig
+            $this->fetcherConfig,
+            $this->cache
         );
         $this->url = 'http://tests/';
 


### PR DESCRIPTION
* Resolves: #2325 

## Summary

We had multiple reports now of shared hoster environments where the updating of some feeds fail because they can't write to the temp directory.

One possible issue is that they can't write to /tmp at all (which is the default nextcloud uses).
Or that they can write to /tmp but for some reason the hoster allows all users to share /tmp.

This PR changes that in using the instance ID of Nextcloud a unique identifier that is stable.

Example from my dev instance:

```
root@31fa29494eed:/var/www/html# ls -l /tmp/news-oc2iqvwq927d/cache/
total 12
drwxr-x--- 2 www-data www-data 4096 Aug 22 16:50 feedFavicon
drwxr-x--- 2 www-data www-data 4096 Aug 22 16:42 feedLogo
drwxr-x--- 4 www-data www-data 4096 Aug 22 16:42 purifier
```


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
