### PR TITLE
Change items list style in compact mode to improve readability (and better match v24's style)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [25.x.x]
 ### Changed
+- Items list style in compact mode to improve readability (and better match v24's style) (#2918)
 
 ### Fixed
 

--- a/src/components/feed-display/FeedItemRow.vue
+++ b/src/components/feed-display/FeedItemRow.vue
@@ -170,7 +170,11 @@ export default Vue.extend({
 	}
 
 	.feed-item-row.compact {
-		display: flex; padding: 1px 1px !important;
+		display: flex; padding: 4px 4px !important;
+		border-bottom: 1px solid var(--color-border);
+	}
+	.feed-item-row.compact a.external {
+		line-height: 0;
 	}
 
 	.feed-item-row:hover {

--- a/src/components/feed-display/VirtualScroll.vue
+++ b/src/components/feed-display/VirtualScroll.vue
@@ -117,7 +117,7 @@ export default Vue.extend({
 		let renderedItems = 0
 		let upperPaddingItems = 0
 		let lowerPaddingItems = 0
-		const itemHeight = this.compactMode ? 37 : 111
+		const itemHeight = this.compactMode ? 44 : 111
 		const padding = GRID_ITEM_HEIGHT
 		if (this.$slots.default && this.$el && this.$el.getBoundingClientRect) {
 			const childComponents = this.$slots.default.filter(child => !!child.componentOptions)


### PR DESCRIPTION
* Resolves: #2918

## Summary

The recent v25 update looks quite OK, but there are minor differences in the compact mode, compared to v24, that IMHO should be added to v25:
1) Increase padding for rows.
2) Add a small border between the rows.
3) Center favicon vertically.

Before:
![news-light-old](https://github.com/user-attachments/assets/2309c066-90bb-48db-a37d-805ff91477aa)
![news-light-new](https://github.com/user-attachments/assets/967cbd01-e189-4166-b26f-32e2aaae502a)
After:
![news-dark-old](https://github.com/user-attachments/assets/103d5adc-6931-47d4-bc7c-33985f67d666)
![news-dark-new](https://github.com/user-attachments/assets/92fd7dc9-a8c8-4495-a670-9c89d469e6d6)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.

