### PR TITLE
fix: restore old scroll behaviour to scoll after arcticles needed for mark scroll on read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 
 ### Fixed
-- restore old scroll behaviour to scroll after arcticles needed for mark scroll on read (#2817)
+- restore old scroll behaviour to scroll after articles needed for mark scroll on read (#2817)
 
 
 # Releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 
 ### Fixed
+- restore old scroll behaviour to scoll after arcticles needed for mark scroll on read (#2817)
 
 
 # Releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 
 ### Fixed
-- restore old scroll behaviour to scoll after arcticles needed for mark scroll on read (#2817)
+- restore old scroll behaviour to scroll after arcticles needed for mark scroll on read (#2817)
 
 
 # Releases

--- a/src/components/feed-display/VirtualScroll.vue
+++ b/src/components/feed-display/VirtualScroll.vue
@@ -177,4 +177,11 @@ export default Vue.extend({
 	position: relative;
 	overflow-y: scroll;
 }
+.container-window::after {
+    content: '';
+    display: block;
+    /* Subtract the height of the Nextcloud and Feed header. */
+    height: calc(100vh - 50px - 54px);
+    background-repeat: no-repeat;
+}
 </style>


### PR DESCRIPTION
* Related: #2817
## Summary

Add ::after css from News 24 so that articles can be scrolled out and marked read as before

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
