### PR TITLE
fix: Mark as read on Scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - scroll stops after first bunch of items when they are marked read during scroll
 - marked read items disappear when showAll is disabled in folder or feed view
 - Feed item lists are merged when filtered (#2516)
+- Mark as read on Scroll (#2503)
 
 # Releases
 ## [25.0.0-alpha10] - 2024-10-14


### PR DESCRIPTION
* Related: #2503

## Summary

The last items at the end are not marked read, because  they do not scrolled out. This will be another task to scroll the last items out of the view as in news 24.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
