### PR TITLE
feat: add import/export opml to user settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - If title of feed is empty during creation set hostname of feed as title (#2872)
 - Add command to import OPML file
 - Add API to import OPML file or request body
+- add import/export `opml` to user settings (#2541)
 
 ### Fixed
 - Feed without Title returned by DB causes exception (#2872)

--- a/src/store/folder.ts
+++ b/src/store/folder.ts
@@ -69,8 +69,12 @@ export const mutations = {
 		state: FolderState,
 		folders: Folder[],
 	) {
-		const updatedFolders = [...state.folders, ...folders].sort((a, b) => a.name.localeCompare(b.name))
-		state.folders = [...updatedFolders]
+		const updatedFolders = [...state.folders, ...folders]
+			.filter((folder, index, self) =>
+				self.findIndex(f => f.id === folder.id) === index)
+			.sort((a, b) => a.name.localeCompare(b.name))
+
+		state.folders = updatedFolders
 	},
 
 	[FOLDER_MUTATION_TYPES.DELETE_FOLDER](


### PR DESCRIPTION
* Related: #2541 

## Summary

Add import/export to user settings. Keep as draft until the api "/import/opml" is implemented.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
