### PR TITLE
feat: Add OPML Import API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 - If title of feed is empty during creation set hostname of feed as title (#2872)
 - Add command to import OPML file
+- Add API to import OPML file or request body
 
 ### Fixed
 - Feed without Title returned by DB causes exception (#2872)

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -56,7 +56,10 @@ return ['routes' => [
 
 // export
 ['name' => 'export#opml', 'url' => '/export/opml', 'verb' => 'GET'],
-['name' => 'export#articles', 'url' => '/export/articles', 'verb' => 'GET'],
+['name' => 'item#share', 'url' => '/items/{itemId}/share/{shareRecipientId}', 'verb' => 'POST'],
+
+// import
+['name' => 'import#opml', 'url' => '/import/opml', 'verb' => 'POST'],
 
 // general API
 ['name' => 'api#index', 'url' => '/api', 'verb' => 'GET'],

--- a/lib/Controller/ImportController.php
+++ b/lib/Controller/ImportController.php
@@ -41,12 +41,13 @@ class ImportController extends Controller
     public function opml(): void
     {
         $data = '';
-        if ($this->request->files->has('file')) {
-            $file = $this->request->files->get('file');
-            $data = $file->getContent();
+        if (isset($this->request->files['file'])) {
+            $file = $this->request->files['file'];
+            $data = file_get_contents($file['tmp_name']);
         } else {
             $data = $this->request->getContent();
         }
+
 
         $this->opmlService->import($this->getUserId(), $data);
     }

--- a/lib/Controller/ImportController.php
+++ b/lib/Controller/ImportController.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Nextcloud - News
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author    Alessandro Cosentino <cosenal@gmail.com>
+ * @author    Bernhard Posselt <dev@bernhard-posselt.com>
+ * @copyright 2012 Alessandro Cosentino
+ * @copyright 2012-2014 Bernhard Posselt
+ */
+
+namespace OCA\News\Controller;
+
+use OCA\News\Service\OpmlService;
+use \OCP\IRequest;
+use OCP\IUserSession;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+
+/**
+ * Class ExportController
+ *
+ * @package OCA\News\Controller
+ */
+class ImportController extends Controller
+{
+
+    public function __construct(
+        IRequest $request,
+        ?IUserSession $userSession,
+        private OpmlService $opmlService
+    ) {
+        parent::__construct($request, $userSession);
+    }
+
+
+    #[NoCSRFRequired]
+    #[NoAdminRequired]
+    public function opml(): void
+    {
+        $data = '';
+        if ($this->request->files->has('file')) {
+            $file = $this->request->files->get('file');
+            $data = $file->getContent();
+        } else {
+            $data = $this->request->getContent();
+        }
+
+        $this->opmlService->import($this->getUserId(), $data);
+    }
+}


### PR DESCRIPTION
* References: #2541, #2874

## Summary

This adds an API that will take an OPML file as either a File upload with the name `file`, or as a request body.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
