### PR TITLE
Release 25.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 
 ### Fixed
+
+# Releases
+## [25.0.2] - 2024-11-25
+### Fixed
 - add h1 header to title in feed item row for better accessibility (#2921)
 - Downgrade htmlpurifier to 4.17.0 to fix log flooding (#2924)
 
-# Releases
 ## [25.0.1] - 2024-11-24
 ### Changed
 - always show `All articles` route entry (#2913)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>25.0.1</version>
+    <version>25.0.2</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
## Summary

Fixed
- add h1 header to title in feed item row for better accessibility (#2921)
- Downgrade htmlpurifier to 4.17.0 to fix log flooding (#2924)


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
