### PR TITLE
fix: remove mime type check when importing opml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Fixed
 - use appropriate semantic HTML elements for the item list to be recognised by screen readers
 - make title in item list clickable for screen readers to select the current item
+- remove mime type check when importing `opml`, they are not reliable anyway
 
 # Releases
 ## [25.0.3] - 2024-11-27

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -460,7 +460,7 @@ export default Vue.extend({
 		},
 		async importOpml(event) {
 			const file = event.target.files[0]
-			if (file && file.type === 'text/x-opml+xml') {
+			if (file) {
 				this.selectedFile = file
 			} else {
 				showError(t('news', 'Please select a valid OPML file'))


### PR DESCRIPTION
* Resolves: #2944 
## Summary

* remove mime type check when importing `opml`, they are not reliable anyway

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
