### PR TITLE
Adjust search urls to match changed Vue routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
+- Adjust search urls to match changed Vue routes (#2408)
 
 # Releases
 ## [25.0.0-alpha1] - 2023-10-24

--- a/lib/Search/FeedSearchProvider.php
+++ b/lib/Search/FeedSearchProvider.php
@@ -70,7 +70,7 @@ class FeedSearchProvider implements IProvider
                 $this->urlGenerator->imagePath('core', 'rss.svg'),
                 $feed->getTitle(),
                 $this->l10n->t('Unread articles') . ': ' . $feed->getUnreadCount(),
-                $this->urlGenerator->linkToRoute('news.page.index') . '#/items/feeds/' . $feed->getId()
+                $this->urlGenerator->linkToRoute('news.page.index') . '#/feed/' . $feed->getId()
             );
         }
 

--- a/lib/Search/FolderSearchProvider.php
+++ b/lib/Search/FolderSearchProvider.php
@@ -71,7 +71,7 @@ class FolderSearchProvider implements IProvider
                 $this->urlGenerator->imagePath('core', 'filetypes/folder.svg'),
                 $folder->getName(),
                 '',
-                $this->urlGenerator->linkToRoute('news.page.index') . '#/items/folders/' . $folder->getId()
+                $this->urlGenerator->linkToRoute('news.page.index') . '#/folder/' . $folder->getId()
             );
         }
 

--- a/lib/Search/ItemSearchProvider.php
+++ b/lib/Search/ItemSearchProvider.php
@@ -94,13 +94,13 @@ class ItemSearchProvider implements IProvider
         }
 
         $icon = $this->urlGenerator->imagePath('core', 'filetypes/text.svg');
-        
+
         foreach ($search_result as $item) {
             $list[] = new SearchResultEntry(
                 $icon,
                 $item->getTitle(),
                 $this->stripTruncate($item->getBody(), 50),
-                $this->urlGenerator->linkToRoute('news.page.index') . '#/items/feeds/' . $item->getFeedId()
+                $this->urlGenerator->linkToRoute('news.page.index') . '#/feed/' . $item->getFeedId()
             );
         }
 

--- a/tests/Unit/Search/FeedSearchProviderTest.php
+++ b/tests/Unit/Search/FeedSearchProviderTest.php
@@ -125,6 +125,6 @@ class FeedSearchProviderTest extends TestCase
         $this->assertSame('some_tErm', $entry['title']);
         $this->assertSame('folderpath.svg', $entry['thumbnailUrl']);
         $this->assertSame('Unread articles: 1', $entry['subline']);
-        $this->assertSame('/news#/items/feeds/1', $entry['resourceUrl']);
+        $this->assertSame('/news#/feed/1', $entry['resourceUrl']);
     }
 }

--- a/tests/Unit/Search/FolderSearchProviderTest.php
+++ b/tests/Unit/Search/FolderSearchProviderTest.php
@@ -127,6 +127,6 @@ class FolderSearchProviderTest extends TestCase
         $this->assertSame('some_tErm', $entry['title']);
         $this->assertSame('folderpath.svg', $entry['thumbnailUrl']);
         $this->assertSame('', $entry['subline']);
-        $this->assertSame('/news#/items/folders/1', $entry['resourceUrl']);
+        $this->assertSame('/news#/folder/1', $entry['resourceUrl']);
     }
 }

--- a/tests/Unit/Search/ItemSearchProviderTest.php
+++ b/tests/Unit/Search/ItemSearchProviderTest.php
@@ -93,7 +93,7 @@ class ItemSearchProviderTest extends TestCase
         $query->expects($this->once())
                 ->method('getLimit')
                 ->willReturn(10);
-        
+
         $user->expects($this->once())
                 ->method('getUID')
                 ->willReturn('user');
@@ -101,7 +101,7 @@ class ItemSearchProviderTest extends TestCase
         $query->expects($this->once())
               ->method('getTerm')
               ->willReturn('some text');
-        
+
 
         $items = [
             Item::fromRow(['id' => 1,'title' => 'some_tErm', 'body' => 'some text', 'feedId' => 1]),
@@ -142,6 +142,6 @@ class ItemSearchProviderTest extends TestCase
         $this->assertSame('some_tErm', $entry['title']);
         $this->assertSame('folderpath.svg', $entry['thumbnailUrl']);
         $this->assertSame('some text', $entry['subline']);
-        $this->assertSame('/news#/items/feeds/1', $entry['resourceUrl']);
+        $this->assertSame('/news#/feed/1', $entry['resourceUrl']);
     }
 }


### PR DESCRIPTION
* Resolves: #2408

## Summary

The routes for feeds and folders changed during the Vue rewrite.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
