### PR TITLE
Set of fixes for 25.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - add shortcut 'shift + a' to mark all articles in current feed/folder read
 
 ### Fixed
-- shortkey 'r' not working in unread view when "Show all articles" is enabled
+- shortcut 'r' not working in unread view when "Show all articles" is enabled
 
 # Releases
 ## [25.0.0] - 2024-11-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [25.x.x]
 ### Changed
+- always show `All articles` route entry
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ## [25.x.x]
 ### Changed
 - always show `All articles` route entry
+- remove confirmation dialog when mark read folders/feeds
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 - always show `All articles` route entry
 - remove confirmation dialog when mark read folders/feeds
+- add shortcut 'shift + a' to mark all articles in current feed/folder read
 
 ### Fixed
 - shortkey 'r' not working in unread view when "Show all articles" is enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - remove confirmation dialog when mark read folders/feeds
 
 ### Fixed
+- shortkey 'r' not working in unread view when "Show all articles" is enabled
 
 # Releases
 ## [25.0.0] - 2024-11-19

--- a/src/components/AddFeed.vue
+++ b/src/components/AddFeed.vue
@@ -87,7 +87,12 @@
 						type="primary"
 						:disabled="disableAddFeed"
 						@click="addFeed()">
-						{{ t("news", "Subscribe") }}
+						<div v-if="addingFeed">
+							<NcLoadingIcon name="Adding feed" />
+						</div>
+						<div v-else>
+							{{ t("news", "Subscribe") }}
+						</div>
 					</NcButton>
 				</fieldset>
 			</form>
@@ -103,6 +108,7 @@ import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
+import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 
 import { Folder } from '../types/Folder'
 import { ACTIONS } from '../store'
