### PR TITLE
Release 25.0.0-alpha10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,20 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [25.x.x]
 ### Changed
-- Require NC 29
-- Require PHP 8.2 or higher
 
+### Fixed
+
+# Releases
+## [25.0.0-alpha10] - 2024-10-14
+### Changed
+- Require NC 29 or 30, dropped support for NC 28
+- Require PHP 8.2 or higher
 ### Fixed
 - Scroll position is not reset when switching between articles & feeds (#2548)
 - Unread counter does not count down when folders or feeds are marked read (#2800)
 - Query fetching status didn't work (#2800)
 - Keyboard shortcuts are active even when searching (#2738)
 
-
-# Releases
 ## [25.0.0-alpha9] - 2024-10-03
 ### Fixed
 - Use updated user agent when fetching feeds and favicons (#2788)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>25.0.0-alpha9</version>
+    <version>25.0.0-alpha10</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
* Resolves: #2719

## Summary
### Changed
- Require NC 29 or 30, dropped support for NC 28
- Require PHP 8.2 or higher
### Fixed
- Scroll position is not reset when switching between articles & feeds (#2548)
- Unread counter does not count down when folders or feeds are marked read (#2800)
- Query fetching status didn't work (#2800)
- Keyboard shortcuts are active even when searching (#2738)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
