### PR TITLE
Release 24.0.0-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,17 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 # Unreleased
 ## [24.x.x]
 ### Changed
+
+### Fixed
+
+# Releases
+## [24.0.0-beta1] - 2023-08-26
+### Changed
 - Drop support for Nextcloud 25, Supported: 26, 27 (#2316)
 - Add a new command for occ `./occ news:updater:job` allows to check and reset the update job (#2166)
 - Check for available http(s) compression options and use them (gzip, deflate, brotli) (#2328)
 - Change and unify [cache](https://nextcloud.github.io/news/install/#cache) to use the instance ID of Nextcloud (#2331)
-### Fixed
 
-# Releases
 ## [23.0.0] - 2023-08-16
 No notable changes compared to 23.0.0-beta1
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>24.0.0</version>
+    <version>24.0.0-beta1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
## Summary

Changed

- Drop support for Nextcloud 25, Supported: 26, 27 (#2316)
- Add a new command for occ `./occ news:updater:job` allows to check and reset the update job (#2166)
- Check for available http(s) compression options and use them (gzip, deflate, brotli) (#2328)
- Change and unify [cache](https://nextcloud.github.io/news/install/#cache) to use the instance ID of Nextcloud (#2331)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
