### PR TITLE
Add migration to allow feed title to be null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 
 ### Fixed
-
+- Allow feed title to be null in DB. #2745
 
 # Releases
 ## [25.0.0-alpha8] - 2024-07-07

--- a/lib/Migration/Version250000Date20240817095614.php
+++ b/lib/Migration/Version250000Date20240817095614.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024 Benjamin Brahmer <info@b-brahmer.de>
+ *
+ * @author Benjamin Brahmer <info@b-brahmer.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\News\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * FIXME Auto-generated migration step: Please modify to your needs!
+ */
+class Version250000Date20240817095614 extends SimpleMigrationStep {
+
+    /**
+     * @param IOutput $output
+     * @param Closure(): ISchemaWrapper $schemaClosure
+     * @param array $options
+     */
+    public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+    }
+
+    /**
+     * @param IOutput $output
+     * @param Closure(): ISchemaWrapper $schemaClosure
+     * @param array $options
+     * @return null|ISchemaWrapper
+     */
+    public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+        /** @var ISchemaWrapper $schema */
+        $schema = $schemaClosure();
+
+        if ($schema->hasTable('news_feeds')) {
+            $table = $schema->getTable('news_feeds');
+            $table->getColumn('title')->setNotnull(false);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * @param IOutput $output
+     * @param Closure(): ISchemaWrapper $schemaClosure
+     * @param array $options
+     */
+    public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+    }
+}


### PR DESCRIPTION
* Resolves: #2692

## Summary

Allow feed title to be null in DB. Nothing we can do in the backend when there is no title.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
