### PR TITLE
fix feed title issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [25.x.x]
 ### Changed
+- If title of feed is empty during creation set hostname of feed as title (#2872)
 
 ### Fixed
+- Feed without Title returned by DB causes exception (#2872)
 
 # Releases
 ## [25.0.0-alpha14] - 2024-11-10

--- a/lib/Db/Feed.php
+++ b/lib/Db/Feed.php
@@ -241,9 +241,9 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getTitle(): string
+    public function getTitle(): ?string
     {
         return $this->title;
     }

--- a/lib/Service/FeedServiceV2.php
+++ b/lib/Service/FeedServiceV2.php
@@ -232,7 +232,7 @@ class FeedServiceV2 extends Service
         if ($this->existsForUser($userId, $feedUrl)) {
             throw new ServiceConflictException('Feed with this URL exists');
         }
-        
+
         if ($feed === null) {
             throw new ServiceNotFoundException('Failed to fetch feed');
         }
@@ -242,11 +242,15 @@ class FeedServiceV2 extends Service
             ->setHttpLastModified(null)
             ->setArticlesPerUpdate(count($items));
 
-        if (!is_null($title)) {
+        if ($title !== null) {
             $feed->setTitle($title);
         }
+   
+        if ($feed->getTitle() === null) {
+            $feed->setTitle(parse_url($feedUrl)['host']);
+        }
 
-        if (!is_null($user)) {
+        if ($user !== null) {
             $feed->setBasicAuthUser($user)
                 ->setBasicAuthPassword($password);
         }


### PR DESCRIPTION
* Resolves: #2797

## Summary

While testing the new opml import function and trying to export the feeds from my dev server as opml I came across this issue again, since #869 and  #2745 it is possible to add feeds without a title.
But this is causing other issues for example when you try to export your feeds because the DB Feed Entity expects the title to be a string.

With my changes it is now ok if a feed title is null, that should allow people to see feeds even when they do not have a title.
This is of course not optimal because a feed without a title is hard to identify in the feed list, if the feed has a logo or favicon you at least see that else you just see an empty line. You are still able to call open the menu though to remove or rename the feed.

So I also added a check if the title is null during the first creation of the feed and decided to use the hostname of the url that the user entered when adding the feed, which might differ from the actual feed url since some blogs and I think especially podcasts use some cdn for that.

Hope this fixes the last issues.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
