### PR TITLE
fix: Navigating to the news app always opens /explore instead of remembering the last viewed feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - marked read items disappear when showAll is disabled in folder or feed view
 - Feed item lists are merged when filtered (#2516)
 - Mark as read on Scroll (#2503)
+- Open news with the last viewed feed or folder (#2507)
 
 # Releases
 ## [25.0.0-alpha10] - 2024-10-14

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -80,7 +80,9 @@ class PageController extends Controller
             'compactExpand',
             'preventReadOnScroll',
             'oldestFirst',
-            'showAll'
+            'showAll',
+            'lastViewedFeedId',
+            'lastViewedFeedType'
         ];
 
         foreach ($usersettings as $setting) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -63,11 +63,11 @@ export default Vue.extend({
 		...mapState(['app']),
 	},
 	async created() {
+		// fetch starred to get starred count
+		await this.$store.dispatch(ACTIONS.FETCH_STARRED)
 		// fetch folders and feeds to build side bar
 		await this.$store.dispatch(ACTIONS.FETCH_FOLDERS)
 		await this.$store.dispatch(ACTIONS.FETCH_FEEDS)
-		// fetch starred to get starred count
-		await this.$store.dispatch(ACTIONS.FETCH_STARRED)
 	},
 	methods: {
 		stopPlaying() {

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -7,6 +7,8 @@ import FeedPanel from '../components/routes/Feed.vue'
 import FolderPanel from '../components/routes/Folder.vue'
 import AllPanel from '../components/routes/All.vue'
 
+import store from './../store/app'
+
 export const ROUTES = {
 	EXPLORE: 'explore',
 	STARRED: 'starred',
@@ -17,8 +19,30 @@ export const ROUTES = {
 }
 
 const getInitialRoute = function() {
-	// TODO: Fetch Recent route from Browser Session?
-	return ROUTES.UNREAD
+	const params: { feedId?: string; folderId?: string } = {}
+
+	switch (store.state.lastViewedFeedType) {
+	case '0':
+		params.feedId = store.state.lastViewedFeedId
+		return {
+			name: ROUTES.FEED,
+			params,
+		}
+	case '1':
+		params.folderId = store.state.lastViewedFeedId
+		return {
+			name: ROUTES.FOLDER,
+			params,
+		}
+	case '2':
+		return { name: ROUTES.STARRED }
+	case '3':
+		return { name: ROUTES.ALL }
+	case '5':
+		return { name: ROUTES.EXPLORE }
+	default:
+		return { name: ROUTES.UNREAD }
+	}
 }
 
 const routes = [

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -12,6 +12,8 @@ export type AppInfoState = {
 	oldestFirst: boolean;
 	preventReadOnScroll: boolean;
 	showAll: boolean;
+	lastViewedFeedId: string;
+	lastViewedFeedType: string;
 }
 
 const state: AppInfoState = {
@@ -21,6 +23,8 @@ const state: AppInfoState = {
 	oldestFirst: loadState('news', 'oldestFirst', null) === '1',
 	preventReadOnScroll: loadState('news', 'preventReadOnScroll', null) === '1',
 	showAll: loadState('news', 'showAll', null) === '1',
+	lastViewedFeedId: loadState('news', 'lastViewedFeedId', '0'),
+	lastViewedFeedType: loadState('news', 'lastViewedFeedType', '6'),
 }
 
 const getters = {
@@ -41,6 +45,12 @@ const getters = {
 	},
 	showAll() {
 		return state.showAll
+	},
+	lastViewedFeedId() {
+		return state.lastViewedFeedId
+	},
+	lastViewedFeedType() {
+		return state.lastViewedFeedType
 	},
 }
 


### PR DESCRIPTION
* Resolves: #2507

## Summary

Open news with the last viewed feed or folder

The state of the folders is stored in an other table, so this will be an other task to do.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
