### PR TITLE
feat: emulate structural heading navigation to workaround problems with screen readers and the dynamic scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ## [25.x.x]
 ### Changed
 - Show red error bubble only if more than 8 updates fail.
+- Emulate structural heading navigation in screen reader mode with the jump to previous/next articles keys
+- Add `PageDown` and `PageUp` for article heading navigation in screen reader mode
 
 ### Fixed
 

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -1,8 +1,9 @@
 <template>
-	<article class="feed-item-display"
+	<div class="feed-item-display"
 		:class="{ 'screenreader': screenReaderMode }"
+		:aria-posinset="itemIndex"
 		:aria-setsize="itemCount"
-		:aria-posinset="itemIndex">
+		@focusin="selectItemOnFocus">
 		<ShareItem v-if="showShareMenu" :item-id="item.id" @close="closeShareMenu()" />
 
 		<div class="action-bar">
@@ -124,7 +125,7 @@
 			<div class="body" :dir="item.rtl && 'rtl'" v-html="item.body" />
 			<!--eslint-enable-->
 		</div>
-	</article>
+	</div>
 </template>
 
 <script lang="ts">
@@ -195,6 +196,15 @@ export default Vue.extend({
 		 */
 		clearSelected(): void {
 			this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: undefined })
+		},
+		/**
+		 * Use parent click handler to select item when focused,
+		 * needed by screen reader navigation
+		 */
+		selectItemOnFocus(): void {
+			if (this.screenReaderMode && this.$store.getters.selected !== this.item) {
+				this.$emit('click-item')
+			}
 		},
 		/**
 		 * Returns locale formatted date string

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -5,6 +5,12 @@
 				<slot name="header" />
 			</div>
 
+			<button v-if="screenReaderMode"
+				v-shortkey="['pageup']"
+				class="hidden"
+				@shortkey="jumpToPreviousItem">
+				Prev
+			</button>
 			<button v-shortkey="['arrowleft']" class="hidden" @shortkey="jumpToPreviousItem">
 				Prev
 			</button>
@@ -13,6 +19,12 @@
 			</button>
 			<button v-shortkey="['p']" class="hidden" @shortkey="jumpToPreviousItem">
 				Prev
+			</button>
+			<button v-if="screenReaderMode"
+				v-shortkey="['pagedown']"
+				class="hidden"
+				@shortkey="jumpToNextItem">
+				Next
 			</button>
 			<button v-shortkey="['arrowright']" class="hidden" @shortkey="jumpToNextItem">
 				Next
@@ -64,7 +76,7 @@
 							:item-index="index + 1"
 							:item="item"
 							:class="{ 'active': selectedItem && selectedItem.id === item.id }"
-							@show-details="$emit('show-details')" />
+							@click-item="clickItem(item)" />
 						<FeedItemRow v-else
 							:key="item.id"
 							:ref="'feedItemRow' + item.id"

--- a/src/components/feed-display/VirtualScroll.vue
+++ b/src/components/feed-display/VirtualScroll.vue
@@ -30,6 +30,7 @@ export default Vue.extend({
 			checkMarkRead: true,
 			seenItems: new Map(),
 			lastRendered: null,
+			elementToFocus: null,
 		}
 	},
 	computed: {
@@ -45,10 +46,10 @@ export default Vue.extend({
 				return this.$store.state.items.fetchingItems[this.fetchKey]
 			},
 		},
-		compactMode: {
+		displayMode: {
 			cache: false,
 			get() {
-				return this.$store.getters.displaymode === '1'
+				return this.$store.getters.displaymode
 			},
 		},
 	},
@@ -117,7 +118,7 @@ export default Vue.extend({
 		let renderedItems = 0
 		let upperPaddingItems = 0
 		let lowerPaddingItems = 0
-		const itemHeight = this.compactMode ? 44 : 111
+		const itemHeight = this.displayMode === '1' ? 44 : 111
 		const padding = GRID_ITEM_HEIGHT
 		if (this.$slots.default && this.$el && this.$el.getBoundingClientRect) {
 			const childComponents = this.$slots.default.filter(child => !!child.componentOptions)
@@ -160,10 +161,23 @@ export default Vue.extend({
 		const scrollTop = this.scrollTop
 		this.$nextTick(() => {
 			if (this.elementToShow) {
+				// Workaround for buggy scroll with screen readers.
+				// Remember currently selected item to focus on next tick
+				if (this.displayMode === '2') {
+					this.elementToFocus = this.elementToShow
+				}
 				this.elementToShow.scrollIntoView({ behavior: 'auto', block: 'start' })
 				this.elementToShow = null
 			} else {
 				this.$el.scrollTop = scrollTop
+			}
+			// Focus title link in article to emulate structural heading navigation
+			// with screen readers
+			if (this.elementToFocus) {
+				const titleLink = this.elementToFocus.querySelector('a')
+				if (titleLink) {
+					titleLink.focus()
+				}
 			}
 		})
 

--- a/src/components/modals/HelpModal.vue
+++ b/src/components/modals/HelpModal.vue
@@ -19,6 +19,22 @@
 				<tbody>
 					<tr>
 						<td>
+							<kbd>PageDown</kbd>
+						</td>
+						<td>
+							{{ t('news', 'Jump to next article') }} {{ t('news', '(screenreader mode)') }}
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<kbd>PageUp</kbd>
+						</td>
+						<td>
+							{{ t('news', 'Jump to previous article') }} {{ t('news', '(screenreader mode)') }}
+						</td>
+					</tr>
+					<tr>
+						<td>
 							<kbd>n</kbd>
 							/
 							<kbd>j</kbd>


### PR DESCRIPTION
* Related: #2939 

## Summary

This PR will change the article navigation in screen reader mode to workaround problems with the dynamic scroll and screen reader software.
When switching between articles with the keyboard shortcuts the article title link will be focused as starting point for reading the article.
If the focus switches to the previous or next article, for e.g. when using tab or other navigation keys, the article will be automatically selected, to prevent the navigation from getting lost.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
