### PR TITLE
Release 25.0.0-alpha13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [25.x.x]
 ### Changed
+
+### Fixed
+
+# Releases
+## [25.0.0-alpha13] - 2024-11-07
+### Changed
 - Performance improvements on item list
 - Rework feed and global sort ordering
 - Add 'r' shortkey to refresh feed and item list
@@ -21,7 +27,6 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - Folders and Feeds in Sidebar are not sorted alphabetically (#2838)
 - Unread Counter becomes negative (#2839)
 
-# Releases
 ## [25.0.0-alpha12] - 2024-10-23
 ### Changed
 - Feed ordering will now be used for sorting items (#2678)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>25.0.0-alpha12</version>
+    <version>25.0.0-alpha13</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
## Summary

Changed
- Performance improvements on item list
- Rework feed and global sort ordering
- Add 'r' shortkey to refresh feed and item list
- Show automatically new news items on VueJS implementation (#2502)
- Show when feeds and folder have errors
- Add keyboard shortcuts 'd', 'f', 'c' and 'v' to switch between feeds and folders

Fixed
- starred items in a feed can prevent further scrolling
- j shortcut doesn't load more items in infinite scroll (#2847)
- Feed ordering uses wrong values (#2846)
- Folders and Feeds in Sidebar are not sorted alphabetically (#2838)
- Unread Counter becomes negative (#2839)


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
