### PR TITLE
fix: store HTTP last modified date from response header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 
 ### Fixed
-- Allow feed title to be null in DB. #2745
+- Allow feed title to be null in DB. (#2745)
+- Store HTTP last modified date from response header (#2724)
 
 # Releases
 ## [25.0.0-alpha8] - 2024-07-07

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -142,7 +142,8 @@ class FeedFetcher implements IFeedFetcher
         $feed = $this->buildFeed(
             $parsedFeed,
             $url,
-            $location
+            $location,
+            $resource->getResponse()->getLastModified()
         );
 
         $items = [];
@@ -485,7 +486,7 @@ class FeedFetcher implements IFeedFetcher
      *
      * @return Feed
      */
-    protected function buildFeed(FeedInterface $feed, string $url, string $location): Feed
+    protected function buildFeed(FeedInterface $feed, string $url, string $location, ?DateTime $httpLastModified): Feed
     {
         $newFeed = new Feed();
 
@@ -497,8 +498,8 @@ class FeedFetcher implements IFeedFetcher
         $newFeed->setUrl($url);  // the url used to add the feed
         $newFeed->setLocation($location);  // the url where the feed was found
         $newFeed->setLink($feed->getLink());  // <link> attribute in the feed
-        if ($feed->getLastModified() instanceof DateTime) {
-            $newFeed->setHttpLastModified($feed->getLastModified()->format(DateTime::RSS));
+        if ($httpLastModified instanceof DateTime) {
+            $newFeed->setHttpLastModified($httpLastModified->format(DateTime::RSS));
         }
         $newFeed->setAdded($this->time->getTime());
 

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -73,7 +73,7 @@ class FeedFetcher implements IFeedFetcher
      * @var FetcherConfig
      */
     private $fetcherConfig;
-     
+
     /**
      * @var Cache
      */
@@ -379,11 +379,11 @@ class FeedFetcher implements IFeedFetcher
         $favicon = null;
         // trim the string because authors do funny things
         $feed_logo = $feed->getLogo();
-        
+
         if (!is_null($feed_logo)) {
             $favicon = trim($feed_logo);
         }
-        
+
         ini_set('user_agent', FetcherConfig::DEFAULT_USER_AGENT);
 
         $base_url = new Net_URL2($url);
@@ -500,15 +500,11 @@ class FeedFetcher implements IFeedFetcher
             $title = strip_tags($this->decodeTwice($feed->getTitle()));
             $newFeed->setTitle($title);
         }
+
         $newFeed->setUrl($url);  // the url used to add the feed
         $newFeed->setLocation($location);  // the url where the feed was found
         $newFeed->setLink($feed->getLink());  // <link> attribute in the feed
-        if ($feed->getLastModified() instanceof DateTime) {
-            $newFeed->setHttpLastModified($feed->getLastModified()->format(DateTime::RSS));
-        }
         $newFeed->setAdded($this->time->getTime());
-
-
 
         $favicon = $this->getFavicon($feed, $url);
         $newFeed->setFaviconLink($favicon);

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -142,9 +142,14 @@ class FeedFetcher implements IFeedFetcher
         $feed = $this->buildFeed(
             $parsedFeed,
             $url,
-            $location,
-            $resource->getResponse()->getLastModified()
+            $location
         );
+
+        if (!is_null($resource->getResponse()->getLastModified())) {
+            $feed->setHttpLastModified($resource->getResponse()->getLastModified()->format(DateTime::RSS));
+        } elseif (!is_null($lastModified)) {
+            $feed->setHttpLastModified($lastModified->format(DateTime::RSS));
+        }
 
         $items = [];
         $RTL = $this->determineRtl($parsedFeed);
@@ -486,7 +491,7 @@ class FeedFetcher implements IFeedFetcher
      *
      * @return Feed
      */
-    protected function buildFeed(FeedInterface $feed, string $url, string $location, ?DateTime $httpLastModified): Feed
+    protected function buildFeed(FeedInterface $feed, string $url, string $location): Feed
     {
         $newFeed = new Feed();
 
@@ -498,8 +503,8 @@ class FeedFetcher implements IFeedFetcher
         $newFeed->setUrl($url);  // the url used to add the feed
         $newFeed->setLocation($location);  // the url where the feed was found
         $newFeed->setLink($feed->getLink());  // <link> attribute in the feed
-        if ($httpLastModified instanceof DateTime) {
-            $newFeed->setHttpLastModified($httpLastModified->format(DateTime::RSS));
+        if ($feed->getLastModified() instanceof DateTime) {
+            $newFeed->setHttpLastModified($feed->getLastModified()->format(DateTime::RSS));
         }
         $newFeed->setAdded($this->time->getTime());
 


### PR DESCRIPTION
This addresses a scenario where a server providing a feed responds with a `Last-Modified` header that is derived from a file modification time. A static site generator, for example, may re-create a feed file without making changes to the file contents - in particular the `pubDate` for any feed items. Now the mtime and `Last-Modified` header have a date that is newer than any `pubDate` elements.

If News sends a request with a `If-Modified-Since` header based on the older `pubDate` then the server will respond with 200 and send the entire feed file contents even though the feed has not logically changed. To minimise server bandwidth, ideally News sends a last modified date based on the `Last-Modified` header it received during the last fetch so that the server can respond with 304.

## Summary

- When an HTTP `Last-Modified` header is present store the value from the header.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
