### PR TITLE
fix: adopt search to NC 28 filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 ### Changed
 
 ### Fixed
+- Fix search support for Nextcloud 28
 
 # Releases
 ## [25.0.0-alpha2] - 2023-11-08

--- a/lib/Search/FeedSearchProvider.php
+++ b/lib/Search/FeedSearchProvider.php
@@ -59,7 +59,12 @@ class FeedSearchProvider implements IProvider
     public function search(IUser $user, ISearchQuery $query): SearchResult
     {
         $list = [];
-        $term = strtolower($query->getTerm());
+        if (method_exists($query, 'getFilter')) {
+            $term = $query->getFilter('term')?->get() ?? '';
+        } else {
+            $term = $query->getTerm();
+        }
+        $term = strtolower($term);
 
         foreach ($this->service->findAllForUser($user->getUID()) as $feed) {
             if (strpos(strtolower($feed->getTitle()), $term) === false) {

--- a/lib/Search/FolderSearchProvider.php
+++ b/lib/Search/FolderSearchProvider.php
@@ -60,7 +60,12 @@ class FolderSearchProvider implements IProvider
     public function search(IUser $user, ISearchQuery $query): SearchResult
     {
         $list = [];
-        $term = strtolower($query->getTerm());
+        if (method_exists($query, 'getFilter')) {
+            $term = $query->getFilter('term')?->get() ?? '';
+        } else {
+            $term = $query->getTerm();
+        }
+        $term = strtolower($term);
 
         foreach ($this->service->findAllForUser($user->getUID()) as $folder) {
             if (strpos(strtolower($folder->getName()), $term) === false) {

--- a/lib/Search/ItemSearchProvider.php
+++ b/lib/Search/ItemSearchProvider.php
@@ -60,13 +60,13 @@ class ItemSearchProvider implements IProvider
     private function stripTruncate(string $string, int $length = 50): string
     {
         $string = strip_tags(trim($string));
-      
+
         if (strlen($string) > $length) {
             $string = wordwrap($string, $length);
             $string = explode("\n", $string, 2);
             $string = $string[0];
         }
-      
+
         return $string;
     }
 
@@ -76,13 +76,19 @@ class ItemSearchProvider implements IProvider
         $offset = (int) ($query->getCursor() ?? 0);
         $limit = $query->getLimit();
 
+        if (method_exists($query, 'getFilter')) {
+            $term = $query->getFilter('term')?->get() ?? '';
+        } else {
+            $term = $query->getTerm();
+        }
+
         $search_result = $this->service->findAllWithFilters(
             $user->getUID(),
             ListType::ALL_ITEMS,
             $limit,
             $offset,
             false,
-            [$query->getTerm()]
+            [$term]
         );
 
         $last = end($search_result);


### PR DESCRIPTION
## Summary

Adjusts search to use filters rather than terms, fixing the phpstan check

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
