### PR TITLE
Performance improvements and ordering rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 ### Fixed
 - starred items in a feed can prevent further scrolling
+- j shortcut doesn't load more items in infinite scroll (#2847)
 - Feed ordering uses wrong values (#2846)
 
 # Releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ## [25.x.x]
 ### Changed
 - Performance improvements on item list
+- Rework feed and global sort ordering
 
 ### Fixed
+- starred items in a feed can prevent further scrolling
 
 # Releases
 ## [25.0.0-alpha12] - 2024-10-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [25.x.x]
 ### Changed
+- Performance improvements on item list
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 ### Fixed
 - starred items in a feed can prevent further scrolling
+- Feed ordering uses wrong values (#2846)
 
 # Releases
 ## [25.0.0-alpha12] - 2024-10-23

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -282,8 +282,8 @@ export default Vue.extend({
 
 			},
 			set(newValue) {
+				this.$store.dispatch(ACTIONS.RESET_LAST_ITEM_LOADED)
 				this.saveSetting('oldestFirst', newValue)
-				this.$store.dispatch(ACTIONS.RESET_ITEMS)
 			},
 		},
 		preventReadOnScroll: {

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -142,6 +142,7 @@ export default Vue.extend({
 			cache: [] as FeedItem[] | undefined,
 			filteredItemcache: [] as FeedItem,
 			selectedItem: undefined as FeedItem | undefined,
+			debouncedClickItem: null,
 		}
 	},
 	computed: {
@@ -203,6 +204,7 @@ export default Vue.extend({
 	},
 	mounted() {
 		this.mounted = true
+		this.setupDebouncedClick()
 	},
 	methods: {
 		refreshItemList() {
@@ -329,6 +331,12 @@ export default Vue.extend({
 
 			return response.sort(this.sort)
 		},
+		// debounce clicks to prevent multiple api calls when on the end of the actual loaded list
+		setupDebouncedClick() {
+			this.debouncedClickItem = _.debounce((Item) => {
+				this.clickItem(Item)
+			}, 20, { leading: true })
+		},
 		// Trigger the click event programmatically to benefit from the item handling inside the FeedItemRow component
 		clickItem(item: FeedItem) {
 			if (!item) {
@@ -361,7 +369,8 @@ export default Vue.extend({
 			// Jump to the previous item
 			if (currentIndex > 0) {
 				const previousItem = items[currentIndex - 1]
-				this.clickItem(previousItem)
+				this.debouncedClickItem(previousItem)
+
 			}
 		},
 
@@ -371,7 +380,7 @@ export default Vue.extend({
 			// Jump to the first item, if none was selected, otherwise jump to the next item
 			if (currentIndex === -1 || (currentIndex < items.length - 1)) {
 				const nextItem = items[currentIndex + 1]
-				this.clickItem(nextItem)
+				this.debouncedClickItem(nextItem)
 			}
 		},
 	},

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -170,6 +170,9 @@ export default Vue.extend({
 			        globalOrdering: this.changedGlobalOrdering,
 		      }
 		},
+		changedShowAll() {
+			return this.$store.getters.showAll
+		},
 	},
 	watch: {
 		getSelectedItem(newVal) {
@@ -196,6 +199,11 @@ export default Vue.extend({
 			// refresh the list with the new ordering
 			this.refreshItemList()
 			this.$refs.virtualScroll.scrollTop = 0
+		},
+		// showAll has changed rebuild item list
+		changedShowAll() {
+			this.cache = undefined
+			this.refreshItemList()
 		},
 	},
 	created() {

--- a/src/components/feed-display/FeedItemRow.vue
+++ b/src/components/feed-display/FeedItemRow.vue
@@ -141,7 +141,7 @@ export default Vue.extend({
 			return this.$store.getters.feeds.find((feed: Feed) => feed.id === id) || {}
 		},
 		markRead(item: FeedItem): void {
-			if (!this.keepUnread) {
+			if (!this.keepUnread && item.unread) {
 				this.$store.dispatch(ACTIONS.MARK_READ, { item })
 			}
 		},

--- a/src/components/routes/Feed.vue
+++ b/src/components/routes/Feed.vue
@@ -1,6 +1,6 @@
 <template>
-	<ContentTemplate :items="items"
-		:config="{ ordering: feed?.ordering || FEED_ORDER.NEWEST }"
+	<ContentTemplate v-if="!loading"
+		:items="items"
 		:fetch-key="'feed-' + feedId"
 		@load-more="fetchMore()">
 		<template #header>
@@ -23,7 +23,6 @@ import ContentTemplate from '../ContentTemplate.vue'
 import { FeedItem } from '../../types/FeedItem'
 import { ACTIONS, MUTATIONS } from '../../store'
 import { Feed } from '../../types/Feed'
-import { FEED_ORDER } from '../../dataservices/feed.service'
 
 export default Vue.extend({
 	components: {
@@ -37,13 +36,10 @@ export default Vue.extend({
 		},
 	},
 	computed: {
-		FEED_ORDER() {
-			return FEED_ORDER
-		},
 		...mapState(['items', 'feeds']),
-		feed(): Feed | null {
+		feed(): Feed {
 			const feeds = this.$store.getters.feeds
-			return feeds ? feeds.find((feed: Feed) => feed.id === this.id) : null
+			return feeds.find((feed: Feed) => feed.id === this.id)
 		},
 		items(): FeedItem[] {
 			return this.$store.state.items.allItems.filter((item: FeedItem) => {
@@ -53,6 +49,9 @@ export default Vue.extend({
 		id(): number {
 			return Number(this.feedId)
 		},
+		loading() {
+			return this.$store.getters.loading
+		},
 	},
 	created() {
 		this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: undefined })
@@ -61,8 +60,8 @@ export default Vue.extend({
 	},
 	methods: {
 		async fetchMore() {
-			if (!this.$store.state.items.fetchingItems['feed-' + this.feedId]) {
-			  this.$store.dispatch(ACTIONS.FETCH_FEED_ITEMS, { feedId: this.id, ordering: this.feed?.ordering || 0 })
+			if (!this.loading && !this.$store.state.items.fetchingItems['feed-' + this.feedId]) {
+			  this.$store.dispatch(ACTIONS.FETCH_FEED_ITEMS, { feedId: this.id })
 			}
 		},
 	},

--- a/src/dataservices/feed.service.ts
+++ b/src/dataservices/feed.service.ts
@@ -4,9 +4,9 @@ import axios from '@nextcloud/axios'
 import { API_ROUTES } from '../types/ApiRoutes'
 
 export enum FEED_ORDER {
+	DEFAULT = 0,
 	OLDEST = 1,
-	NEWEST = 0,
-	DEFAULT = 2,
+	NEWEST = 2,
 }
 
 export enum FEED_UPDATE_MODE {

--- a/src/dataservices/item.service.ts
+++ b/src/dataservices/item.service.ts
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import { AxiosResponse } from 'axios'
 import axios from '@nextcloud/axios'
 import store from './../store/app'
+import feedstore from './../store/feed'
 
 import { API_ROUTES } from '../types/ApiRoutes'
 import { FeedItem } from '../types/FeedItem'
@@ -85,12 +86,11 @@ export class ItemService {
 	 *
 	 * @param feedId id number of feed to retrieve items for
 	 * @param start (id of last unread item loaded)
-	 * @param ordering (0 = NEWEST, 1 = OLDEST, 2 = DEFAULT)
 	 * @return {AxiosResponse} response object containing backend request response
 	 */
-	static async fetchFeedItems(feedId: number, start?: number, ordering?: number): Promise<AxiosResponse> {
+	static async fetchFeedItems(feedId: number, start?: number): Promise<AxiosResponse> {
 		let oldestFirst
-		switch (ordering) {
+		switch (feedstore.state.ordering['feed-' + feedId]) {
 		case FEED_ORDER.OLDEST:
 			oldestFirst = true
 			break

--- a/src/store/feed.ts
+++ b/src/store/feed.ts
@@ -27,11 +27,13 @@ export const FEED_ACTION_TYPES = {
 export type FeedState = {
 	feeds: Feed[];
 	unreadCount: number;
+	ordering: { [key: string]: number };
 }
 
 const state: FeedState = {
 	feeds: [],
 	unreadCount: 0,
+	ordering: {},
 }
 
 const getters = {
@@ -140,6 +142,8 @@ export const actions = {
 		{ commit }: ActionParams<FeedState>,
 		{ feed, ordering }: { feed: Feed, ordering: FEED_ORDER },
 	) {
+		state.ordering = { ...state.ordering, ['feed-' + feed.id]: ordering }
+		commit(FEED_ITEM_MUTATION_TYPES.SET_LAST_ITEM_LOADED, { key: 'feed-' + feed.id, lastItem: undefined })
 		await FeedService.updateFeed({ feedId: feed.id as number, ordering })
 
 		commit(FEED_MUTATION_TYPES.UPDATE_FEED, { id: feed.id, ordering })
@@ -205,6 +209,9 @@ export const mutations = {
 	) {
 		feeds.forEach(it => {
 			state.feeds.push(it)
+			if (it.ordering) {
+				state.ordering['feed-' + it.id] = it.ordering
+			}
 		})
 	},
 

--- a/src/store/item.ts
+++ b/src/store/item.ts
@@ -16,7 +16,7 @@ export const FEED_ITEM_ACTION_TYPES = {
 	FETCH_FEED_ITEMS: 'FETCH_FEED_ITEMS',
 	FETCH_FOLDER_FEED_ITEMS: 'FETCH_FOLDER_FEED_ITEMS',
 	FETCH_ITEMS: 'FETCH_ITEMS',
-	RESET_ITEMS: 'RESET_ITEMS',
+	RESET_LAST_ITEM_LOADED: 'RESET_LAST_ITEM_LOADED',
 }
 
 export type ItemState = {
@@ -159,14 +159,13 @@ export const actions = {
 	 * @param param1 ActionArgs
 	 * @param param1.start Start data
 	 * @param param1.feedId ID of the feed
-	 * @param param1.ordering Ordering of the feed
 	 */
 	async [FEED_ITEM_ACTION_TYPES.FETCH_FEED_ITEMS](
 		{ commit }: ActionParams<ItemState>,
-		{ feedId, start, ordering }: { feedId: number; start: number; ordering: number },
+		{ feedId, start }: { feedId: number; start: number },
 	) {
 		commit(FEED_ITEM_MUTATION_TYPES.SET_FETCHING, { key: 'feed-' + feedId, fetching: true })
-		const response = await ItemService.debounceFetchFeedItems(feedId, start || state.lastItemLoaded['feed-' + feedId], ordering)
+		const response = await ItemService.debounceFetchFeedItems(feedId, start || state.lastItemLoaded['feed-' + feedId])
 		commit(FEED_ITEM_MUTATION_TYPES.SET_ITEMS, response?.data.items)
 		if (response?.data.items.length < 40) {
 			commit(FEED_ITEM_MUTATION_TYPES.SET_ALL_LOADED, { key: 'feed-' + feedId, loaded: true })
@@ -292,22 +291,16 @@ export const actions = {
 	},
 
 	/**
-	 * Remove all loaded items from memory and reset ItemsLoaded counters
+	 * Reset lastItemsLoaded counters
 	 *
 	 * @param param0 ActionParams
-	 * @param param0.dispatch Dispatch
-	 * @param param1 ActionArgs
-	 * @param param1.start Start data
+	 * @param param0.commit Commit action
+	 * @param param0.state ItemState
 	 */
-	[FEED_ITEM_ACTION_TYPES.RESET_ITEMS](
-		{ dispatch }: ActionParams<ItemState>,
-		{ start }: { start: number } = { start: 0 },
-	) {
-		state.allItems.splice(start, state.allItems.length - start)
-		state.allItemsLoaded = {}
-		state.lastItemLoaded = {}
-		dispatch(FEED_ITEM_ACTION_TYPES.FETCH_STARRED, 0)
-		dispatch(FEED_ITEM_ACTION_TYPES.FETCH_ITEMS, 0)
+	[FEED_ITEM_ACTION_TYPES.RESET_LAST_ITEM_LOADED]({ commit, state }: ActionParams<ItemState>) {
+		Object.entries(state.lastItemLoaded).forEach(([key]) => {
+			commit(FEED_ITEM_MUTATION_TYPES.SET_LAST_ITEM_LOADED, { key, lastItem: undefined })
+		})
 	},
 }
 

--- a/src/store/item.ts
+++ b/src/store/item.ts
@@ -358,7 +358,15 @@ export const mutations = {
 		{ item }: { item: FeedItem },
 	) {
 		const idx = state.allItems.findIndex((it) => it.id === item.id)
-		state.allItems[idx] = { ...state.allItems[idx], ...item }
+		// Since spread-syntax doesn't work here properly with vue2, update
+		// each property on its own as workaround to prevent rebuilding
+		// the whole item list when changing the unread or starred status
+		// state.allItems[idx] = { ...state.allItems[idx], ...item }
+		state.allItems[idx].starred = item.starred
+		state.allItems[idx].unread = item.unread
+		// UPDATE_ITEM currently only used when toggle starred and unread
+		// add title to make js-test happy
+		state.allItems[idx].title = item.title
 	},
 
 	[FEED_ITEM_MUTATION_TYPES.SET_FETCHING](

--- a/src/store/item.ts
+++ b/src/store/item.ts
@@ -365,7 +365,7 @@ export const mutations = {
 		{ item }: { item: FeedItem },
 	) {
 		const idx = state.allItems.findIndex((it) => it.id === item.id)
-		state.allItems.splice(idx, 1, item)
+		state.allItems[idx] = { ...state.allItems[idx], ...item }
 	},
 
 	[FEED_ITEM_MUTATION_TYPES.SET_FETCHING](

--- a/tests/javascript/unit/components/feed-display/FeedItemRow.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemRow.spec.ts
@@ -12,6 +12,7 @@ describe('FeedItemRow.vue', () => {
 		feedId: 1,
 		title: 'feed item',
 		pubDate: Date.now() / 1000,
+		unread: true,
 	}
 	const mockFeed = {
 		id: 1,


### PR DESCRIPTION
* Resolves: #2846
* Resolves: #2847

## Summary

This PR changes the way when the sorted item list is updated, to prevent sorting the whole list for every click or twice for changing to next item when navigating with keyboard.
Also the item list now shows the correct items immediately after changing, the feed or global sort order.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
