### PR TITLE
Fix: Set CURLOPT_USERAGENT for Scraper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 # Unreleased
 ## [24.x.x]
 ### Changed
-
+- Set User Agent for curl in Scraper
+  
 ### Fixed
 
 # Releases

--- a/lib/Scraper/Scraper.php
+++ b/lib/Scraper/Scraper.php
@@ -37,7 +37,7 @@ class Scraper implements IScraper
             CURLOPT_RETURNTRANSFER => true,     // return web page
             CURLOPT_HEADER         => false,    // do not return headers
             CURLOPT_FOLLOWLOCATION => true,     // follow redirects
-            //CURLOPT_USERAGENT    => "php-news", // who am i
+            CURLOPT_USERAGENT      => "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36", // who am i
             CURLOPT_AUTOREFERER    => true,     // set referer on redirect
             CURLOPT_CONNECTTIMEOUT => 120,      // timeout on connect
             CURLOPT_TIMEOUT        => 120,      // timeout on response

--- a/lib/Scraper/Scraper.php
+++ b/lib/Scraper/Scraper.php
@@ -16,6 +16,7 @@ use fivefilters\Readability\Configuration;
 use fivefilters\Readability\ParseException;
 use League\Uri\Exceptions\SyntaxError;
 use Psr\Log\LoggerInterface;
+use OCA\News\Config\FetcherConfig;
 
 class Scraper implements IScraper
 {
@@ -37,7 +38,7 @@ class Scraper implements IScraper
             CURLOPT_RETURNTRANSFER => true,     // return web page
             CURLOPT_HEADER         => false,    // do not return headers
             CURLOPT_FOLLOWLOCATION => true,     // follow redirects
-            CURLOPT_USERAGENT      => "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36", // who am i
+            CURLOPT_USERAGENT      => FetcherConfig::DEFAULT_USER_AGENT, // who am i
             CURLOPT_AUTOREFERER    => true,     // set referer on redirect
             CURLOPT_CONNECTTIMEOUT => 120,      // timeout on connect
             CURLOPT_TIMEOUT        => 120,      // timeout on response


### PR DESCRIPTION
Some sites do not serve content without a User Agent 


## Summary

Set CURLOPT_USERAGENT= FetcherConfig::DEFAULT_USER_AGENT

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
