### PR TITLE
Display modes and screen reader mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 - add region role to content list and details so that it can be used by screen readers
 - split display settings in "display mode" and "split mode" to allow combining modes
+- add display mode optimized for screen readers
 
 ### Fixed
 - use appropriate semantic HTML elements for the item list to be recognised by screen readers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ## [25.x.x]
 ### Changed
 - add region role to content list and details so that it can be used by screen readers
+- split display settings in "display mode" and "split mode" to allow combining modes
 
 ### Fixed
 - use appropriate semantic HTML elements for the item list to be recognised by screen readers

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -115,9 +115,7 @@ class PageController extends Controller
         $settings = [
             'showAll',
             'preventReadOnScroll',
-            'oldestFirst',
-            'displaymode',
-            'splitmode'
+            'oldestFirst'
         ];
 
         $exploreUrl = $this->settings->getValueString(
@@ -164,16 +162,12 @@ class PageController extends Controller
         bool $preventReadOnScroll,
         bool $oldestFirst,
         bool $disableRefresh,
-        int  $displaymode,
-        int  $splitmode
     ): void {
         $settings = [
             'showAll'             => $showAll,
             'preventReadOnScroll' => $preventReadOnScroll,
             'oldestFirst'         => $oldestFirst,
-            'disableRefresh'      => $disableRefresh,
-            'displaymode'         => $displaymode,
-            'splitmode'           => $splitmode,
+            'disableRefresh'      => $disableRefresh
         ];
 
         foreach ($settings as $setting => $value) {

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -75,14 +75,14 @@ class PageController extends Controller
         );
 
         $usersettings = [
-            'compact',
-            'compactExpand',
             'preventReadOnScroll',
             'oldestFirst',
             'showAll',
             'lastViewedFeedId',
             'lastViewedFeedType',
-            'disableRefresh'
+            'disableRefresh',
+            'displaymode',
+            'splitmode'
         ];
 
         foreach ($usersettings as $setting) {
@@ -114,10 +114,10 @@ class PageController extends Controller
     {
         $settings = [
             'showAll',
-            'compact',
             'preventReadOnScroll',
             'oldestFirst',
-            'compactExpand'
+            'displaymode',
+            'splitmode'
         ];
 
         $exploreUrl = $this->settings->getValueString(
@@ -152,28 +152,28 @@ class PageController extends Controller
 
     /**
      * @param bool $showAll
-     * @param bool $compact
      * @param bool $preventReadOnScroll
      * @param bool $oldestFirst
-     * @param bool $compactExpand
      * @param bool $disableRefresh
+     * @param int  $displaymode
+     * @param int  $splitmode
      */
     #[NoAdminRequired]
     public function updateSettings(
         bool $showAll,
-        bool $compact,
         bool $preventReadOnScroll,
         bool $oldestFirst,
-        bool $compactExpand,
-        bool $disableRefresh
+        bool $disableRefresh,
+        int  $displaymode,
+        int  $splitmode
     ): void {
         $settings = [
             'showAll'             => $showAll,
-            'compact'             => $compact,
             'preventReadOnScroll' => $preventReadOnScroll,
             'oldestFirst'         => $oldestFirst,
-            'compactExpand'       => $compactExpand,
             'disableRefresh'      => $disableRefresh,
+            'displaymode'         => $displaymode,
+            'splitmode'           => $splitmode,
         ];
 
         foreach ($settings as $setting => $value) {

--- a/src/components/ContentTemplate.vue
+++ b/src/components/ContentTemplate.vue
@@ -81,9 +81,13 @@ const showDetails = ref(false)
 const contentElement = ref()
 
 const layout = computed(() => {
-	if (appStore.getters.compact(appStore.state)) {
-		return appStore.getters.compactExpand(appStore.state) ? 'horizontal-split' : 'no-split'
-	} else {
+	switch (appStore.getters.splitmode(appStore.state)) {
+	case '1':
+		return 'horizontal-split'
+	case '2':
+		return 'no-split'
+	case '0':
+	default:
 		return 'vertical-split'
 	}
 })

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -176,6 +176,7 @@
 						</label>
 						<select id="select-splitmode"
 							v-model="splitmode"
+							:disabled="displaymode === '2'"
 							:value="splitmode">
 							<option v-for="splitMode in splitModeOptions"
 								:key="splitMode.id"
@@ -326,6 +327,10 @@ export default Vue.extend({
 				{
 					id: '1',
 					name: t('news', 'Compact'),
+				},
+				{
+					id: '2',
+					name: t('news', 'Screenreader'),
 				},
 			],
 			splitModeOptions: [

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -156,6 +156,34 @@
 				</NcButton>
 				<HelpModal v-if="showHelp" @close="showHelp=false" />
 				<div>
+					<div class="select-container">
+						<label>
+							{{ t('news', 'Display mode') }}
+						</label>
+						<select id="select-displaymode"
+							v-model="displaymode"
+							:value="displaymode">
+							<option v-for="displayMode in displayModeOptions"
+								:key="displayMode.id"
+								:value="displayMode.id">
+								{{ displayMode.name }}
+							</option>
+						</select>
+					</div>
+					<div class="select-container">
+						<label>
+							{{ t('news', 'Split mode') }}
+						</label>
+						<select id="select-splitmode"
+							v-model="splitmode"
+							:value="splitmode">
+							<option v-for="splitMode in splitModeOptions"
+								:key="splitMode.id"
+								:value="splitMode.id">
+								{{ splitMode.name }}
+							</option>
+						</select>
+					</div>
 					<div>
 						<input id="toggle-preventreadonscroll"
 							v-model="preventReadOnScroll"
@@ -163,24 +191,6 @@
 							class="checkbox">
 						<label for="toggle-preventreadonscroll">
 							{{ t('news', 'Disable mark read through scrolling') }}
-						</label>
-					</div>
-					<div>
-						<input id="toggle-compact"
-							v-model="compact"
-							type="checkbox"
-							class="checkbox">
-						<label for="toggle-compact">
-							{{ t('news', 'Compact view') }}
-						</label>
-					</div>
-					<div v-if="compact">
-						<input id="toggle-compact-expand"
-							v-model="compactExpand"
-							type="checkbox"
-							class="checkbox">
-						<label for="toggle-compact-expand">
-							{{ t('news', 'Expanded compact view') }}
 						</label>
 					</div>
 					<div>
@@ -308,6 +318,30 @@ export default Vue.extend({
 			polling: null,
 			uploadStatus: null,
 			selectedFile: null,
+			displayModeOptions: [
+				{
+					id: '0',
+					name: t('news', 'Default'),
+				},
+				{
+					id: '1',
+					name: t('news', 'Compact'),
+				},
+			],
+			splitModeOptions: [
+				{
+					id: '0',
+					name: t('news', 'Vertical'),
+				},
+				{
+					id: '1',
+					name: t('news', 'Horizontal'),
+				},
+				{
+					id: '2',
+					name: t('news', 'Off'),
+				},
+			],
 		}
 	},
 	computed: {
@@ -336,20 +370,20 @@ export default Vue.extend({
 				return this.$store.getters.loading
 			},
 		},
-		compact: {
+		displaymode: {
 			get() {
-				return this.$store.getters.compact
+				return this.$store.getters.displaymode
 			},
 			set(newValue) {
-				this.saveSetting('compact', newValue)
+				this.saveSetting('displaymode', newValue)
 			},
 		},
-		compactExpand: {
+		splitmode: {
 			get() {
-				return this.$store.getters.compactExpand
+				return this.$store.getters.splitmode
 			},
 			set(newValue) {
-				this.saveSetting('compactExpand', newValue)
+				this.saveSetting('splitmode', newValue)
 			},
 		},
 		oldestFirst: {
@@ -443,7 +477,9 @@ export default Vue.extend({
 					key,
 				},
 			)
-			value = value ? '1' : '0'
+			if (typeof value === 'boolean') {
+				value = value ? '1' : '0'
+			}
 			try {
 				const { data } = await axios.post(url, {
 					configValue: value,
@@ -659,6 +695,18 @@ export default Vue.extend({
 .button-container button {
   flex: 1;
 }
+
+.select-container {
+  display: flex;
+  align-items: center;
+}
+
+.select-container select {
+  min-width: 140px;
+  text-overflow: ellipsis;
+  margin-left: auto;
+}
+
 .new-folder-container {
 	padding: calc(var(--default-grid-baseline, 4px)* 2);
 }

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -25,20 +25,20 @@
 				@click="toggleRead(item)" />
 			<CloseIcon :title="t('news', 'Close details')"
 				tabindex="0"
-				@click="compactMode ? $emit('show-details') : clearSelected()" />
-			<button v-if="compactMode"
+				@click="splitModeOff ? $emit('show-details') : clearSelected()" />
+			<button v-if="splitModeOff"
 				v-shortkey="{s: ['s'], l: ['l'], i: ['i']}"
 				class="hidden"
 				@shortkey="toggleStarred(item)">
 				toggleStarred
 			</button>
-			<button v-if="compactMode"
+			<button v-if="splitModeOff"
 				v-shortkey="['u']"
 				class="hidden"
 				@shortkey="toggleRead(item)">
 				toggleRead
 			</button>
-			<button v-if="compactMode"
+			<button v-if="splitModeOff"
 				v-shortkey="['esc']"
 				class="hidden"
 				@shortkey="$emit('show-details')">
@@ -169,8 +169,8 @@ export default Vue.extend({
 	},
 	computed: {
 		...mapState(['feeds']),
-		compactMode() {
-			return (this.$store.getters.compact && !this.$store.getters.compactExpand)
+		splitModeOff() {
+			return this.$store.getters.splitmode === '2'
 		},
 	},
 	methods: {

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -1,5 +1,8 @@
 <template>
-	<div class="feed-item-display">
+	<article class="feed-item-display"
+		:class="{ 'screenreader': screenReaderMode }"
+		:aria-setsize="itemCount"
+		:aria-posinset="itemIndex">
 		<ShareItem v-if="showShareMenu" :item-id="item.id" @close="closeShareMenu()" />
 
 		<div class="action-bar">
@@ -38,7 +41,7 @@
 				@shortkey="toggleRead(item)">
 				toggleRead
 			</button>
-			<button v-if="splitModeOff"
+			<button v-if="splitModeOff && !screenReaderMode"
 				v-shortkey="['esc']"
 				class="hidden"
 				@shortkey="$emit('show-details')">
@@ -121,7 +124,7 @@
 			<div class="body" :dir="item.rtl && 'rtl'" v-html="item.body" />
 			<!--eslint-enable-->
 		</div>
-	</div>
+	</article>
 </template>
 
 <script lang="ts">
@@ -160,6 +163,16 @@ export default Vue.extend({
 			type: Object,
 			required: true,
 		},
+		itemCount: {
+			type: Number,
+			required: false,
+			default: null,
+		},
+		itemIndex: {
+			type: Number,
+			required: false,
+			default: null,
+		},
 	},
 	data: () => {
 		return {
@@ -169,6 +182,9 @@ export default Vue.extend({
 	},
 	computed: {
 		...mapState(['feeds']),
+		screenReaderMode() {
+			return this.$store.getters.displaymode === '2'
+		},
 		splitModeOff() {
 			return this.$store.getters.splitmode === '2'
 		},
@@ -248,6 +264,10 @@ export default Vue.extend({
 		overflow-y: hidden;
 		display: flex;
 		flex-direction: column;
+	}
+
+	.feed-item-display.screenreader {
+		height: 111px;
 	}
 
 	.article {

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -29,13 +29,13 @@
 			<button v-shortkey="['shift','a']" class="hidden" @shortkey="$emit('mark-read')">
 				markFeedRead
 			</button>
-			<button v-if="compactMode"
+			<button v-if="splitModeOff"
 				v-shortkey="['e']"
 				class="hidden"
 				@shortkey="selectedItem && $emit('show-details')">
 				showDetails
 			</button>
-			<button v-if="compactMode"
+			<button v-if="splitModeOff"
 				v-shortkey="['enter']"
 				class="hidden"
 				@shortkey="selectedItem && $emit('show-details')">
@@ -144,8 +144,8 @@ export default Vue.extend({
 		isLoading() {
 			return this.$store.getters.loading
 		},
-		compactMode() {
-			return (this.$store.getters.compact && !this.$store.getters.compactExpand)
+		splitModeOff() {
+			return this.$store.getters.splitmode === '2'
 		},
 	},
 	watch: {

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -29,13 +29,13 @@
 			<button v-shortkey="['shift','a']" class="hidden" @shortkey="$emit('mark-read')">
 				markFeedRead
 			</button>
-			<button v-if="splitModeOff"
+			<button v-if="splitModeOff && !screenReaderMode"
 				v-shortkey="['e']"
 				class="hidden"
 				@shortkey="selectedItem && $emit('show-details')">
 				showDetails
 			</button>
-			<button v-if="splitModeOff"
+			<button v-if="splitModeOff && !screenReaderMode"
 				v-shortkey="['enter']"
 				class="hidden"
 				@shortkey="selectedItem && $emit('show-details')">
@@ -57,7 +57,16 @@
 				@load-more="fetchMore()">
 				<template v-if="items && items.length > 0">
 					<template v-for="(item, index) in filteredItemcache">
-						<FeedItemRow :key="item.id"
+						<FeedItemDisplay v-if="screenReaderMode"
+							:key="item.id"
+							:ref="'feedItemRow' + item.id"
+							:item-count="filteredItemcache.length"
+							:item-index="index + 1"
+							:item="item"
+							:class="{ 'active': selectedItem && selectedItem.id === item.id }"
+							@show-details="$emit('show-details')" />
+						<FeedItemRow v-else
+							:key="item.id"
 							:ref="'feedItemRow' + item.id"
 							:item-count="filteredItemcache.length"
 							:item-index="index + 1"
@@ -76,6 +85,7 @@ import Vue from 'vue'
 import _ from 'lodash'
 
 import VirtualScroll from './VirtualScroll.vue'
+import FeedItemDisplay from './FeedItemDisplay.vue'
 import FeedItemRow from './FeedItemRow.vue'
 
 import { FeedItem } from '../../types/FeedItem'
@@ -85,6 +95,7 @@ import { ACTIONS, MUTATIONS } from '../../store'
 export default Vue.extend({
 	components: {
 		VirtualScroll,
+		FeedItemDisplay,
 		FeedItemRow,
 	},
 	props: {
@@ -143,6 +154,9 @@ export default Vue.extend({
 		},
 		isLoading() {
 			return this.$store.getters.loading
+		},
+		screenReaderMode() {
+			return this.$store.getters.displaymode === '2'
 		},
 		splitModeOff() {
 			return this.$store.getters.splitmode === '2'

--- a/src/components/feed-display/FeedItemRow.vue
+++ b/src/components/feed-display/FeedItemRow.vue
@@ -22,15 +22,15 @@
 		</div>
 
 		<div class="main-container" :class="{ 'compact': compactMode }">
-			<div class="title-container" :class="{ 'compact': compactMode && !verticalSplit, 'unread': item.unread }">
-				<h1 :dir="item.rtl && 'rtl'">
-					<a href="#"
-						:title="t('news', 'Open article')"
-						@click="select()">
-						{{ item.title }}
-					</a>
-				</h1>
-			</div>
+			<h1 class="title-container"
+				:class="{ 'compact': compactMode && !verticalSplit, 'unread': item.unread }"
+				:dir="item.rtl && 'rtl'">
+				<a href="#"
+					:title="t('news', 'Open article')"
+					@click="select()">
+					{{ item.title }}
+				</a>
+			</h1>
 
 			<div v-if="!compactMode || !verticalSplit" class="intro-container" :class="{ 'compact': compactMode }">
 				<!-- eslint-disable vue/no-v-html -->
@@ -245,15 +245,17 @@ export default Vue.extend({
 	}
 
 	.feed-item-row .title-container {
-		color: var(--color-text-lighter);
-
 		flex-grow: 1;
 		overflow: hidden;
 		white-space: nowrap;
 		text-overflow: ellipsis;
 	}
 
-	.feed-item-row .title-container.unread {
+	.feed-item-row .title-container a {
+		color: var(--color-text-lighter);
+	}
+
+	.feed-item-row .title-container.unread a {
 		color: var(--color-main-text);
 		font-weight: bold;
 	}

--- a/src/components/feed-display/FeedItemRow.vue
+++ b/src/components/feed-display/FeedItemRow.vue
@@ -22,7 +22,7 @@
 		</div>
 
 		<div class="main-container" :class="{ 'compact': compactMode }">
-			<div class="title-container" :class="{ 'compact': compactMode, 'unread': item.unread }">
+			<div class="title-container" :class="{ 'compact': compactMode && !verticalSplit, 'unread': item.unread }">
 				<h1 :dir="item.rtl && 'rtl'">
 					<a href="#"
 						:title="t('news', 'Open article')"
@@ -32,13 +32,13 @@
 				</h1>
 			</div>
 
-			<div class="intro-container" :class="{ 'compact': compactMode }">
+			<div v-if="!compactMode || !verticalSplit" class="intro-container" :class="{ 'compact': compactMode }">
 				<!-- eslint-disable vue/no-v-html -->
 				<span class="intro" v-html="item.intro" />
 				<!--eslint-enable-->
 			</div>
 
-			<div class="date-container" :class="{ 'compact': compactMode }">
+			<div v-if="!compactMode || !verticalSplit" class="date-container" :class="{ 'compact': compactMode }">
 				<time class="date" :title="formatDate(item.pubDate*1000, 'yyyy-MM-dd HH:mm:ss')" :datetime="formatDatetime(item.pubDate*1000, 'yyyy-MM-ddTHH:mm:ssZ')">
 					{{ getRelativeTimestamp(item.pubDate*1000) }}
 				</time>
@@ -131,7 +131,10 @@ export default Vue.extend({
 	computed: {
 		...mapState(['feeds']),
 		compactMode() {
-			return this.$store.getters.compact
+			return this.$store.getters.displaymode === '1'
+		},
+		verticalSplit() {
+			return this.$store.getters.splitmode === '0'
 		},
 	},
 	methods: {

--- a/src/components/feed-display/VirtualScroll.vue
+++ b/src/components/feed-display/VirtualScroll.vue
@@ -173,7 +173,11 @@ export default Vue.extend({
 		},
 		[
 			h('div', { class: 'upper-padding', style: { height: Math.max((upperPaddingItems) * itemHeight, 0) + 'px' } }),
-			h('ul', { class: 'container-window', style: { height: Math.max((renderedItems) * itemHeight, 0) + 'px' } }, children),
+			h('div', {
+				class: 'container-window',
+				style: { height: Math.max((renderedItems) * itemHeight, 0) + 'px' },
+				attrs: { role: 'feed' },
+			}, children),
 			h('div', { class: 'lower-padding', style: { height: Math.max((lowerPaddingItems) * itemHeight, 0) + 'px' } }),
 		])
 	},

--- a/src/components/feed-display/VirtualScroll.vue
+++ b/src/components/feed-display/VirtualScroll.vue
@@ -48,7 +48,7 @@ export default Vue.extend({
 		compactMode: {
 			cache: false,
 			get() {
-				return this.$store.getters.compact
+				return this.$store.getters.displaymode === '1'
 			},
 		},
 	},

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -42,7 +42,8 @@ const getters = {
 		return state.displaymode
 	},
 	splitmode() {
-		return state.splitmode
+		// ignore split mode when screenreader mode is set
+		return state.displaymode === '2' ? '2' : state.splitmode
 	},
 	oldestFirst() {
 		return state.oldestFirst

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -8,8 +8,8 @@ export const APPLICATION_ACTION_TYPES = {
 export type AppInfoState = {
 	error?: Error;
 	loading: boolean;
-	compact: boolean;
-	compactExpand: boolean;
+	displaymode: string;
+	splitmode: string;
 	oldestFirst: boolean;
 	preventReadOnScroll: boolean;
 	showAll: boolean;
@@ -21,8 +21,8 @@ export type AppInfoState = {
 const state: AppInfoState = {
 	error: undefined,
 	loading: true,
-	compact: loadState('news', 'compact', null) === '1',
-	compactExpand: loadState('news', 'compactExpand', null) === '1',
+	displaymode: loadState('news', 'displaymode', '0'),
+	splitmode: loadState('news', 'splitmode', '0'),
 	oldestFirst: loadState('news', 'oldestFirst', null) === '1',
 	preventReadOnScroll: loadState('news', 'preventReadOnScroll', null) === '1',
 	showAll: loadState('news', 'showAll', null) === '1',
@@ -38,11 +38,11 @@ const getters = {
 	loading() {
 		return state.loading
 	},
-	compact() {
-		return state.compact
+	displaymode() {
+		return state.displaymode
 	},
-	compactExpand() {
-		return state.compactExpand
+	splitmode() {
+		return state.splitmode
 	},
 	oldestFirst() {
 		return state.oldestFirst
@@ -83,17 +83,17 @@ export const mutations = {
 	) {
 		state.loading = value
 	},
-	compact(
+	displaymode(
 		state: AppInfoState,
-		{ value }: { value: boolean },
+		{ value }: { value: string },
 	) {
-		state.compact = value
+		state.displaymode = value
 	},
-	compactExpand(
+	splitmode(
 		state: AppInfoState,
-		{ value }: { value: boolean },
+		{ value }: { value: string },
 	) {
-		state.compactExpand = value
+		state.splitmode = value
 	},
 	oldestFirst(
 		state: AppInfoState,

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -193,12 +193,12 @@ class PageControllerTest extends TestCase
         $result = [
             'settings' => [
                 'showAll' => true,
-                'compact' => true,
                 'preventReadOnScroll' => true,
                 'oldestFirst' => true,
-                'compactExpand' => true,
                 'language' => 'de',
-                'exploreUrl' => 'test'
+                'exploreUrl' => 'test',
+                'displaymode' => '0',
+                'splitmode' => '0'
             ]
         ];
 
@@ -210,10 +210,10 @@ class PageControllerTest extends TestCase
                      ->method('getUserValue')
                      ->withConsecutive(
                         ['becka', 'news', 'showAll'],
-                        ['becka', 'news', 'compact'],
                         ['becka', 'news', 'preventReadOnScroll'],
                         ['becka', 'news', 'oldestFirst'],
-                        ['becka', 'news', 'compactExpand']
+                        ['becka', 'news', 'displaymode'],
+                        ['becka', 'news', 'splitmode']
                      )
                      ->will($this->returnValue('1'));
         $this->settings->expects($this->once())
@@ -236,12 +236,12 @@ class PageControllerTest extends TestCase
         $result = [
             'settings' => [
                 'showAll' => true,
-                'compact' => true,
                 'preventReadOnScroll' => true,
                 'oldestFirst' => true,
                 'language' => 'de',
-                'compactExpand' => true,
-                'exploreUrl' => 'abc'
+                'exploreUrl' => 'abc',
+                'displaymode' => '0',
+                'splitmode' => '0'
             ]
         ];
 
@@ -253,10 +253,10 @@ class PageControllerTest extends TestCase
                     ->method('getUserValue')
                     ->withConsecutive(
                         ['becka', 'news', 'showAll'],
-                        ['becka', 'news', 'compact'],
                         ['becka', 'news', 'preventReadOnScroll'],
                         ['becka', 'news', 'oldestFirst'],
-                        ['becka', 'news', 'compactExpand']
+                        ['becka', 'news', 'displaymode'],
+                        ['becka', 'news', 'splitmode']
                     )
                     ->will($this->returnValue('1'));
         $this->settings->expects($this->once())
@@ -280,10 +280,10 @@ class PageControllerTest extends TestCase
                     ->method('setUserValue')
                     ->withConsecutive(
                         ['becka', 'news', 'showAll', '1'],
-                        ['becka', 'news', 'compact', '1'],
                         ['becka', 'news', 'preventReadOnScroll', '0'],
                         ['becka', 'news', 'oldestFirst', '1'],
-                        ['becka', 'news', 'compactExpand', '1'],
+                        ['becka', 'news', 'displaymode', '0'],
+                        ['becka', 'news', 'splitmode', '1'],
                         ['becka', 'news', 'disableRefresh', '0']
                     );
 

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -196,9 +196,7 @@ class PageControllerTest extends TestCase
                 'preventReadOnScroll' => true,
                 'oldestFirst' => true,
                 'language' => 'de',
-                'exploreUrl' => 'test',
-                'displaymode' => '0',
-                'splitmode' => '0'
+                'exploreUrl' => 'test'
             ]
         ];
 
@@ -206,14 +204,12 @@ class PageControllerTest extends TestCase
              ->method('getLanguageCode')
              ->will($this->returnValue('de'));
 
-        $this->config->expects($this->exactly(5))
+        $this->config->expects($this->exactly(3))
                      ->method('getUserValue')
                      ->withConsecutive(
                         ['becka', 'news', 'showAll'],
                         ['becka', 'news', 'preventReadOnScroll'],
-                        ['becka', 'news', 'oldestFirst'],
-                        ['becka', 'news', 'displaymode'],
-                        ['becka', 'news', 'splitmode']
+                        ['becka', 'news', 'oldestFirst']
                      )
                      ->will($this->returnValue('1'));
         $this->settings->expects($this->once())
@@ -239,9 +235,7 @@ class PageControllerTest extends TestCase
                 'preventReadOnScroll' => true,
                 'oldestFirst' => true,
                 'language' => 'de',
-                'exploreUrl' => 'abc',
-                'displaymode' => '0',
-                'splitmode' => '0'
+                'exploreUrl' => 'abc'
             ]
         ];
 
@@ -249,14 +243,12 @@ class PageControllerTest extends TestCase
                    ->method('getLanguageCode')
                    ->will($this->returnValue('de'));
 
-        $this->config->expects($this->exactly(5))
+        $this->config->expects($this->exactly(3))
                     ->method('getUserValue')
                     ->withConsecutive(
                         ['becka', 'news', 'showAll'],
                         ['becka', 'news', 'preventReadOnScroll'],
-                        ['becka', 'news', 'oldestFirst'],
-                        ['becka', 'news', 'displaymode'],
-                        ['becka', 'news', 'splitmode']
+                        ['becka', 'news', 'oldestFirst']
                     )
                     ->will($this->returnValue('1'));
         $this->settings->expects($this->once())
@@ -276,18 +268,16 @@ class PageControllerTest extends TestCase
      */
     public function testUpdateSettings()
     {
-        $this->config->expects($this->exactly(6))
+        $this->config->expects($this->exactly(4))
                     ->method('setUserValue')
                     ->withConsecutive(
                         ['becka', 'news', 'showAll', '1'],
                         ['becka', 'news', 'preventReadOnScroll', '0'],
                         ['becka', 'news', 'oldestFirst', '1'],
-                        ['becka', 'news', 'displaymode', '0'],
-                        ['becka', 'news', 'splitmode', '1'],
                         ['becka', 'news', 'disableRefresh', '0']
                     );
 
-        $this->controller->updateSettings(true, true, false, true, true, false);
+        $this->controller->updateSettings(true, false, true, false);
     }
 
     public function testExplore()


### PR DESCRIPTION
* Resolves: #2940 

## Summary

This PR replaces the current display options and adds a screen reader optimized mode

This are the new settings:

display mode: default, compact, screenreader
split mode: vertical, horizontal, off

The screen reader mode uses a single column layout with rendering the original article in the list.

This PR needs to convert the old expand/compactExpand settings:

compact 0 -> displaymode 0, splitmode 0
compact 1, compactExpand 0 -> displaymode 1, splitmode 0
compact 1, compactExpand 1 -> displaymode 1, splitmode 1

@SMillerDev @Grotax where can I find how the conversion should be made?  


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
