### PR TITLE
[Vue Rewrite] Routes: Folder and All Articles Components and Routes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -28,3 +28,9 @@ export default Vue.extend({
 	},
 })
 </script>
+
+<style>
+	.material-design-icon {
+		color: var(--color-text-lighter)
+	}
+</style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -24,7 +24,6 @@ export default Vue.extend({
 	async created() {
 		await this.$store.dispatch(ACTIONS.FETCH_FOLDERS)
 		await this.$store.dispatch(ACTIONS.FETCH_FEEDS)
-		await this.$store.dispatch(ACTIONS.FETCH_STARRED)
 	},
 })
 </script>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -4,17 +4,29 @@
 		<NcAppNavigationNew :text="t('news', 'Subscribe')"
 			button-id="new-feed-button"
 			button-class="icon-add"
-			@click="showShowAddFeed()" />
+			:icon="true"
+			@click="showShowAddFeed()">
+			<template #icon>
+				<PlusIcon />
+			</template>
+		</NcAppNavigationNew>
 		<template #list>
 			<NcAppNavigationNewItem :title="t('news', 'New folder')"
-				icon="icon-add-folder"
-				@new-item="newFolder" />
+				:icon="true"
+				@new-item="newFolder">
+				<template #icon>
+					<FolderPlusIcon />
+				</template>
+			</NcAppNavigationNewItem>
 
 			<NcAppNavigationItem :title="t('news', 'Unread articles')" icon="icon-rss" :to="{ name: ROUTES.UNREAD }">
 				<template #actions>
 					<NcActionButton icon="icon-checkmark" @click="alert('TODO: Mark Read')">
 						t('news','Mark read')
 					</NcActionButton>
+				</template>
+				<template #icon>
+					<EyeIcon />
 				</template>
 				<template #counter>
 					<NcCounterBubble>{{ items.unreadCount }}</NcCounterBubble>
@@ -26,6 +38,9 @@
 						t('news','Mark read')
 					</ActionButton>
 				</template>
+				<template #icon>
+					<RssIcon />
+				</template>
 			</NcAppNavigationItem>
 			<NcAppNavigationItem :title="t('news', 'Starred')" icon="icon-starred" :to="{ name: ROUTES.STARRED }">
 				<template #counter>
@@ -36,18 +51,20 @@
 			<NcAppNavigationItem v-for="topLevelItem in topLevelNav"
 				:key="topLevelItem.name || topLevelItem.title"
 				:title="topLevelItem.name || topLevelItem.title"
-				:icon="isFolder(topLevelItem) ? 'icon-folder': ''"
+				:icon="true"
 				:to="isFolder(topLevelItem) ? { name: ROUTES.FOLDER, params: { folderId: topLevelItem.id.toString() }} : { name: ROUTES.FEED, params: { feedId: topLevelItem.id.toString() } }"
 				:allow-collapse="true">
 				<template #default>
 					<NcAppNavigationItem v-for="feed in topLevelItem.feeds"
 						:key="feed.name"
 						:title="feed.title"
+						:icon="true"
 						:to="{ name: ROUTES.FEED, params: { feedId: feed.id } }">
 						<template #icon>
 							<RssIcon v-if="!feed.faviconLink" />
-							<span v-if="feed.faviconLink" style="width: 24px; background-size: contain;" :style="{ 'backgroundImage': 'url(' + feed.faviconLink + ')' }" />
+							<span v-if="feed.faviconLink" style="width: 16px; height: 16px; background-size: contain;" :style="{ 'backgroundImage': 'url(' + feed.faviconLink + ')' }" />
 						</template>
+
 						<template #actions>
 							<NcActionButton icon="icon-checkmark"
 								@click="alert('TODO: Mark read')">
@@ -101,6 +118,7 @@
 					</NcAppNavigationItem>
 				</template>
 				<template #icon>
+					<FolderIcon v-if="topLevelItem.feedCount !== undefined" style="width:22px" />
 					<RssIcon v-if="topLevelItem.feedCount === undefined && !topLevelItem.faviconLink" />
 					<span v-if="topLevelItem.feedCount === undefined && topLevelItem.faviconLink" style="height: 16px; width: 16px; background-size: contain;" :style="{ 'backgroundImage': 'url(' + topLevelItem.faviconLink + ')' }" />
 				</template>
