### PR TITLE
fix(tests): initialise http last modified as null

### DIFF
--- a/tests/Unit/Fetcher/FeedFetcherTest.php
+++ b/tests/Unit/Fetcher/FeedFetcherTest.php
@@ -347,7 +347,7 @@ class FeedFetcherTest extends TestCase
             false,
             'account@email.com',
             'F9sEU*Rt%:KFK8HMHT&',
-            $this->modified->format(DateTime::RSS)
+            null
         );
 
         $this->assertEquals([$feed, [$item]], $result);
@@ -697,9 +697,6 @@ class FeedFetcherTest extends TestCase
         $this->feed_mock->expects($this->exactly(1))
             ->method('getLink')
             ->will($this->returnValue($this->feed_link));
-        $this->feed_mock->expects($this->exactly(2))
-            ->method('getLastModified')
-            ->will($this->returnValue($this->modified));
         $this->feed_mock->expects($this->exactly(1))
             ->method('getLanguage')
             ->will($this->returnValue($lang));
@@ -710,7 +707,6 @@ class FeedFetcherTest extends TestCase
         $feed->setLink($this->feed_link);
         $feed->setLocation($this->location);
         $feed->setUrl($url);
-        $feed->setHttpLastModified((new DateTime('@3'))->format(DateTime::RSS));
         $feed->setAdded($this->time);
 
         $feed->setFaviconLink('http://anon.google.com');


### PR DESCRIPTION
* Resolves: Failing unit tests from #2724 

## Summary

When creating a `Feed` instance, `httpLastModified` should be null until the fetcher retrieves a correct value from the feed server.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
