### PR TITLE
never tag a release as nightly in the appstore

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -68,7 +68,7 @@ jobs:
           appstore_token: ${{ secrets.APPSTORE_TOKEN }}
           download_url: ${{ steps.attach_to_release.outputs.browser_download_url }}
           app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          nightly: ${{ github.event.release.prerelease }}
+          nightly: false          
 
       - name: Delete crt and key from local storage
         run: rm -f ~/.nextcloud/certificates/*


### PR DESCRIPTION
## Summary
As mentioned by the docs nightly releases are meant for automated (nightly) builds, which we do not have, therefore changing the setting to false.

Also I want to change the format of the version for pre-releases by adding a dot.

25.0.0-alpha14 would become 25.0.0-alpha.14 both are valid semver versions but it seems like many nextcloud apps use the later format so I would like to adjust to that.

Fingers crossed that the appstore will actually understand that those are pre-releases.

https://docs.nextcloud.com/server/latest/developer_manual/app_publishing_maintenance/release_process.html#pre-releases

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
