### PR TITLE
fix: Folders and Feeds in Sidebar are not sorted alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - starred items in a feed can prevent further scrolling
 - j shortcut doesn't load more items in infinite scroll (#2847)
 - Feed ordering uses wrong values (#2846)
+- Folders and Feeds in Sidebar are not sorted alphabetically (#2838)
 
 # Releases
 ## [25.0.0-alpha12] - 2024-10-23

--- a/lib/Db/FeedMapperV2.php
+++ b/lib/Db/FeedMapperV2.php
@@ -64,7 +64,8 @@ class FeedMapperV2 extends NewsMapperV2
             ->andWhere('feeds.deleted_at = 0')
             ->groupBy('feeds.id')
             ->setParameter('unread', true, IQueryBuilder::PARAM_BOOL)
-            ->setParameter('user_id', $userId);
+            ->setParameter('user_id', $userId)
+            ->addOrderBy('title');
 
         return $this->findEntities($builder);
     }
@@ -88,7 +89,8 @@ class FeedMapperV2 extends NewsMapperV2
             ->where('user_id = :user_id')
             ->andWhere('id = :id')
             ->setParameter('user_id', $userId)
-            ->setParameter('id', $id);
+            ->setParameter('id', $id)
+            ->addOrderBy('title');
 
         return $this->findEntity($builder);
     }

--- a/lib/Db/FolderMapperV2.php
+++ b/lib/Db/FolderMapperV2.php
@@ -54,7 +54,8 @@ class FolderMapperV2 extends NewsMapperV2
                 ->from($this->tableName)
                 ->where('user_id = :user_id')
                 ->andWhere('deleted_at = 0')
-                ->setParameter('user_id', $userId);
+                ->setParameter('user_id', $userId)
+                ->addOrderBy('name');
 
         return $this->findEntities($builder);
     }
@@ -69,7 +70,8 @@ class FolderMapperV2 extends NewsMapperV2
         $builder = $this->db->getQueryBuilder();
         $builder->select('*')
             ->from($this->tableName)
-            ->where('deleted_at = 0');
+            ->where('deleted_at = 0')
+            ->addOrderBy('name');
 
         return $this->findEntities($builder);
     }


### PR DESCRIPTION
* Resolves: #2838

## Summary

This is the simplest and most efficient way to get the sidebar items sorted, instead of adding another sort to the frontend sidebar logic.
But I don't know if there are other APPS that uses this API and expect the current order, which actually corresponds to the date of creation

The only disadvantage is that when new elements are added, they have to be resorted or the page must be reloaded.

@Grotax @SMillerDev 
If you agree, I will add the logic to re-sort the list when adding feeds or folders in a new PR.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
