### PR TITLE
Remove non-functional unread and starred filter and code cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - Add command to import OPML file
 - Add API to import OPML file or request body
 - add import/export `opml` to user settings (#2541)
+- Remove non-functional unread and starred filter
 
 ### Fixed
 - Feed without Title returned by DB causes exception (#2872)

--- a/src/components/ContentTemplate.vue
+++ b/src/components/ContentTemplate.vue
@@ -5,7 +5,6 @@
 			<NcAppContentList>
 				<FeedItemDisplayList :items="items"
 					:fetch-key="fetchKey"
-					:config="config"
 					@load-more="emit('load-more')">
 					<template #header>
 						<slot name="header" />
@@ -50,7 +49,7 @@ import TextIcon from 'vue-material-design-icons/Text.vue'
 
 import { FeedItem } from '../types/FeedItem'
 
-import FeedItemDisplayList, { Config } from './feed-display/FeedItemDisplayList.vue'
+import FeedItemDisplayList from './feed-display/FeedItemDisplayList.vue'
 import FeedItemDisplay from './feed-display/FeedItemDisplay.vue'
 
 defineProps({
@@ -61,9 +60,6 @@ defineProps({
 	fetchKey: {
 		type: String,
 		required: true,
-	},
-	config: {
-		type: Object as PropType<Config>,
 	},
 })
 

--- a/src/components/MoveFeed.vue
+++ b/src/components/MoveFeed.vue
@@ -61,8 +61,6 @@ export default Vue.extend({
 			return this.$store.state.folders.folders
 		},
 		disableMoveFeed(): boolean {
-			console.log('feed', this.feed)
-			console.log('this.folder', this.folder)
 			return (this.folder !== undefined && this.folder.id === this.feed.folderId)
 		},
 	},

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -129,9 +129,6 @@
 			<NcAppNavigationItem :name="t('news', 'Explore')"
 				icon="true"
 				:to="{ name: ROUTES.EXPLORE }">
-				<template #counter>
-					<NcCounterBubble>35</NcCounterBubble>
-				</template>
 				<template #icon>
 					<EarthIcon />
 				</template>

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -88,9 +88,6 @@ export default Vue.extend({
 		return {
 			mounted: false,
 
-			// Show unread items at start
-			filter: () => { return this.unreadFilter },
-
 			// Determine the sorting order
 			sort: (a: FeedItem, b: FeedItem) => {
 				if (a.id > b.id) {
@@ -230,9 +227,6 @@ export default Vue.extend({
 		fetchMore() {
 			this.$emit('load-more')
 		},
-		noFilter(): boolean {
-			return true
-		},
 		unreadFilter(item: FeedItem): boolean {
 			return item.unread
 		},
@@ -243,15 +237,9 @@ export default Vue.extend({
 		filterSortedItems(): FeedItem[] {
 			let response = [...this.items] as FeedItem[]
 
-			let itemFilter = this.filter
-
-			if (this.fetchKey !== 'starred' && !this.$store.getters.showAll) {
-				itemFilter = this.unreadFilter
-			}
-
 			// if we're filtering on unread, we want to cache the unread items when the user presses the filter button
 			// that way when the user opens an item, it won't be removed from the displayed list of items (once it's no longer unread)
-			if (itemFilter === this.unreadFilter) {
+			if (this.fetchKey !== 'starred' && !this.$store.getters.showAll) {
 				if (!this.cache) {
 					if (this.items.length > 0) {
 						this.cache = this.items.filter(this.unreadFilter)
@@ -264,8 +252,6 @@ export default Vue.extend({
 					}
 				}
 				response = [...this.cache as FeedItem[]]
-			} else {
-				response = response.filter(this.filter)
 			}
 
 			// filter items that are already loaded but do not yet match the current view

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -343,11 +343,7 @@ export default Vue.extend({
 
 	.header-content {
 		flex-grow: 1;
-		padding-left: 50px;
+		padding-left: 52px;
 		font-weight: 700;
-	}
-
-	.filter-container {
-		padding: 5px;
 	}
 </style>

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -45,7 +45,7 @@
 </template>
 
 <script lang="ts">
-import Vue, { type PropType } from 'vue'
+import Vue from 'vue'
 import _ from 'lodash'
 
 import VirtualScroll from './VirtualScroll.vue'
@@ -54,14 +54,6 @@ import FeedItemRow from './FeedItemRow.vue'
 import { FeedItem } from '../../types/FeedItem'
 import { FEED_ORDER } from '../../dataservices/feed.service'
 import { ACTIONS } from '../../store'
-
-const DEFAULT_DISPLAY_LIST_CONFIG = {
-	ordering: FEED_ORDER.NEWEST,
-}
-
-export type Config = {
-	ordering: number;
-}
 
 export default Vue.extend({
 	components: {
@@ -76,12 +68,6 @@ export default Vue.extend({
 		fetchKey: {
 			type: String,
 			required: true,
-		},
-		config: {
-			type: Object as PropType<Config>,
-			default: () => {
-				return DEFAULT_DISPLAY_LIST_CONFIG
-			},
 		},
 	},
 	data() {
@@ -104,9 +90,6 @@ export default Vue.extend({
 		}
 	},
 	computed: {
-		cfg() {
-			return _.defaults({ ...this.config }, DEFAULT_DISPLAY_LIST_CONFIG)
-		},
 		getSelectedItem() {
 			return this.$store.getters.selected
 		},

--- a/src/components/routes/Starred.vue
+++ b/src/components/routes/Starred.vue
@@ -1,7 +1,6 @@
 <template>
 	<ContentTemplate :items="starred"
 		:fetch-key="'starred'"
-		:config="{ starFilter: false }"
 		@load-more="fetchMore()">
 		<template #header>
 			{{ t('news', 'Starred') }}

--- a/src/components/routes/Unread.vue
+++ b/src/components/routes/Unread.vue
@@ -1,7 +1,6 @@
 <template>
 	<ContentTemplate :items="unread() ?? []"
 		:fetch-key="'unread'"
-		:config="{ unreadFilter: false }"
 		@load-more="fetchMore()">
 		<template #header>
 			{{ t('news', 'Unread Articles') }}

--- a/src/store/feed.ts
+++ b/src/store/feed.ts
@@ -5,7 +5,6 @@ import { Feed } from '../types/Feed'
 import { FOLDER_MUTATION_TYPES, FEED_MUTATION_TYPES, FEED_ITEM_MUTATION_TYPES } from '../types/MutationTypes'
 import { FolderService } from '../dataservices/folder.service'
 import { FEED_ORDER, FEED_UPDATE_MODE, FeedService } from '../dataservices/feed.service'
-import { ItemService } from '../dataservices/item.service'
 
 export const FEED_ACTION_TYPES = {
 	ADD_FEED: 'ADD_FEED',
@@ -95,12 +94,12 @@ export const actions = {
 			commit(FEED_MUTATION_TYPES.ADD_FEED, response.data.feeds[0])
 		} catch (e) {
 			// TODO: show error to user if failure
-			console.log(e)
+			console.error(e)
 		}
 	},
 
 	async [FEED_ACTION_TYPES.MOVE_FEED](
-		{ commit }: ActionParams<FeedState>,
+		state: FeedState,
 		{ feedId, folderId }: { feedId: number, folderId: number },
 	) {
 		// Check that url is resolvable
@@ -110,12 +109,12 @@ export const actions = {
 				folderId,
 			})
 
-			// The feed list seems to refresh, but the parent folder does not update in the UI
-			// We will do this directly by resetting the states of the folders and feeds and fetching them again
-			// commit(FEED_MUTATION_TYPES.UPDATE_FEED, { id: feedId, folderId })
+			if (!response) {
+				console.error('error moving feed %d', feedId)
+			}
 		} catch (e) {
 			// TODO: show error to user if failure
-			console.log(e)
+			console.error(e)
 		}
 	},
 


### PR DESCRIPTION
Resolves: #2847 

## Summary

These filters are redundant to the unread and starred route, but they only filter already loaded items and didn't will work as expected, because they could initially hide items or prevent the scroll from loading additional items from the backend, depending the user settings.
For an app that has only a small part of all items loaded, this type of filter cannot work.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
