### PR TITLE
Release 25.0.0-alpha4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,18 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 # Unreleased
 ## [25.x.x]
 ### Changed
+
+### Fixed
+
+
+# Releases
+## [25.0.0-alpha4] - 2023-01-25
+### Changed
 - Add DB index for news_feeds.deleted_at (#2526)
 
 ### Fixed
-- Mark over 65535 unread items as "read"
+- PostgreSQL implement fix for marking over 65535 unread items as "read" (#2557)
 
-# Releases
 ## [25.0.0-alpha3] - 2023-12-24
 ### Changed
 - Changed default page when starting app (#2515)


### PR DESCRIPTION
## Summary

Changed
- Add DB index for news_feeds.deleted_at (#2526)

Fixed
- PostgreSQL implement fix for marking over 65535 unread items as "read" (#2557)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
