### PR TITLE
fix: Items keep popping up in Folder, All or Unread view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - restore old scroll behavior to scroll after articles needed for mark scroll on read (#2817)
 - 25.0.0-alpha2: Feed folder bar menu always opens collapsed (#2508)
 - fix: hide folder/feeds with no unread items when `showAll` is disabled (#2503)
+- Items keep popping up in Folder, All or Unread view (#2833)
 
 # Releases
 ## [25.0.0-alpha11] - 2024-10-19

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -229,6 +229,10 @@ export default Vue.extend({
 		unreadFilter(item: FeedItem): boolean {
 			return item.unread
 		},
+		outOfScopeFilter(item: FeedItem): boolean {
+			const lastItemLoaded = this.$store.state.items.lastItemLoaded[this.fetchKey]
+			return (this.$store.getters.oldestFirst ? lastItemLoaded >= item.id : lastItemLoaded <= item.id)
+		},
 		toggleFilter(filter: (item: FeedItem) => boolean) {
 			if (this.filter === filter) {
 				this.filter = this.noFilter
@@ -268,6 +272,11 @@ export default Vue.extend({
 				response = [...this.cache as FeedItem[]]
 			} else {
 				response = response.filter(this.filter)
+			}
+
+			// filter items that are already loaded but do not yet match the current view (unread, all, folder...)
+			if (!this.fetchKey.startsWith('feed-') && this.$store.state.items.lastItemLoaded[this.fetchKey] > 0) {
+				response = response.filter(this.outOfScopeFilter)
 			}
 
 			return response.sort(this.sort)

--- a/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
@@ -27,6 +27,9 @@ describe('FeedItemDisplayList.vue', () => {
 					allItemsLoaded: {
 						unread: false,
 					},
+					lastItemLoaded: {
+						unread: 0,
+					},
 				},
 			},
 			actions: {


### PR DESCRIPTION
* Resolves: #2833

## Summary

Added a new filter to prevent items that were loaded in other views with eventually different orderings from popping up early in a merged view.

Add only Items to the view where item id are between start and the view specific lastItemLoaded.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
