### PR TITLE
Fix horizontal grow of feed item rows

### DIFF
--- a/src/components/feed-display/FeedItemRow.vue
+++ b/src/components/feed-display/FeedItemRow.vue
@@ -188,6 +188,7 @@ export default Vue.extend({
 	}
 
 	.feed-item-row .main-container {
+		flex-grow: 1;
 		min-width: 0;
 	}
 


### PR DESCRIPTION
## Summary

This small change fixes that feed item rows are not growing horizontally when the title and description are very short.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
