### PR TITLE
allow inline/eval script if debug mode is turned on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 # Unreleased
 ## [25.x.x]
 ### Changed
-- Use Nextcloud vue components for item list and article view
-- Fix aspect ratio of article images
+- Use Nextcloud vue components for item list and article view (#2401)
+- Fix aspect ratio of article images (#2401)
+- Allow usage of Vue devtools in Firefox (#2412)
 
 ### Fixed
 - Adjust search urls to match changed Vue routes (#2408)

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -103,7 +103,7 @@ class PageController extends Controller
             ->addAllowedFrameDomain('https://vk.com')
             ->addAllowedFrameDomain('https://www.vk.com');
 
-        if($this->settings->getSystemValue('debug')) {
+        if ($this->settings->getSystemValue('debug')) {
             $csp->allowInlineScript(true);
             $csp->allowEvalScript(true);
         }

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -102,6 +102,12 @@ class PageController extends Controller
             ->addAllowedFrameDomain('https://www.player.vimeo.com')
             ->addAllowedFrameDomain('https://vk.com')
             ->addAllowedFrameDomain('https://www.vk.com');
+
+        if($this->settings->getSystemValue('debug')) {
+            $csp->allowInlineScript(true);
+            $csp->allowEvalScript(true);
+        }
+
         $response->setContentSecurityPolicy($csp);
 
         return $response;


### PR DESCRIPTION
## Summary

This would enable vue devtools in Firefox when debug mode is activated.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
