### PR TITLE
Wording consistency with other Nextcloud apps

### DIFF
--- a/templates-old/part.settings.php
+++ b/templates-old/part.settings.php
@@ -2,12 +2,12 @@
     <button name="app settings"
             class="settings-button"
             data-apps-slide-toggle="#app-settings-content">
-        <?php p($l->t('Settings')); ?>
+        <?php p($l->t('News settings')); ?>
     </button>
 </div>
 
 <div id="app-settings-content">
-    <h3><?php p($l->t('Settings')); ?></h3>
+    <h3><?php p($l->t('News settings')); ?></h3>
 
     <fieldset class="settings-fieldset">
         <ul class="settings-fieldset-interior">


### PR DESCRIPTION
Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

Wording consistency with other Nextcloud apps because in other Nextcloud apps, the settings button's wording is : 

"{name of the app} settings"

* Resolves: # <!-- related github issue -->

## Summary

<!-- your text -->

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
