### PR TITLE
Make ccMixter's favicon use HTTPS instead of HTTP.

### DIFF
--- a/lib/Explore/feeds/feeds.en.json
+++ b/lib/Explore/feeds/feeds.en.json
@@ -89,7 +89,7 @@
 	},
 	{
 		"title": "ccMixter",
-		"favicon": "http://ccmixter.org/mixter-files/images/mixter-default.gif",
+		"favicon": "https://ccmixter.org/mixter-files/images/mixter-default.gif",
 		"url": "http://ccmixter.org/",
 		"feed": "http://ccmixter.org/api/query?f=rss&tags=editorial_pick&sort=date&dir=DESC&limit=22",
 		"description": "Editor’s picks from the global music community",


### PR DESCRIPTION
Make ccMixter's favicon use HTTPS instead of HTTP.

## Summary

ccMixter's favicon is loaded using HTTP instead of HTTPS, this leads to browsers declaring the entire page as "mixed content". The favicon is also available on HTTPS.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
