### PR TITLE
Release 25.0.0-alpha8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,20 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [25.x.x]
 ### Changed
+
+
+### Fixed
+
+
+# Releases
+## [25.0.0-alpha8] - 2024-07-07
+### Changed
 - Add support for moving feeds to another folder from the sidebar feed menu (#2707)
 - Persist the filter state and show unread items by default (#2704)
 
 ### Fixed
 - Fix undefined item when using `j` and `k` keyboards shortcuts in an empty feed (#2689)
 
-# Releases
 ## [25.0.0-alpha7] - 2024-06-10
 ### Changed
 - added alternative development environment (#2670)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>25.0.0-alpha7</version>
+    <version>25.0.0-alpha8</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION


* Resolves: # <!-- related github issue -->

## Summary

Changed
- Add support for moving feeds to another folder from the sidebar feed menu (#2707)
- Persist the filter state and show unread items by default (#2704)

Fixed
- Fix undefined item when using `j` and `k` keyboards shortcuts in an empty feed (#2689)


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
