### PR TITLE
Add Listener for missing db indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 # Unreleased
 ## [25.x.x]
 ### Changed
+- Add DB index for news_feeds.deleted_at (#2526)
 
 ### Fixed
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>25.0.0-alpha3</version>
+    <version>25.0.0-alpha4</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>

--- a/docs/install.md
+++ b/docs/install.md
@@ -123,9 +123,9 @@ Connect to your DB and execute the commands. Don't forget to switch to the right
 For example in mysql: `use nextcloud;`
 
 ```sql
-DROP TABLE oc_news_folders;
-DROP TABLE oc_news_feeds;
 DROP TABLE oc_news_items;
+DROP TABLE oc_news_feeds;
+DROP TABLE oc_news_folders;
 ```
 
 Then we remove the traces in the migrations table.
@@ -149,4 +149,4 @@ DELETE FROM oc_jobs WHERE class='OCA\\News\\Cron\\Updater';
 DELETE FROM oc_jobs WHERE argument='["OCA\\\\News\\\\Cron\\\\Updater","run"]';
 ```
 
-Now nothing is left from News in your nextcloud installation.
+Now nothing is left from News in your Nextcloud installation.

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -24,6 +24,7 @@ use OCA\News\Hooks\UserDeleteHook;
 use OCA\News\Search\FeedSearchProvider;
 use OCA\News\Search\FolderSearchProvider;
 use OCA\News\Search\ItemSearchProvider;
+use OCA\News\Listeners\AddMissingIndicesListener;
 use OCA\News\Utility\Cache;
 
 use OCP\AppFramework\Bootstrap\IBootContext;
@@ -34,6 +35,7 @@ use OCP\AppFramework\App;
 use OCA\News\Fetcher\FeedFetcher;
 use OCA\News\Fetcher\Fetcher;
 use OCP\User\Events\BeforeUserDeletedEvent;
+use OCP\DB\Events\AddMissingIndicesEvent;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -87,6 +89,7 @@ class Application extends App implements IBootstrap
 
 
         $context->registerEventListener(BeforeUserDeletedEvent::class, UserDeleteHook::class);
+        $context->registerEventListener(AddMissingIndicesEvent::class, AddMissingIndicesListener::class);
 
         // parameters
         $context->registerParameter('exploreDir', __DIR__ . '/../Explore/feeds');

--- a/lib/Listeners/AddMissingIndicesListener.php
+++ b/lib/Listeners/AddMissingIndicesListener.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Nextcloud - News
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author    Benjamin Brahmer <info@b-brahmer.de>
+ * @copyright 2023 Benjamin Brahmer
+ */
+
+ namespace OCA\News\Listeners;
+
+ use OCP\EventDispatcher\Event;
+ use OCP\EventDispatcher\IEventListener;
+ use OCP\DB\Events\AddMissingIncidesEvent;
+
+ /**
+ * @template-implements IEventListener<Event|AddMissingIndicesEvent>
+ */
+class AddMissingIndicesListener implements IEventListener
+{
+    public function handle(Event $event): void
+    {
+        if (!$event instanceof AddMissingIncidesEvent) {
+            return;
+        }
+
+        $event->addMissingIndex('news_feeds', 'news_feeds_deleted_at_index', ['deleted_at']);
+    }
+}

--- a/lib/Listeners/AddMissingIndicesListener.php
+++ b/lib/Listeners/AddMissingIndicesListener.php
@@ -14,7 +14,7 @@
 
  use OCP\EventDispatcher\Event;
  use OCP\EventDispatcher\IEventListener;
- use OCP\DB\Events\AddMissingIncidesEvent;
+ use OCP\DB\Events\AddMissingIndicesEvent;
 
  /**
  * @template-implements IEventListener<Event|AddMissingIndicesEvent>
@@ -23,7 +23,7 @@ class AddMissingIndicesListener implements IEventListener
 {
     public function handle(Event $event): void
     {
-        if (!$event instanceof AddMissingIncidesEvent) {
+        if (!$event instanceof AddMissingIndicesEvent) {
             return;
         }
 

--- a/lib/Migration/Version140200Date20200824201413.php
+++ b/lib/Migration/Version140200Date20200824201413.php
@@ -181,6 +181,8 @@ class Version140200Date20200824201413 extends SimpleMigrationStep {
 			$table->addIndex(['user_id'], 'news_feeds_user_id_index');
 			$table->addIndex(['folder_id'], 'news_feeds_folder_id_index');
 			$table->addIndex(['url_hash'], 'news_feeds_url_hash_index');
+			//added with news 25.x
+			$table->addIndex(['deleted_at'], 'news_feeds_deleted_at_index');
 		}
 
 		if (!$schema->hasTable('news_items')) {

--- a/lib/Migration/Version150004Date20201009183830.php
+++ b/lib/Migration/Version150004Date20201009183830.php
@@ -72,7 +72,7 @@ class Version150004Date20201009183830 extends SimpleMigrationStep {
 	    $item_name = $this->connection->getQueryBuilder()->getTableName('news_items');
 	    $feed_name = $this->connection->getQueryBuilder()->getTableName('news_feeds');
 
-	    $items_query = "DELETE FROM ${item_name} WHERE ${item_name}.`feed_id` NOT IN (SELECT DISTINCT id FROM ${feed_name})";
+	    $items_query = "DELETE FROM {$item_name} WHERE {$item_name}.`feed_id` NOT IN (SELECT DISTINCT id FROM {$feed_name})";
         $this->connection->executeQuery($items_query);
 	}
 }

--- a/lib/Migration/Version150005Date20201009192341.php
+++ b/lib/Migration/Version150005Date20201009192341.php
@@ -41,13 +41,13 @@ class Version150005Date20201009192341 extends SimpleMigrationStep {
         $feed_name = $this->connection->getQueryBuilder()->getTableName('news_feeds');
         $folder_name = $this->connection->getQueryBuilder()->getTableName('news_folders');
 
-        $items_query = "DELETE FROM ${feed_name} WHERE ${feed_name}.`folder_id` NOT IN (SELECT DISTINCT id FROM ${folder_name}) AND ${feed_name}.`folder_id` IS NOT NULL";
+        $items_query = "DELETE FROM {$feed_name} WHERE {$feed_name}.`folder_id` NOT IN (SELECT DISTINCT id FROM {$folder_name}) AND {$feed_name}.`folder_id` IS NOT NULL";
         $this->connection->executeQuery($items_query);
 
         $item_name = $this->connection->getQueryBuilder()->getTableName('news_items');
         $feed_name = $this->connection->getQueryBuilder()->getTableName('news_feeds');
 
-        $items_query = "DELETE FROM ${item_name} WHERE ${item_name}.`feed_id` NOT IN (SELECT DISTINCT id FROM ${feed_name})";
+        $items_query = "DELETE FROM {$item_name} WHERE {$item_name}.`feed_id` NOT IN (SELECT DISTINCT id FROM {$feed_name})";
         $this->connection->executeQuery($items_query);
 	}
 


### PR DESCRIPTION
* Resolves: #2526

## Summary

This should in theory allow admins to get the notification of missing indices and the option to add them via
`occ db:add-missing-indices`

tested:

- [x] changed migration creates the new index on first install
![grafik](https://github.com/nextcloud/news/assets/5429298/a5b2c7d2-a225-4f3c-8045-903c047b283c)

- [x] occ db:add-missing-indices is offered in admin overview after upgrade
![grafik](https://github.com/nextcloud/news/assets/5429298/e65272f8-1fce-4d0f-8751-30823f105ebe)
```
root@5a630161f41e:/var/www/html# sudo -u www-data php ./occ db:add-missing-indices          
Adding additional news_feeds_deleted_at_index index to the oc_news_feeds table, this can take some time...
oc_news_feeds table updated successfully.
```

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