@@ -126,10 +144,13 @@
 			</NcAppNavigationItem>
 
 			<NcAppNavigationItem :title="t('news', 'Explore')"
-				icon="icon-link"
+				icon="true"
 				:to="{ name: ROUTES.EXPLORE }">
 				<template #counter>
 					<NcCounterBubble>35</NcCounterBubble>
+				</template>
+				<template #icon>
+					<EarthIcon />
 				</template>
 			</NcAppNavigationItem>
 		</template>
@@ -150,6 +171,11 @@ import NcCounterBubble from '@nextcloud/vue/dist/Components/NcCounterBubble.js'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 
 import RssIcon from 'vue-material-design-icons/Rss.vue'
+import FolderIcon from 'vue-material-design-icons/Folder.vue'
+import EyeIcon from 'vue-material-design-icons/Eye.vue'
+import EarthIcon from 'vue-material-design-icons/Earth.vue'
+import FolderPlusIcon from 'vue-material-design-icons/FolderPlus.vue'
+import PlusIcon from 'vue-material-design-icons/Plus.vue'
 
 import { ROUTES } from '../routes'
 import { ACTIONS, AppState } from '../store'
@@ -177,11 +203,15 @@ export default Vue.extend({
 		NcAppNavigationNew,
 		NcAppNavigationItem,
 		NcAppNavigationNewItem,
-		// AppNavigationCounter,
 		NcCounterBubble,
 		NcActionButton,
 		AddFeed,
 		RssIcon,
+		FolderIcon,
+		EyeIcon,
+		EarthIcon,
+		FolderPlusIcon,
+		PlusIcon,
 	},
 	data: () => {
 		return {

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -20,7 +20,7 @@
 					<NcCounterBubble>{{ items.unreadCount }}</NcCounterBubble>
 				</template>
 			</NcAppNavigationItem>
-			<NcAppNavigationItem :title="t('news', 'All articles')" icon="icon-rss">
+			<NcAppNavigationItem :title="t('news', 'All articles')" icon="icon-rss" :to="{ name: ROUTES.ALL }">
 				<template #actions>
 					<ActionButton icon="icon-checkmark" @click="alert('TODO: Edit')">
 						t('news','Mark read')
@@ -37,13 +37,13 @@
 				:key="topLevelItem.name || topLevelItem.title"
 				:title="topLevelItem.name || topLevelItem.title"
 				:icon="isFolder(topLevelItem) ? 'icon-folder': ''"
-				:to="isFolder(topLevelItem) ? {} : { name: ROUTES.FEED, params: { feedId: topLevelItem.id.toString() } }"
+				:to="isFolder(topLevelItem) ? { name: ROUTES.FOLDER, params: { folderId: topLevelItem.id.toString() }} : { name: ROUTES.FEED, params: { feedId: topLevelItem.id.toString() } }"
 				:allow-collapse="true">
 				<template #default>
 					<NcAppNavigationItem v-for="feed in topLevelItem.feeds"
 						:key="feed.name"
 						:title="feed.title"
-						:to="{ name: ROUTES.FEED, props: { feedId: feed.id } }">
+						:to="{ name: ROUTES.FEED, params: { feedId: feed.id } }">
 						<template #icon>
 							<RssIcon v-if="!feed.faviconLink" />
 							<span v-if="feed.faviconLink" style="width: 24px; background-size: contain;" :style="{ 'backgroundImage': 'url(' + feed.faviconLink + ')' }" />

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -183,7 +183,7 @@ export default Vue.extend({
 
 </script>
 
-<style scoped>
+<style>
 	.feed-item-display {
 		max-height: 100%;
 		overflow-y: hidden;
@@ -208,6 +208,22 @@ export default Vue.extend({
 
 	.article .body a {
 		color: #3a84e4
+	}
+
+	.article .body ul {
+		margin: 7px 0;
+		padding-left: 14px;
+		list-style-type: disc;
+	}
+
+	.article .body ul li {
+		cursor: default;
+		line-height: 21px;
+	}
+
+	.article .body p {
+		line-height: 1.5;
+		margin: 7px 0 14px 0;
 	}
 
 	.article .subtitle {

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -1,5 +1,5 @@
 <template>
-	<div>
+	<div style="height: 100%; display: flex; flex-direction: column;">
 		<div style="justify-content: right; display: flex">
 			<NcActions class="filter-container" :force-menu="true">
 				<template #icon>
@@ -193,6 +193,7 @@ export default Vue.extend({
 	.feed-item-container {
 		max-width: 50%;
 		overflow-y: hidden;
+		height: calc(100vh - 50px - 50px - 10px)
 	}
 
 	.filter-container {

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -1,6 +1,6 @@
 <template>
-	<div style="height: 100%; display: flex; flex-direction: column;">
-		<div style="justify-content: right; display: flex">
+	<div class="feed-item-display-list">
+		<div class="header">
 			<NcActions class="filter-container" :force-menu="true">
 				<template #icon>
 					<FilterIcon />
@@ -180,6 +180,12 @@ export default Vue.extend({
 </script>
 
 <style scoped>
+	.feed-item-display-list {
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+	}
+
 	.virtual-scroll {
 		border-top: 1px solid var(--color-border);
 		width: 100%;
@@ -194,6 +200,11 @@ export default Vue.extend({
 		max-width: 50%;
 		overflow-y: hidden;
 		height: calc(100vh - 50px - 50px - 10px)
+	}
+
+	.header {
+		justify-content: right;
+		display: flex;
 	}
 
 	.filter-container {

--- a/src/components/routes/All.vue
+++ b/src/components/routes/All.vue
@@ -1,0 +1,63 @@
+<template>
+	<div class="route-container">
+		<div class="header">
+			{{ t('news', 'All Articles') }}
+		</div>
+
+		<FeedItemDisplayList :items="allItems"
+			:fetch-key="'all'"
+			@load-more="fetchMore()" />
+	</div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { mapState } from 'vuex'
+
+import FeedItemDisplayList from '../feed-display/FeedItemDisplayList.vue'
+
+import { FeedItem } from '../../types/FeedItem'
+import { ACTIONS, MUTATIONS } from '../../store'
+
+export default Vue.extend({
+	components: {
+		FeedItemDisplayList,
+	},
+	computed: {
+		...mapState(['items']),
+
+		allItems(): FeedItem[] {
+			return this.$store.getters.allItems
+		},
+	},
+	created() {
+		this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: undefined })
+	},
+	methods: {
+		async fetchMore() {
+			if (!this.$store.state.items.fetchingItems.all) {
+			  this.$store.dispatch(ACTIONS.FETCH_ITEMS)
+			}
+		},
+	},
+})
+</script>
+
+<style scoped>
+	.route-container {
+		height: 100%;
+	}
+
+	.header {
+		padding-left: 50px;
+		position: absolute;
+		top: 1em;
+		font-weight: 700;
+	}
+
+	.counter-bubble {
+		display: inline-block;
+		vertical-align: sub;
+		margin-left: 10px;
+	}
+</style>

--- a/src/components/routes/Folder.vue
+++ b/src/components/routes/Folder.vue
@@ -1,0 +1,94 @@
+<template>
+	<div class="route-container">
+		<div class="header">
+			{{ folder ? folder.name : '' }}
+			<NcCounterBubble v-if="folder" class="counter-bubble">
+				{{ unreadCount }}
+			</NcCounterBubble>
+		</div>
+
+		<FeedItemDisplayList :items="items" :fetch-key="'folder-'+folderId" @load-more="fetchMore()" />
+	</div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { mapState } from 'vuex'
+
+import NcCounterBubble from '@nextcloud/vue/dist/Components/NcCounterBubble.js'
+
+import FeedItemDisplayList from '../feed-display/FeedItemDisplayList.vue'
+
+import { FeedItem } from '../../types/FeedItem'
+import { ACTIONS, MUTATIONS } from '../../store'
+import { Feed } from '../../types/Feed'
+import { Folder } from '../../types/Folder'
+
+export default Vue.extend({
+	components: {
+		NcCounterBubble,
+		FeedItemDisplayList,
+	},
+	props: {
+		folderId: {
+			type: String,
+			required: true,
+		},
+	},
+	computed: {
+		...mapState(['items', 'feeds', 'folders']),
+		folder(): Folder {
+			return this.$store.getters.folders.find((folder: Folder) => folder.id === this.id)
+		},
+		items(): FeedItem[] {
+			const feeds: Array<number> = this.$store.getters.feeds.filter((feed: Feed) => feed.folderId === this.id).map((feed: Feed) => feed.id)
+
+			return this.$store.state.items.allItems.filter((item: FeedItem) => {
+				return feeds.includes(item.feedId)
+			}) || []
+		},
+		id(): number {
+			return Number(this.folderId)
+		},
+		unreadCount(): number {
+			const totalUnread = this.$store.getters.feeds
+				.filter((feed: Feed) => feed.folderId === this.id)
+				.reduce((acc: number, feed: Feed) => { acc += feed.unreadCount; return acc }, 0)
+
+			return totalUnread
+		},
+	},
+	created() {
+		this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: undefined })
+		this.fetchMore()
+		this.$watch(() => this.$route.params, this.fetchMore)
+	},
+	methods: {
+		async fetchMore() {
+			if (!this.$store.state.items.fetchingItems['folder-' + this.folderId]) {
+			  this.$store.dispatch(ACTIONS.FETCH_FOLDER_FEED_ITEMS, { folderId: this.id })
+			}
+		},
+	},
+})
+</script>
+
+<style scoped>
+.route-container {
+	height: 100%;
+}
+
+.header {
+	padding-left: 50px;
+	position: absolute;
+	top: 1em;
+	font-weight: 700;
+}
+
+.counter-bubble {
+	display: inline-block;
+	vertical-align: sub;
+	margin-left: 10px;
+}
+
+</style>

--- a/src/components/routes/Starred.vue
+++ b/src/components/routes/Starred.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="route-container">
 		<div class="header">
-			Starred
+			{{ t('news', 'Starred') }}
 			<NcCounterBubble class="counter-bubble">
 				{{ items.starredCount }}
 			</NcCounterBubble>

--- a/src/components/routes/Unread.vue
+++ b/src/components/routes/Unread.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="route-container">
 		<div class="header">
-			Unread
+			{{ t('news', 'Unread Articles') }}
 			<NcCounterBubble class="counter-bubble">
 				{{ items.unreadCount }}
 			</NcCounterBubble>

--- a/src/dataservices/item.service.ts
+++ b/src/dataservices/item.service.ts
@@ -6,16 +6,39 @@ import { API_ROUTES } from '../types/ApiRoutes'
 import { FeedItem } from '../types/FeedItem'
 
 export const ITEM_TYPES = {
-	ALL: 0,
+	FEED: 0,
+	FOLDER: 1,
 	STARRED: 2,
+	ALL: 3,
 	UNREAD: 6,
 }
 
 export class ItemService {
 
+	static debounceFetchAll = _.debounce(ItemService.fetchAll, 400, { leading: true })
 	static debounceFetchStarred = _.debounce(ItemService.fetchStarred, 400, { leading: true })
 	static debounceFetchUnread = _.debounce(ItemService.fetchUnread, 400, { leading: true })
 	static debounceFetchFeedItems = _.debounce(ItemService.fetchFeedItems, 400, { leading: true })
+	static debounceFetchFolderFeedItems = _.debounce(ItemService.fetchFolderItems, 400, { leading: true })
+
+	/**
+	 * Makes backend call to retrieve all items
+	 *
+	 * @param start (id of last starred item loaded)
+	 * @return {AxiosResponse} response object containing backend request response
+	 */
+	static async fetchAll(start: number): Promise<AxiosResponse> {
+		return await axios.get(API_ROUTES.ITEMS, {
+			params: {
+				limit: 40,
+				oldestFirst: false,
+				search: '',
+				showAll: true,
+				type: ITEM_TYPES.ALL,
+				offset: start,
+			},
+		})
+	}
 
 	/**
 	 * Makes backend call to retrieve starred items
@@ -29,7 +52,7 @@ export class ItemService {
 				limit: 40,
 				oldestFirst: false,
 				search: '',
-				showAll: false,
+				showAll: true,
 				type: ITEM_TYPES.STARRED,
 				offset: start,
 			},
@@ -68,10 +91,31 @@ export class ItemService {
 				limit: 40,
 				oldestFirst: false,
 				search: '',
-				showAll: false,
-				type: ITEM_TYPES.ALL,
+				showAll: true,
+				type: ITEM_TYPES.FEED,
 				offset: start,
 				id: feedId,
+			},
+		})
+	}
+
+	/**
+	 * Makes backend call to retrieve items from a specific folder
+	 *
+	 * @param folderId id number of folder to retrieve items for
+	 * @param start (id of last unread item loaded)
+	 * @return {AxiosResponse} response object containing backend request response
+	 */
+	static async fetchFolderItems(folderId: number, start: number): Promise<AxiosResponse> {
+		return await axios.get(API_ROUTES.ITEMS, {
+			params: {
+				limit: 40,
+				oldestFirst: false,
+				search: '',
+				showAll: true,
+				type: ITEM_TYPES.FOLDER,
+				offset: start,
+				id: folderId,
 			},
 		})
 	}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,12 +4,16 @@ import ExplorePanel from '../components/routes/Explore.vue'
 import StarredPanel from '../components/routes/Starred.vue'
 import UnreadPanel from '../components/routes/Unread.vue'
 import FeedPanel from '../components/routes/Feed.vue'
+import FolderPanel from '../components/routes/Folder.vue'
+import AllPanel from '../components/routes/All.vue'
 
 export const ROUTES = {
 	EXPLORE: 'explore',
 	STARRED: 'starred',
 	UNREAD: 'unread',
 	FEED: 'feed',
+	FOLDER: 'folder',
+	ALL: 'all',
 }
 
 const getInitialRoute = function() {
@@ -47,6 +51,18 @@ const routes = [
 		name: ROUTES.FEED,
 		path: '/feed/:feedId',
 		component: FeedPanel,
+		props: true,
+	},
+	{
+		name: ROUTES.FOLDER,
+		path: '/folder/:folderId',
+		component: FolderPanel,
+		props: true,
+	},
+	{
+		name: ROUTES.ALL,
+		path: '/all',
+		component: AllPanel,
 		props: true,
 	},
 ]

--- a/tests/javascript/unit/components/routes/All.spec.ts
+++ b/tests/javascript/unit/components/routes/All.spec.ts
@@ -1,0 +1,65 @@
+import Vuex, { Store } from 'vuex'
+import { shallowMount, createLocalVue, Wrapper } from '@vue/test-utils'
+
+import All from '../../../../../src/components/routes/All.vue'
+import FeedItemDisplayList from '../../../../../src/components/feed-display/FeedItemDisplayList.vue'
+
+jest.mock('@nextcloud/axios')
+
+describe('All.vue', () => {
+	'use strict'
+	const localVue = createLocalVue()
+	localVue.use(Vuex)
+	let wrapper: Wrapper<All>
+
+	const mockItem = {
+		feedId: 1,
+		title: 'feed item',
+		pubDate: Date.now() / 1000,
+	}
+
+	let store: Store<any>
+	beforeAll(() => {
+		store = new Vuex.Store({
+			state: {
+				items: {
+					fetchingItems: {
+						all: false,
+					},
+				},
+			},
+			actions: {
+			},
+			getters: {
+				allItems: () => [mockItem, mockItem, mockItem],
+			},
+		})
+
+		store.dispatch = jest.fn()
+		store.commit = jest.fn()
+
+		wrapper = shallowMount(All, {
+			propsData: {
+				item: mockItem,
+			},
+			localVue,
+			store,
+		})
+	})
+
+	it('should get all items from state', () => {
+		expect((wrapper.findComponent(FeedItemDisplayList)).props().items.length).toEqual(3)
+	})
+
+	it('should dispatch FETCH_ITEMS action if not fetchingItems.all', () => {
+		(wrapper.vm as any).$store.state.items.fetchingItems.all = true;
+
+		(wrapper.vm as any).fetchMore()
+		expect(store.dispatch).not.toBeCalled();
+
+		(wrapper.vm as any).$store.state.items.fetchingItems.all = false;
+
+		(wrapper.vm as any).fetchMore()
+		expect(store.dispatch).toBeCalled()
+	})
+})

--- a/tests/javascript/unit/components/routes/Folder.spec.ts
+++ b/tests/javascript/unit/components/routes/Folder.spec.ts
@@ -1,0 +1,89 @@
+import Vuex, { Store } from 'vuex'
+import { shallowMount, createLocalVue, Wrapper } from '@vue/test-utils'
+
+import Folder from '../../../../../src/components/routes/Folder.vue'
+import FeedItemDisplayList from '../../../../../src/components/feed-display/FeedItemDisplayList.vue'
+
+jest.mock('@nextcloud/axios')
+
+describe('Folder.vue', () => {
+	'use strict'
+	const localVue = createLocalVue()
+	localVue.use(Vuex)
+	let wrapper: Wrapper<Folder>
+
+	const mockFeed = {
+		id: 789,
+		title: 'feed name',
+		unreadCount: 2,
+		folderId: 123,
+	}
+
+	const mockFeed2 = {
+		id: 456,
+		title: 'feed name 2',
+		unreadCount: 2,
+		folderId: 123,
+	}
+
+	const mockFolder = {
+		id: 123,
+		name: 'folder name',
+	}
+
+	let store: Store<any>
+	beforeAll(() => {
+		store = new Vuex.Store({
+			state: {
+				items: {
+					fetchingItems: {
+						'folder-123': false,
+					},
+					allItems: [{
+						feedId: 789,
+						title: 'feed item',
+					}, {
+						feedId: 456,
+						title: 'feed item 2',
+					}],
+				},
+			},
+			actions: {
+			},
+			getters: {
+				feeds: () => [mockFeed, mockFeed2],
+				folders: () => [mockFolder],
+			},
+		})
+
+		store.dispatch = jest.fn()
+		store.commit = jest.fn()
+
+		wrapper = shallowMount(Folder, {
+			propsData: {
+				folderId: '123',
+			},
+			mocks: {
+				$route: {
+					params: {},
+				},
+			},
+			localVue,
+			store,
+		})
+	})
+
+	it('should display feed title and unread count', () => {
+		expect(wrapper.find('.header').text()).toContain(mockFolder.name)
+		expect(wrapper.find('.header').text()).toContain((mockFeed.unreadCount + mockFeed2.unreadCount).toString())
+	})
+
+	it('should get folder items from state', () => {
+		expect((wrapper.findComponent(FeedItemDisplayList)).props().items.length).toEqual(2)
+	})
+
+	it('should dispatch FETCH_FOLDER_FEED_ITEMS action on fetchMore', () => {
+		(wrapper.vm as any).fetchMore()
+		expect(store.dispatch).toBeCalled()
+	})
+})

--- a/tests/javascript/unit/services/item.service.spec.ts
+++ b/tests/javascript/unit/services/item.service.spec.ts
@@ -11,6 +11,20 @@ describe('item.service.ts', () => {
 		(axios.post as any).mockReset()
 	})
 
+	describe('fetchAll', () => {
+		it('should call GET with offset set to start param, ALL item type', async () => {
+			(axios as any).get.mockResolvedValue({ data: { feeds: [] } })
+
+			await ItemService.fetchAll(0)
+
+			expect(axios.get).toBeCalled()
+			const queryParams = (axios.get as any).mock.calls[0][1].params
+
+			expect(queryParams.offset).toEqual(0)
+			expect(queryParams.type).toEqual(ITEM_TYPES.ALL)
+		})
+	})
+
 	describe('fetchStarred', () => {
 		it('should call GET with offset set to start param and STARRED item type', async () => {
 			(axios as any).get.mockResolvedValue({ data: { feeds: [] } })
@@ -40,7 +54,7 @@ describe('item.service.ts', () => {
 	})
 
 	describe('fetchFeedItems', () => {
-		it('should call GET with offset set to start param, UNREAD item type, and id set to feedId', async () => {
+		it('should call GET with offset set to start param, FEED item type, and id set to feedId', async () => {
 			(axios as any).get.mockResolvedValue({ data: { feeds: [] } })
 
 			await ItemService.fetchFeedItems(123, 0)
@@ -50,7 +64,22 @@ describe('item.service.ts', () => {
 
 			expect(queryParams.id).toEqual(123)
 			expect(queryParams.offset).toEqual(0)
-			expect(queryParams.type).toEqual(ITEM_TYPES.ALL)
+			expect(queryParams.type).toEqual(ITEM_TYPES.FEED)
+		})
+	})
+
+	describe('fetchFolderItems', () => {
+		it('should call GET with offset set to start param, FOLDER item type, and id set to folderId', async () => {
+			(axios as any).get.mockResolvedValue({ data: { feeds: [] } })
+
+			await ItemService.fetchFolderItems(123, 0)
+
+			expect(axios.get).toBeCalled()
+			const queryParams = (axios.get as any).mock.calls[0][1].params
+
+			expect(queryParams.id).toEqual(123)
+			expect(queryParams.offset).toEqual(0)
+			expect(queryParams.type).toEqual(ITEM_TYPES.FOLDER)
 		})
 	})
 

--- a/tests/javascript/unit/store/item.spec.ts
+++ b/tests/javascript/unit/store/item.spec.ts
@@ -52,6 +52,21 @@ describe('item.ts', () => {
 			})
 		})
 
+		describe('FETCH_FOLDER_FEED_ITEMS', () => {
+			it('should call ItemService and commit items to state', async () => {
+				const mockItems = [{ id: 123, title: 'feed item' }]
+				const fetchMock = jest.fn()
+				fetchMock.mockResolvedValue({ data: { items: mockItems } })
+				ItemService.debounceFetchFolderFeedItems = fetchMock as any
+				const commit = jest.fn()
+
+				await (actions[FEED_ITEM_ACTION_TYPES.FETCH_FOLDER_FEED_ITEMS] as any)({ commit }, { feedId: 123 })
+
+				expect(fetchMock).toBeCalled()
+				expect(commit).toBeCalledWith(FEED_ITEM_MUTATION_TYPES.SET_ITEMS, mockItems)
+			})
+		})
+
 		it('MARK_READ should call GET and commit returned feeds to state', async () => {
 			const item = { id: 1 }
 			const commit = jest.fn()


### PR DESCRIPTION
Related to https://github.com/nextcloud/news/pull/748

Follows https://github.com/nextcloud/news/pull/2343

## 🗒️ Summary
Add Route + Components for:
 - All Articles in Folder
 - All Articles in DB

Add More Material Design Icon Components to Side Panel

## ✅ Checklist
- [x] Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits

~- [ ] Changelog entry added for all important changes.~ (Can we add the `skip-changelog` label to prevent the check for changelog? )

## :camera: Visual
All Articles Route:
<img width="1141" alt="Screenshot 2023-09-03 at 6 10 11 PM" src="https://github.com/nextcloud/news/assets/1504590/bfc74070-de9a-4b2e-bfb7-de01709f759c">

Folder Articles Route:
<img width="1444" alt="Screenshot 2023-09-03 at 6 10 31 PM" src="https://github.com/nextcloud/news/assets/1504590/4bcc8d3c-8bfa-440f-9506-8200b24828b3">


Side Bar Icons:
<img width="497" alt="Screenshot 2023-09-03 at 6 10 03 PM" src="https://github.com/nextcloud/news/assets/1504590/9cdb646c-1c97-47fd-8aab-ed2f7df7bf8a">


## ➡️  Up Next
- Sidebar Actions ([WIP](https://github.com/devlinjunker/news/commit/7e9f96947c40a2088f1d88ead901ecee46933a93))
- use `?selected=<id>` url query parameter to store and parse which Feed Item is displayed in `FeedItemDisplay`
- Update Documentation
- Mobile friendly layout
- Warning and Error Messages
- Audio/Video Feed Items
- Share Menu
- Clean up Explore Panel
- Quick access to Settings
  - Keyboard Navigation?
  - Reverse Order (Oldest to Newest)
  - Upload/Download Subscriptions/Articles
  - Mark on Scroll?
  - Compact/Expanded View?