### PR TITLE
[Actions] Frontend tests do not try to install firefox

### DIFF
--- a/.github/workflows/frontend-nodejs-tests.yml
+++ b/.github/workflows/frontend-nodejs-tests.yml
@@ -41,7 +41,8 @@ jobs:
           app: 'news'
           check-code: false
 
-      - name: Install frontend requirements
-        run: sudo apt update && sudo apt install firefox
+      - name: Firefox version
+        run: firefox -v
+
       - name: Run frontend tests
         run: cd ../server/apps/news && make js-test


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

While the frontend tests were running I checked the logs and was a bit surprised that `apt install firefox` caused a install of the snap version over the already installed firefox image. I guess that is what ubuntu is today... well. And setting up snap and installing it over the existing install of course takes for ever.

Therefore removing the install step that I added 4 years ago. December 5 Github will start switching the ubuntu-latest label to ubuntu 24.04 will see if that breaks something.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
