### PR TITLE
Release 25.0.0-alpha7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,18 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [25.x.x]
 ### Changed
+
+### Fixed
+
+# Releases
+## [25.0.0-alpha7] - 2024-06-10
+### Changed
 - added alternative development environment (#2670)
 - Implement `j` and `k` keyboards shortcuts for navigating through feed items (#2671)
 - Implement `s`, `i` and `l` keyboards shortcuts for staring current feed item (#2677)
 - Implement `o` keyboards shortcut for opening the URL of current feed item (#2677)
 - Implement `u` keyboards shortcut for marking current feed item read/unread (#2677)
 - Implement highlighting of active feed item (#2677)
-
-### Fixed
 
 # Releases
 ## [25.0.0-alpha6] - 2024-05-07

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>25.0.0-alpha6</version>
+    <version>25.0.0-alpha7</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
## Summary

### Changed
- added alternative development environment (#2670)
- Implement `j` and `k` keyboards shortcuts for navigating through feed items (#2671)
- Implement `s`, `i` and `l` keyboards shortcuts for staring current feed item (#2677)
- Implement `o` keyboards shortcut for opening the URL of current feed item (#2677)
- Implement `u` keyboards shortcut for marking current feed item read/unread (#2677)
- Implement highlighting of active feed item (#2677)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
