### PR TITLE
log warning if feed cannot be parsed

### DIFF
--- a/lib/Service/FeedServiceV2.php
+++ b/lib/Service/FeedServiceV2.php
@@ -16,6 +16,7 @@ namespace OCA\News\Service;
 use DateTime;
 use FeedIo\Explorer;
 use FeedIo\Reader\ReadErrorException;
+use FeedIo\Reader\NoAccurateParserException;
 use HTMLPurifier;
 
 use OCA\News\Db\FeedMapperV2;
@@ -283,10 +284,17 @@ class FeedServiceV2 extends Service
                 $feed->getBasicAuthPassword(),
                 $feed->getHttpLastModified()
             );
-        } catch (ReadErrorException $ex) {
+        } catch (ReadErrorException | NoAccurateParserException $ex) {
             $feed->setUpdateErrorCount($feed->getUpdateErrorCount() + 1);
             $feed->setLastUpdateError($ex->getMessage());
 
+            $this->logger->warning(
+                'Error while parsing feed: {url} {error}',
+                [
+                'url'   => $location,
+                'error' => $ex
+                ]
+            );
             return $this->mapper->update($feed);
         }
 


### PR DESCRIPTION
* Resolves: no issue

## Summary

When feedIo cannot match any parser (rss, atom, ..) to the feed it will throw NoAccurateParserException.
So far our code does not handle this exception instead the exception is logged by nextcloud.

It is more useful to know which url triggered this.

Throwing a ReadErrorException because that is how we track feed fetching errors in the service.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
