### PR TITLE
Fix Time Test failing for no reason

### DIFF
--- a/tests/Unit/Utility/TimeTest.php
+++ b/tests/Unit/Utility/TimeTest.php
@@ -45,6 +45,6 @@ class TimeTest extends TestCase
 
         $time = new Time();
         $result = (float) $time->getMicroTime();
-        $this->assertTrue($result > $cur);
+        $this->assertTrue($result >= $cur);
     }
 }

--- a/tests/command/feeds.bats
+++ b/tests/command/feeds.bats
@@ -47,7 +47,7 @@ teardown() {
   run ./occ news:feed:list "$user"
   assert_success
     
-  assert_output --partial '"faviconLink": "https:\/\/nextcloud.com\/wp-content\/uploads\/2022\/03\/favicon.png",'
+  assert_output --partial '"faviconLink": "https:\/\/nextcloud.com\/c\/uploads\/2022\/03\/favicon.png",'
   assert_output --partial  '"faviconLink": "https:\/\/www.heise.de\/favicon.ico?v='
 }
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

This should hopefully fix the time test.

The time test fails sometimes on our ci probably because php is simply to fast or does some magic.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
