### PR TITLE
Fix: Mark over 65535 unread items as "read"

### DIFF
--- a/lib/Db/FeedMapperV2.php
+++ b/lib/Db/FeedMapperV2.php
@@ -186,21 +186,28 @@ class FeedMapperV2 extends NewsMapperV2
             },
             $this->db->executeQuery($idBuilder->getSQL(), $idBuilder->getParameters())->fetchAll()
         );
-        $time = new Time();
-        $builder = $this->db->getQueryBuilder();
-        $builder->update(ItemMapperV2::TABLE_NAME)
-            ->set('unread', $builder->createParameter('unread'))
-            ->set('last_modified', $builder->createParameter('last_modified'))
-            ->andWhere('id IN (:idList)')
-            ->andWhere('unread != :unread')
-            ->setParameter('unread', false, IQueryBuilder::PARAM_BOOL)
-            ->setParameter('idList', $idList, IQueryBuilder::PARAM_INT_ARRAY)
-            ->setParameter('last_modified', $time->getMicroTime(), IQueryBuilder::PARAM_STR);
+        
+		$chunked_idList = array_chunk($idList,65500,true);
+		$res = 0;
+		foreach ($chunked_idList as $idList_chunk)
+		{
+			$time = new Time();
+			$builder = $this->db->getQueryBuilder();
+			$builder->update(ItemMapperV2::TABLE_NAME)
+				->set('unread', $builder->createParameter('unread'))
+				->set('last_modified', $builder->createParameter('last_modified'))
+				->andWhere('id IN (:idList)')
+				->andWhere('unread != :unread')
+				->setParameter('unread', false, IQueryBuilder::PARAM_BOOL)
+				->setParameter('idList', $idList_chunk, IQueryBuilder::PARAM_INT_ARRAY)
+				->setParameter('last_modified', $time->getMicroTime(), IQueryBuilder::PARAM_STR);
 
-        return $this->db->executeStatement(
-            $builder->getSQL(),
-            $builder->getParameters(),
-            $builder->getParameterTypes()
-        );
+			$res += $this->db->executeStatement(
+				$builder->getSQL(),
+				$builder->getParameters(),
+				$builder->getParameterTypes()
+			);
+		}			
+		return $res;
     }
 }


### PR DESCRIPTION
If there are more than 65535 unread items, then when checking “mark as read” you will get an SQL error (SQLSTATE[HY000]: General error: 7 number of parameters must be between 0 and 65535 at) due to the limitation of the number of parameters. The array is divided into smaller ones.


* Resolves: #2556, #2284 <!-- related github issue -->

## Summary

<!-- your text -->

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
