### PR TITLE
fix: undefined item when using j/k akeyboards shortcuts in empty feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 
 ### Fixed
+- Fix undefined item when using `j` and `k` keyboards shortcuts in an empty feed (#2689)
 
 # Releases
 ## [25.0.0-alpha7] - 2024-06-10

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -196,6 +196,10 @@ export default Vue.extend({
 		},
 		// Trigger the click event programmatically to benefit from the item handling inside the FeedItemRow component
 		clickItem(item: FeedItem, alignToTop = false) {
+			if (!item) {
+				return
+			}
+
 			const refName = 'feedItemRow' + item.id
 			const ref = this.$refs[refName]
 			// Make linter happy


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/news/pull/2671#issuecomment-2164692280

## Summary

- fix undefined item when using `j` and `k` keyboards shortcuts in an empty feed

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