@@ -126,6 +132,7 @@ export default Vue.extend({
 		NcCheckboxRadioSwitch,
 		NcButton,
 		NcSelect,
+		NcLoadingIcon,
 	},
 	props: {
 		feed: {
@@ -142,6 +149,7 @@ export default Vue.extend({
 			newFolderName: '',
 
 			autoDiscover: true,
+			addingFeed: false,
 			createNewFolder: false,
 			withBasicAuth: false,
 
@@ -157,6 +165,7 @@ export default Vue.extend({
 		disableAddFeed(): boolean {
 			return (this.feedUrl === ''
 						|| this.feedUrlExists()
+						|| this.addingFeed
 						|| (this.createNewFolder && (this.newFolderName === '' || this.folderNameExists())))
 		},
 	},
@@ -172,6 +181,7 @@ export default Vue.extend({
 		 * Adds a New Feed via the Vuex Store
 		 */
 		async addFeed() {
+			this.addingFeed = true
 			await this.$store.dispatch(ACTIONS.ADD_FEED, {
 				feedReq: {
 					url: this.feedUrl,
@@ -183,6 +193,7 @@ export default Vue.extend({
 			})
 			this.$store.dispatch(ACTIONS.FETCH_FEEDS)
 
+			this.addingFeed = false
 			this.$emit('close')
 		},
 		/**

--- a/src/components/ContentTemplate.vue
+++ b/src/components/ContentTemplate.vue
@@ -117,18 +117,4 @@ function showItem(value) {
 	height: 100%;
 	overflow-y: scroll;
 }
-
-/*
- * can be removed when fixed in nextcloud-vue library
- * https://github.com/nextcloud-libraries/nextcloud-vue/pull/6227
- */
->>> .splitpanes.default-theme.splitpanes--horizontal .splitpanes__splitter {
-	background-color: var(--color-main-background) !important;
-	border-top: 1px solid var(--color-border) !important;
-}
-
->>> .splitpanes.default-theme.splitpanes--horizontal .splitpanes__splitter::before,
->>> .splitpanes.default-theme.splitpanes--horizontal .splitpanes__splitter::after {
-	background-color: var(--color-border) !important;
-}
 </style>

--- a/src/components/ContentTemplate.vue
+++ b/src/components/ContentTemplate.vue
@@ -8,6 +8,7 @@
 				<FeedItemDisplayList :items="items"
 					:fetch-key="fetchKey"
 					@show-details="showItem(true)"
+					@mark-read="emit('mark-read')"
 					@load-more="emit('load-more')">
 					<template #header>
 						<slot name="header" />

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -112,7 +112,10 @@
 					</template>
 					<template #actions>
 						<SidebarFeedLinkActions v-if="topLevelItem.name === undefined && !topLevelItem.url.includes('news/sharedwithme')" :feed-id="topLevelItem.id" />
-						<NcActionButton v-if="topLevelItem.name !== undefined" icon="icon-checkmark" @click="markFolderRead(topLevelItem)">
+						<NcActionButton v-if="topLevelItem.name !== undefined"
+							icon="icon-checkmark"
+							:close-after-click="true"
+							@click="markFolderRead(topLevelItem)">
 							{{ t("news", "Mark read") }}
 						</NcActionButton>
 						<NcActionButton v-if="topLevelItem.name !== undefined" icon="icon-rename" @click="renameFolder(topLevelItem)">
@@ -518,25 +521,17 @@ export default Vue.extend({
 			}
 		},
 		markAllRead() {
-			const shouldMarkRead = window.confirm(t('news', 'Are you sure you want to mark all read?'))
-
-			if (shouldMarkRead) {
-				this.$store.getters.feeds.forEach((feed: Feed) => {
-					this.$store.dispatch(ACTIONS.FEED_MARK_READ, { feed })
-				})
-			}
+			this.$store.getters.feeds.forEach((feed: Feed) => {
+				this.$store.dispatch(ACTIONS.FEED_MARK_READ, { feed })
+			})
 		},
 		markFolderRead(folder: Folder) {
-			const shouldMarkRead = window.confirm(t('news', 'Are you sure you want to mark all read?'))
-
-			if (shouldMarkRead) {
-				const feeds = this.$store.getters.feeds.filter((feed: Feed) => {
-					return feed.folderId === folder.id
-				})
-				feeds.forEach((feed: Feed) => {
-					this.$store.dispatch(ACTIONS.FEED_MARK_READ, { feed })
-				})
-			}
+			const feeds = this.$store.getters.feeds.filter((feed: Feed) => {
+				return feed.folderId === folder.id
+			})
+			feeds.forEach((feed: Feed) => {
+				this.$store.dispatch(ACTIONS.FEED_MARK_READ, { feed })
+			})
 		},
 		renameFolder(folder: Folder) {
 			const name = window.prompt(t('news', 'Rename Folder'), folder.name)

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -34,8 +34,7 @@
 					</NcCounterBubble>
 				</template>
 			</NcAppNavigationItem>
-			<NcAppNavigationItem v-show="showAll"
-				:name="t('news', 'All articles')"
+			<NcAppNavigationItem :name="t('news', 'All articles')"
 				icon="icon-rss"
 				:to="{ name: ROUTES.ALL }">
 				<template #icon>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -510,8 +510,12 @@ export default Vue.extend({
 		},
 		newFolder(value: string) {
 			const folderName = value.trim()
-			const folder = { name: folderName }
-			this.$store.dispatch(ACTIONS.ADD_FOLDERS, { folder })
+			if (this.$store.getters.folders.some(f => f.name === folderName)) {
+				showError(t('news', 'Folder exists already!'))
+			} else {
+				const folder = { name: folderName }
+				this.$store.dispatch(ACTIONS.ADD_FOLDERS, { folder })
+			}
 		},
 		markAllRead() {
 			const shouldMarkRead = window.confirm(t('news', 'Are you sure you want to mark all read?'))

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -580,7 +580,7 @@ export default Vue.extend({
 			if (this.isFolder(item)) {
 				return item.feedCount > 0 || this.isActiveFolder(item) || this.hasActiveFeeds(item) || item.updateErrorCount > 0
 			} else {
-				return item.pinned || item.unreadCount > 0 || item.updateErrorCount > 0 || this.isActiveFeed(item)
+				return item.unreadCount > 0 || item.updateErrorCount > 0 || this.isActiveFeed(item)
 			}
 		},
 		sortedFolderFeeds(item: Feed | Folder) {

--- a/src/components/SidebarFeedLinkActions.vue
+++ b/src/components/SidebarFeedLinkActions.vue
@@ -2,6 +2,7 @@
 	<span>
 		<NcActionButton v-if="feed.unreadCount > 0"
 			icon="icon-checkmark"
+			:close-after-click="true"
 			@click="markRead">
 			{{ t("news", "Mark read") }}
 		</NcActionButton>

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -224,7 +224,10 @@ export default Vue.extend({
 
 			// if we're filtering on unread, we want to cache the unread items when the user presses the filter button
 			// that way when the user opens an item, it won't be removed from the displayed list of items (once it's no longer unread)
-			if (this.fetchKey !== 'starred' && this.fetchKey !== 'all' && !this.$store.getters.showAll) {
+			if (this.fetchKey === 'unread'
+				|| (!this.$store.getters.showAll
+					&& this.fetchKey !== 'starred'
+					&& this.fetchKey !== 'all')) {
 				if (!this.cache) {
 					if (this.items.length > 0) {
 						this.cache = this.items.filter(this.unreadFilter)

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -224,7 +224,7 @@ export default Vue.extend({
 
 			// if we're filtering on unread, we want to cache the unread items when the user presses the filter button
 			// that way when the user opens an item, it won't be removed from the displayed list of items (once it's no longer unread)
-			if (this.fetchKey !== 'starred' && !this.$store.getters.showAll) {
+			if (this.fetchKey !== 'starred' && this.fetchKey !== 'all' && !this.$store.getters.showAll) {
 				if (!this.cache) {
 					if (this.items.length > 0) {
 						this.cache = this.items.filter(this.unreadFilter)

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -26,6 +26,9 @@
 			<button v-shortkey="['r']" class="hidden" @shortkey="refreshFeedList">
 				Refresh
 			</button>
+			<button v-shortkey="['shift','a']" class="hidden" @shortkey="$emit('mark-read')">
+				markRead
+			</button>
 		</div>
 		<div class="feed-item-display-container">
 			<VirtualScroll ref="virtualScroll"

--- a/src/components/routes/Feed.vue
+++ b/src/components/routes/Feed.vue
@@ -2,6 +2,7 @@
 	<ContentTemplate v-if="!loading"
 		:items="items"
 		:fetch-key="'feed-' + feedId"
+		@mark-read="markRead()"
 		@load-more="fetchMore()">
 		<template #header>
 			{{ feed ? feed.title : '' }}
@@ -63,6 +64,9 @@ export default Vue.extend({
 			if (!this.loading && !this.$store.state.items.fetchingItems['feed-' + this.feedId]) {
 			  this.$store.dispatch(ACTIONS.FETCH_FEED_ITEMS, { feedId: this.id })
 			}
+		},
+		async markRead() {
+			this.$store.dispatch(ACTIONS.FEED_MARK_READ, { feed: this.feed })
 		},
 	},
 })

--- a/src/components/routes/Folder.vue
+++ b/src/components/routes/Folder.vue
@@ -1,6 +1,7 @@
 <template>
 	<ContentTemplate :items="items"
 		:fetch-key="'folder-' + folderId"
+		@mark-read="markRead()"
 		@load-more="fetchMore()">
 		<template #header>
 			{{ folder ? folder.name : '' }}
@@ -68,6 +69,14 @@ export default Vue.extend({
 			if (!this.$store.state.items.fetchingItems['folder-' + this.folderId]) {
 			  this.$store.dispatch(ACTIONS.FETCH_FOLDER_FEED_ITEMS, { folderId: this.id })
 			}
+		},
+		async markRead() {
+			const feeds = this.$store.getters.feeds.filter((feed: Feed) => {
+				return feed.folderId === this.folder.id
+			})
+			feeds.forEach((feed: Feed) => {
+				this.$store.dispatch(ACTIONS.FEED_MARK_READ, { feed })
+			})
 		},
 	},
 })

--- a/src/dataservices/item.service.ts
+++ b/src/dataservices/item.service.ts
@@ -36,7 +36,7 @@ export class ItemService {
 				limit: 40,
 				oldestFirst: store.state.oldestFirst,
 				search: '',
-				showAll: store.state.showAll,
+				showAll: true,
 				type: ITEM_TYPES.ALL,
 				offset: start,
 			},

--- a/tests/javascript/unit/components/Sidebar.spec.ts
+++ b/tests/javascript/unit/components/Sidebar.spec.ts
@@ -100,13 +100,11 @@ describe('Sidebar.vue', () => {
 		})
 
 		it('should call mark feed read for all feeds in state', () => {
-			window.confirm = jest.fn().mockReturnValue(true);
 			(wrapper.vm as any).markAllRead()
 			expect((wrapper.vm as any).$store.dispatch).toHaveBeenCalledTimes(2)
 		})
 
 		it('should call mark feed read for all feeds in state with matching folderId', () => {
-			window.confirm = jest.fn().mockReturnValue(true);
 			(wrapper.vm as any).markFolderRead({ id: 123 })
 			expect((wrapper.vm as any).$store.dispatch).toHaveBeenCalledTimes(1)
 		})

--- a/tests/javascript/unit/components/Sidebar.spec.ts
+++ b/tests/javascript/unit/components/Sidebar.spec.ts
@@ -20,6 +20,11 @@ describe('Sidebar.vue', () => {
 		feeds: [{ id: 1, title: 'first', folderId: 123 }]
 	}
 
+	const folders = [{
+		id: 456,
+		name: 'def',
+	}]
+
 	beforeAll(() => {
 		const localVue = createLocalVue()
 		wrapper = shallowMount(AppSidebar, {
@@ -37,6 +42,7 @@ describe('Sidebar.vue', () => {
 					},
 					getters: {
 						feeds,
+						folders,
 						showAll: () => { return true },
 					},
 					dispatch: jest.fn(),
@@ -58,6 +64,12 @@ describe('Sidebar.vue', () => {
 			(wrapper.vm as any).newFolder('abc')
 
 			expect((wrapper.vm as any).$store.dispatch).toHaveBeenCalledWith(ACTIONS.ADD_FOLDERS, { folder: { name: 'abc' } })
+		})
+
+		it('should not dispatch message to store with folder name to create new folder with existing name', () => {
+			(wrapper.vm as any).newFolder('def')
+
+			expect((wrapper.vm as any).$store.dispatch).not.toHaveBeenCalled()
 		})
 
 		it('should dispatch message to store with folder object on delete folder', () => {

--- a/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
@@ -17,6 +17,7 @@ describe('FeedItemDisplayList.vue', () => {
 		feedId: 1,
 		title: 'feed item',
 		pubDate: Date.now() / 1000,
+		unread: true,
 	}
 
 	let store: Store<any>


### PR DESCRIPTION
* Resolves: #2903
* Resolves: #2900 
* Resolves: #2895 

## Summary

This PR also fixes:

* don't add folder when already exist
* disable subscribe button and show loading icon during adding feed process
* don't show pinned feeds with no unread items when "Show all articles" is disabled
* add missing shortcut 'shift + a' to mark all articles in current feed/folder read

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
