### PR TITLE
Release 25.0.0-alpha9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,16 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 
 ### Fixed
+
+
+# Releases
+## [25.0.0-alpha9] - 2024-10-03
+### Fixed
 - Use updated user agent when fetching feeds and favicons (#2788)
 - Allow feed title to be null in DB. (#2745)
 - Store HTTP last modified date from response header (#2724)
 - Admin settings could not be saved (#2533)
 
-# Releases
 ## [25.0.0-alpha8] - 2024-07-07
 ### Changed
 - Add support for moving feeds to another folder from the sidebar feed menu (#2707)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>25.0.0-alpha8</version>
+    <version>25.0.0-alpha9</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Fixed
- Use updated user agent when fetching feeds and favicons (#2788)
- Allow feed title to be null in DB. (#2745)
- Store HTTP last modified date from response header (#2724)
- Admin settings could not be saved (#2533)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
