### PR TITLE
fix: Feed item lists are merged when filtered 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - fix formatting in navigation.scss to make styleint happy
 - scroll stops after first bunch of items when they are marked read during scroll
 - marked read items disappear when showAll is disabled in folder or feed view
+- Feed item lists are merged when filtered (#2516)
 
 # Releases
 ## [25.0.0-alpha10] - 2024-10-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Fixed
 - First features for user settings after vue migration (#2795)
 - fix formatting in navigation.scss to make styleint happy
+- scroll stops after first bunch of items when they are marked read during scroll
 
 # Releases
 ## [25.0.0-alpha10] - 2024-10-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - First features for user settings after vue migration (#2795)
 - fix formatting in navigation.scss to make styleint happy
 - scroll stops after first bunch of items when they are marked read during scroll
+- marked read items disappear when showAll is disabled in folder or feed view
 
 # Releases
 ## [25.0.0-alpha10] - 2024-10-14

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -155,6 +155,9 @@ export default Vue.extend({
 		getSelectedItem(newVal) {
 			this.selectedItem = newVal
 		},
+		fetchKey() {
+			this.cache = undefined
+		},
 	},
 	created() {
 		this.loadFilter()

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -227,7 +227,7 @@ export default Vue.extend({
 
 			// if we're filtering on unread, we want to cache the unread items when the user presses the filter button
 			// that way when the user opens an item, it won't be removed from the displayed list of items (once it's no longer unread)
-			if (this.filter === this.unreadFilter) {
+			if (!this.$store.getters.showAll || this.filter === this.unreadFilter) {
 				if (!this.cache) {
 					if (this.items.length > 0) {
 						this.cache = this.items.filter(this.unreadFilter)

--- a/src/components/routes/Unread.vue
+++ b/src/components/routes/Unread.vue
@@ -53,7 +53,7 @@ export default Vue.extend({
 				if (this.$store.getters.unread.length > 0) {
 					this.unreadCache = this.$store.getters.unread
 				}
-			} else if (this.$store.getters.unread.length > (this.unreadCache?.length)) {
+			} else {
 				for (const item of this.$store.getters.unread) {
 					if (this.unreadCache.find((unread: FeedItem) => unread.id === item.id) === undefined) {
 						this.unreadCache.push(item)

--- a/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
@@ -33,6 +33,7 @@ describe('FeedItemDisplayList.vue', () => {
 			},
 			getters: {
 				unread: () => [mockItem, mockItem],
+				showAll: () => { return true },
 			},
 		})
 


### PR DESCRIPTION
* Resolves: #2516 

## Summary
other fixes:
- when article marked read they are deleted from the unread item list and therefor the unread list is never greater than the cache.
- marked read items disappear when showAll is disabled in folder or feed view

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
