### PR TITLE
fix: remove styles for `.material-design-icon` which act on top navbar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -87,10 +87,6 @@ export default Vue.extend({
 </script>
 
 <style>
-	.material-design-icon {
-		color: var(--color-text-lighter)
-	}
-
 	#news-app {
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
Fix #2506