### PR TITLE
Show red error bubble only if more than 50 updates failed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [25.x.x]
 ### Changed
+- Show red error bubble only if more than 8 updates fail.
 
 ### Fixed
 

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -75,7 +75,7 @@
 								<span v-if="feed.faviconLink" style="width: 16px; height: 16px; background-size: contain;" :style="{ 'backgroundImage': 'url(' + feed.faviconLink + ')' }" />
 							</template>
 							<template #counter>
-								<NcCounterBubble v-show="feed.updateErrorCount > 0"
+								<NcCounterBubble v-show="feed.updateErrorCount > 8"
 									v-tooltip="feed.lastUpdateError"
 									type="highlighted"
 									style="background-color: red">
@@ -92,13 +92,13 @@
 						</NcAppNavigationItem>
 					</template>
 					<template #icon>
-						<FolderAlertIcon v-if="isFolder(topLevelItem) && topLevelItem.updateErrorCount > 0" v-tooltip="t('news', 'Has feeds with errors!')" style="width: 22px; color: red" />
-						<FolderIcon v-if="isFolder(topLevelItem) && topLevelItem.updateErrorCount === 0" style="width:22px" />
+						<FolderAlertIcon v-if="isFolder(topLevelItem) && topLevelItem.updateErrorCount > 8" v-tooltip="t('news', 'Has feeds with errors!')" style="width: 22px; color: red" />
+						<FolderIcon v-if="isFolder(topLevelItem) && topLevelItem.updateErrorCount <= 8" style="width:22px" />
 						<RssIcon v-if="!isFolder(topLevelItem) && !topLevelItem.faviconLink" />
 						<span v-if="!isFolder(topLevelItem) && topLevelItem.faviconLink" style="height: 16px; width: 16px; background-size: contain;" :style="{ 'backgroundImage': 'url(' + topLevelItem.faviconLink + ')' }" />
 					</template>
 					<template #counter>
-						<NcCounterBubble v-if="!isFolder(topLevelItem) && topLevelItem.updateErrorCount > 0"
+						<NcCounterBubble v-if="!isFolder(topLevelItem) && topLevelItem.updateErrorCount > 8"
 							v-tooltip="topLevelItem.lastUpdateError"
 							type="highlighted"
 							style="background-color: red">
@@ -629,9 +629,9 @@ export default Vue.extend({
 				return true
 			}
 			if (this.isFolder(item)) {
-				return item.feedCount > 0 || this.isActiveFolder(item) || this.hasActiveFeeds(item) || item.updateErrorCount > 0
+				return item.feedCount > 0 || this.isActiveFolder(item) || this.hasActiveFeeds(item) || item.updateErrorCount > 8
 			} else {
-				return item.unreadCount > 0 || item.updateErrorCount > 0 || this.isActiveFeed(item)
+				return item.unreadCount > 0 || item.updateErrorCount > 8 || this.isActiveFeed(item)
 			}
 		},
 		sortedFolderFeeds(item: Feed | Folder) {


### PR DESCRIPTION
This restores v24's behavior that hasn't been implemented in v25.

## Summary

Before release 25 there had to be more than 50 feed update errors so that a feed was marked. In v25 every single update error results in a red marking which can be annoying as everybody knows that download errors can happen now and then.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
