### PR TITLE
fix(ui): "a.data.items is undefined" on first run

### DIFF
--- a/lib/Controller/ItemController.php
+++ b/lib/Controller/ItemController.php
@@ -180,9 +180,14 @@ class ItemController extends Controller
             $return['items'] = $this->shareService->mapSharedByDisplayNames($items);
 
             // this gets thrown if there are no items
-            // in that case just return an empty array
+            // in that case just return an empty response
         } catch (ServiceException $ex) {
-            //NO-OP
+            return [
+                'items' => [],
+                'feeds' => [],
+                'newestItemId' => null,
+                'starred' => 0,
+            ];
         }
 
         return $return;

--- a/tests/Unit/Controller/ItemControllerTest.php
+++ b/tests/Unit/Controller/ItemControllerTest.php
@@ -455,6 +455,13 @@ class ItemControllerTest extends TestCase
 
     public function testGetItemsNoNewestItemsId()
     {
+        $result = [
+            'items' => [],
+            'feeds' => [],
+            'newestItemId' => null,
+            'starred' => 0
+        ];
+
         $this->itemsApiExpects(2, ListType::FEED);
 
         $this->itemService->expects($this->once())
@@ -463,7 +470,7 @@ class ItemControllerTest extends TestCase
             ->will($this->throwException(new ServiceNotFoundException('')));
 
         $response = $this->controller->index(ListType::FEED, 2, 3);
-        $this->assertEquals([], $response);
+        $this->assertEquals($result, $response);
     }
 
 


### PR DESCRIPTION
## Summary

When enabling the app for the very first time and opening the view, a toast notification pops up with the following message:

> TypeError: a.data.items is undefined

This is caused by a silenced exception in lib/Controller/ItemController. Due to it, not a single key is set in the $return array.

Responses returned from such a controller will be serialized as JSON. However, the returned value is no longer a key-value array, but an (empty) list and the serializer will convert it to `[]` instead of `{}` what it should've been.

Now it will return a dummy response containing all the keys but empty values, causing the serializer to return an object.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
