### PR TITLE
add single column layout (compact mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,9 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - Add API to import OPML file or request body
 - add import/export `opml` to user settings (#2541)
 - Remove non-functional unread and starred filter
-- add single column layout (compact mode) (#2503)
-- add horizontal split layout (expanded compact mode) (#2503)
 - add single column layout (compact mode) (#2505)
 - add horizontal split layout (expanded compact mode) (#2505)
-- Allow to further drag the feedview list (and/or provide alternative view) (#2505)
+- Allow to further drag the `feedview` list (and/or provide alternative view) (#2505)
 
 ### Fixed
 - Feed without Title returned by DB causes exception (#2872)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - Remove non-functional unread and starred filter
 - add single column layout (compact mode) (#2503)
 - add horizontal split layout (expanded compact mode) (#2503)
+- add single column layout (compact mode) (#2505)
+- add horizontal split layout (expanded compact mode) (#2505)
+- Allow to further drag the feedview list (and/or provide alternative view) (#2505)
 
 ### Fixed
 - Feed without Title returned by DB causes exception (#2872)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - Add API to import OPML file or request body
 - add import/export `opml` to user settings (#2541)
 - Remove non-functional unread and starred filter
+- add single column layout (compact mode) (#2503)
 
 ### Fixed
 - Feed without Title returned by DB causes exception (#2872)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - add import/export `opml` to user settings (#2541)
 - Remove non-functional unread and starred filter
 - add single column layout (compact mode) (#2503)
+- add horizontal split layout (expanded compact mode) (#2503)
 
 ### Fixed
 - Feed without Title returned by DB causes exception (#2872)

--- a/src/components/ContentTemplate.vue
+++ b/src/components/ContentTemplate.vue
@@ -1,6 +1,7 @@
 <template>
 	<NcAppContent :layout="layout"
 		:show-details="showDetails"
+		:list-max-width="100"
 		@update:showDetails="showItem(false)">
 		<template #list>
 			<NcAppContentList>

--- a/src/components/ContentTemplate.vue
+++ b/src/components/ContentTemplate.vue
@@ -1,5 +1,5 @@
 <template>
-	<NcAppContent :layout="compactMode ? 'no-split' : 'vertical-split'"
+	<NcAppContent :layout="layout"
 		:show-details="showDetails"
 		@update:showDetails="showItem(false)">
 		<template #list>
@@ -74,8 +74,12 @@ const showDetails = ref(false)
 
 const contentElement = ref()
 
-const compactMode = computed(() => {
-	return appStore.getters.compact(appStore.state)
+const layout = computed(() => {
+	if (appStore.getters.compact(appStore.state)) {
+		return appStore.getters.compactExpand(appStore.state) ? 'horizontal-split' : 'no-split'
+	} else {
+		return 'vertical-split'
+	}
 })
 
 const selectedFeedItem = computed(() => {

--- a/src/components/ContentTemplate.vue
+++ b/src/components/ContentTemplate.vue
@@ -1,10 +1,12 @@
 <template>
-	<NcAppContent :show-details="showDetails"
-		@update:showDetails="unselectItem()">
+	<NcAppContent :layout="compactMode ? 'no-split' : 'vertical-split'"
+		:show-details="showDetails"
+		@update:showDetails="showItem(false)">
 		<template #list>
 			<NcAppContentList>
 				<FeedItemDisplayList :items="items"
 					:fetch-key="fetchKey"
+					@show-details="showItem(true)"
 					@load-more="emit('load-more')">
 					<template #header>
 						<slot name="header" />
@@ -15,7 +17,9 @@
 
 		<NcAppContentDetails class="feed-item-content">
 			<div ref="contentElement" class="feed-item-content-wrapper">
-				<FeedItemDisplay v-if="selectedFeedItem" :item="selectedFeedItem" />
+				<FeedItemDisplay v-if="selectedFeedItem"
+					:item="selectedFeedItem"
+					@show-details="showItem(false)" />
 				<NcEmptyContent v-else
 					style="margin-top: 20vh"
 					:name="t('news', 'No article selected')"
@@ -38,6 +42,7 @@
 
 import { type PropType, computed, ref, watch } from 'vue'
 
+import appStore from '../store/app'
 import itemStore from '../store/item'
 
 import NcAppContent from '@nextcloud/vue/dist/Components/NcAppContent.js'
@@ -69,28 +74,30 @@ const showDetails = ref(false)
 
 const contentElement = ref()
 
+const compactMode = computed(() => {
+	return appStore.getters.compact(appStore.state)
+})
+
 const selectedFeedItem = computed(() => {
 	return itemStore.getters.selected(itemStore.state)
 })
 
 watch(selectedFeedItem, (newSelectedFeedItem) => {
 	if (newSelectedFeedItem) {
-		showDetails.value = true
 		contentElement.value?.scrollTo(0, 0)
 	} else {
-		showDetails.value = false
+		showItem(false)
 	}
 })
 
 /**
- * Unselect a list item.
+ * set showDetails value
+ *
+ * @param {boolean} value Show or hide item
  *
  */
-function unselectItem() {
-	itemStore.mutations.SET_SELECTED_ITEM(
-		itemStore.state,
-		{ id: undefined },
-	)
+function showItem(value) {
+	showDetails.value = value
 }
 
 </script>

--- a/src/components/ContentTemplate.vue
+++ b/src/components/ContentTemplate.vue
@@ -107,7 +107,7 @@ function showItem(value) {
 
 </script>
 
-<style>
+<style scoped>
 .feed-item-content {
 	overflow:hidden;
 	height: 100%
@@ -116,5 +116,19 @@ function showItem(value) {
 .feed-item-content-wrapper {
 	height: 100%;
 	overflow-y: scroll;
+}
+
+/*
+ * can be removed when fixed in nextcloud-vue library
+ * https://github.com/nextcloud-libraries/nextcloud-vue/pull/6227
+ */
+>>> .splitpanes.default-theme.splitpanes--horizontal .splitpanes__splitter {
+	background-color: var(--color-main-background) !important;
+	border-top: 1px solid var(--color-border) !important;
+}
+
+>>> .splitpanes.default-theme.splitpanes--horizontal .splitpanes__splitter::before,
+>>> .splitpanes.default-theme.splitpanes--horizontal .splitpanes__splitter::after {
+	background-color: var(--color-border) !important;
 }
 </style>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -163,6 +163,15 @@
 							{{ t('news', 'Compact view') }}
 						</label>
 					</div>
+					<div v-if="compact">
+						<input id="toggle-compact-expand"
+							v-model="compactExpand"
+							type="checkbox"
+							class="checkbox">
+						<label for="toggle-compact-expand">
+							{{ t('news', 'Expanded compact view') }}
+						</label>
+					</div>
 					<div>
 						<input id="toggle-showall"
 							v-model="showAll"

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -155,6 +155,15 @@
 						</label>
 					</div>
 					<div>
+						<input id="toggle-compact"
+							v-model="compact"
+							type="checkbox"
+							class="checkbox">
+						<label for="toggle-compact">
+							{{ t('news', 'Compact view') }}
+						</label>
+					</div>
+					<div>
 						<input id="toggle-showall"
 							v-model="showAll"
 							type="checkbox"

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -14,7 +14,7 @@
 			<StarIcon :class="{'starred': item.starred }" @click="toggleStarred(item)" />
 			<EyeIcon v-if="item.unread" @click="toggleRead(item)" />
 			<EyeCheckIcon v-if="!item.unread" @click="toggleRead(item)" />
-			<CloseIcon @click="clearSelected()" />
+			<CloseIcon @click="compactMode ? $emit('show-details') : clearSelected()" />
 			<button v-shortkey="{s: ['s'], l: ['l'], i: ['i']}" class="hidden" @shortkey="toggleStarred(item)" />
 			<button v-shortkey="['o']" class="hidden" @shortkey="openUrl(item)" />
 			<button v-shortkey="['u']" class="hidden" @shortkey="toggleRead(item)" />
@@ -143,6 +143,9 @@ export default Vue.extend({
 	},
 	computed: {
 		...mapState(['feeds']),
+		compactMode() {
+			return this.$store.getters.compact
+		},
 	},
 	methods: {
 		/**

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -144,7 +144,7 @@ export default Vue.extend({
 	computed: {
 		...mapState(['feeds']),
 		compactMode() {
-			return this.$store.getters.compact
+			return (this.$store.getters.compact && !this.$store.getters.compactExpand)
 		},
 	},
 	methods: {

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -36,7 +36,8 @@
 						<FeedItemRow :key="item.id"
 							:ref="'feedItemRow' + item.id"
 							:item="item"
-							:class="{ 'active': selectedItem && selectedItem.id === item.id }" />
+							:class="{ 'active': selectedItem && selectedItem.id === item.id }"
+							@show-details="$emit('show-details')" />
 					</template>
 				</template>
 			</VirtualScroll>
@@ -53,7 +54,7 @@ import FeedItemRow from './FeedItemRow.vue'
 
 import { FeedItem } from '../../types/FeedItem'
 import { FEED_ORDER } from '../../dataservices/feed.service'
-import { ACTIONS } from '../../store'
+import { ACTIONS, MUTATIONS } from '../../store'
 
 export default Vue.extend({
 	components: {
@@ -262,7 +263,8 @@ export default Vue.extend({
 			const element = componentInstance ? componentInstance.$el : undefined
 
 			if (element) {
-				element.click()
+				this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: item.id })
+				this.$store.dispatch(ACTIONS.MARK_READ, { item })
 				const virtualScroll = this.$refs.virtualScroll
 				virtualScroll.showElement(element)
 

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -341,6 +341,7 @@ export default Vue.extend({
 		align-items: center;
 		justify-content: right;
 		height: 54px;
+		min-height: 54px;
 	}
 
 	.header-content {

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -131,6 +131,7 @@ export default Vue.extend({
 		// clear cache on route change
 		fetchKey: {
 			handler() {
+				this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: undefined })
 				if (this.listOrdering === false) {
 					this.$store.dispatch(ACTIONS.RESET_LAST_ITEM_LOADED)
 				}

--- a/src/components/feed-display/FeedItemRow.vue
+++ b/src/components/feed-display/FeedItemRow.vue
@@ -265,6 +265,7 @@ export default Vue.extend({
 
 	.feed-item-row .date-container.compact {
 		flex: 0 0 auto;
+		font-size: small;
 	}
 
 	.feed-item-row .button-container {

--- a/src/components/feed-display/FeedItemRow.vue
+++ b/src/components/feed-display/FeedItemRow.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="feed-item-row" @click="select()">
+	<div class="feed-item-row" :class="{ 'compact': compactMode }" @click="select()">
 		<ShareItem v-if="showShareMenu" :item-id="shareItem" @close="closeShareMenu()" />
 		<div class="link-container">
 			<a class="external"
@@ -16,20 +16,20 @@
 			</a>
 		</div>
 
-		<div class="main-container">
-			<div class="title-container" :class="{ 'unread': item.unread }">
+		<div class="main-container" :class="{ 'compact': compactMode }">
+			<div class="title-container" :class="{ 'compact': compactMode, 'unread': item.unread }">
 				<span :dir="item.rtl && 'rtl'">
 					{{ item.title }}
 				</span>
 			</div>
 
-			<div class="intro-container">
+			<div class="intro-container" :class="{ 'compact': compactMode }">
 				<!-- eslint-disable vue/no-v-html -->
 				<span class="intro" v-html="item.intro" />
 				<!--eslint-enable-->
 			</div>
 
-			<div class="date-container">
+			<div class="date-container" :class="{ 'compact': compactMode }">
 				<time class="date" :title="formatDate(item.pubDate*1000, 'yyyy-MM-dd HH:mm:ss')" :datetime="formatDatetime(item.pubDate*1000, 'yyyy-MM-ddTHH:mm:ssZ')">
 					{{ getRelativeTimestamp(item.pubDate*1000) }}
 				</time>
@@ -100,11 +100,15 @@ export default Vue.extend({
 	},
 	computed: {
 		...mapState(['feeds']),
+		compactMode() {
+			return this.$store.getters.compact
+		},
 	},
 	methods: {
 		select(): void {
 			this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: this.item.id })
 			this.markRead(this.item)
+			this.$emit('show-details')
 		},
 		formatDate(epoch: number): string {
 			return new Date(epoch).toLocaleString()
@@ -165,6 +169,10 @@ export default Vue.extend({
 		display: flex; padding: 10px 10px;
 	}
 
+	.feed-item-row.compact {
+		display: flex; padding: 1px 1px !important;
+	}
+
 	.feed-item-row:hover {
 		background-color: var(--color-background-hover);
 	}
@@ -193,6 +201,12 @@ export default Vue.extend({
 		flex-grow: 1;
 	}
 
+	.feed-item-row .main-container.compact {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+	}
+
 	.feed-item-row .title-container {
 		color: var(--color-text-lighter);
 
@@ -204,7 +218,12 @@ export default Vue.extend({
 
 	.feed-item-row .title-container.unread {
 		color: var(--color-main-text);
-    font-weight: bold;
+		font-weight: bold;
+	}
+
+	.feed-item-row .title-container.compact {
+		flex: 0 1 auto;
+		overflow: unset;
 	}
 
 	.feed-item-row .intro-container {
@@ -213,10 +232,18 @@ export default Vue.extend({
 		overflow: hidden;
 	}
 
+	.feed-item-row .intro-container.compact {
+		flex: 1 1 auto;
+		height: 26pt !important;
+		align-content: center;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
 	.feed-item-row .intro {
 		color: var(--color-text-lighter);
-    font-size: 10pt;
-    font-weight: normal;
+		font-size: 10pt;
+		font-weight: normal;
 	}
 
 	@media only screen and (min-width: 320px) {
@@ -236,6 +263,10 @@ export default Vue.extend({
 		white-space: nowrap;
 	}
 
+	.feed-item-row .date-container.compact {
+		flex: 0 0 auto;
+	}
+
 	.feed-item-row .button-container {
 		display: flex;
 		flex-direction: row;
@@ -244,9 +275,9 @@ export default Vue.extend({
 
 	.feed-item-row .button-container .button-vue, .feed-item-row .button-container .button-vue .button-vue__wrapper, .feed-item-row .button-container .material-design-icon {
 		width: 30px !important;
-    min-width: 30px;
-    min-height: 30px;
-    height: 30px;
+		min-width: 30px;
+		min-height: 30px;
+		height: 30px;
 	}
 
 	.feed-item-row .button-container .material-design-icon {

--- a/src/components/feed-display/VirtualScroll.vue
+++ b/src/components/feed-display/VirtualScroll.vue
@@ -10,8 +10,6 @@ import ItemSkeleton from './ItemSkeleton.vue'
 import { ACTIONS } from '../../store'
 
 const GRID_ITEM_HEIGHT = 200 + 10
-// const GRID_ITEM_WIDTH = 250 + 10
-const LIST_ITEM_HEIGHT = 110 + 1
 
 export default Vue.extend({
 	name: 'VirtualScroll',
@@ -45,6 +43,12 @@ export default Vue.extend({
 			cache: false,
 			get() {
 				return this.$store.state.items.fetchingItems[this.fetchKey]
+			},
+		},
+		compactMode: {
+			cache: false,
+			get() {
+				return this.$store.getters.compact
 			},
 		},
 	},
@@ -113,12 +117,11 @@ export default Vue.extend({
 		let renderedItems = 0
 		let upperPaddingItems = 0
 		let lowerPaddingItems = 0
-		let itemHeight = 1
+		const itemHeight = this.compactMode ? 37 : 111
 		const padding = GRID_ITEM_HEIGHT
 		if (this.$slots.default && this.$el && this.$el.getBoundingClientRect) {
 			const childComponents = this.$slots.default.filter(child => !!child.componentOptions)
 			const viewport = this.$el.getBoundingClientRect()
-			itemHeight = LIST_ITEM_HEIGHT
 			renderedItems = Math.floor((viewport.height + padding + padding) / itemHeight)
 			upperPaddingItems = Math.floor(Math.max(this.scrollTop - padding, 0) / itemHeight)
 			children = childComponents.slice(upperPaddingItems, upperPaddingItems + renderedItems)
@@ -157,7 +160,7 @@ export default Vue.extend({
 		const scrollTop = this.scrollTop
 		this.$nextTick(() => {
 			if (this.elementToShow) {
-				this.elementToShow.scrollIntoView({ behavior: 'auto', block: 'nearest' })
+				this.elementToShow.scrollIntoView({ behavior: 'auto', block: 'start' })
 				this.elementToShow = null
 			} else {
 				this.$el.scrollTop = scrollTop


### PR DESCRIPTION
* Resolves: #2505
* Related: #2503

## Summary
This PR adds alternative modes configurable in the user settings and allow to move the feed list splitter to 100%.
* compact mode: If an article is clicked the article is shown using the whole content view.
* expanded compact mode: horizontal split mode with the item displayed below the item list

**Compact Mode Light Theme**
![CompactModeLight](https://github.com/user-attachments/assets/daef99d5-f42c-4d14-882a-a2e6cbd54fed)
**Compact Mode Details Light Theme**
![CompactModeDetailsLight](https://github.com/user-attachments/assets/7eec438b-6d29-48f9-8adc-ea68a5d906a4)
**Compact Mode Dark Theme**
![CompactModeDark](https://github.com/user-attachments/assets/e7ab3413-09f6-4f7b-ac1b-809552890918)
**Compact Mode Details Dark Theme**
![CompactModeDetailsDark](https://github.com/user-attachments/assets/992c678a-da68-4a30-a860-25077d5d22d1)
**Expanded Compact Mode Ligtht Theme**
![CompactExpandLight](https://github.com/user-attachments/assets/19e403f9-f388-4f17-a788-dc03752bedb8)
**Expanded Compact Mode Dark Theme**
![CompactExpandDark](https://github.com/user-attachments/assets/a3f6498a-f15f-4272-8880-6d1b1da5cc8b)


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
