### PR TITLE
Show error message received from the API when adding feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 
 ### Fixed
+- adding feed via web-ui always use auto-discover
 
 # Releases
 ## [25.1.1] - 2024-12-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 ### Fixed
 - adding feed via web-ui always use auto-discover
+- show 403 forbidden errors when fetching feeds
 
 # Releases
 ## [25.1.1] - 2024-12-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [25.x.x]
 ### Changed
+- show error message in add feed dialog and keep it open if the feed could not be added
 
 ### Fixed
 - adding feed via web-ui always use auto-discover

--- a/lib/Fetcher/Client/FeedIoClient.php
+++ b/lib/Fetcher/Client/FeedIoClient.php
@@ -14,6 +14,7 @@ use DateTime;
 use FeedIo\Adapter\ClientInterface;
 use FeedIo\Adapter\ResponseInterface;
 use FeedIo\Adapter\Guzzle\Response;
+use FeedIo\Adapter\HttpRequestException;
 use FeedIo\Adapter\NotFoundException;
 use FeedIo\Adapter\ServerErrorException;
 use GuzzleHttp\Exception\BadResponseException;
@@ -62,6 +63,8 @@ class FeedIoClient implements ClientInterface
             return new Response($psrResponse, $duration);
         } catch (BadResponseException $e) {
             switch ($e->getResponse()->getStatusCode()) {
+                case 403:
+                    throw new HttpRequestException($e->getMessage());
                 case 404:
                     throw new NotFoundException($e->getMessage());
                 default:

--- a/lib/Service/FeedServiceV2.php
+++ b/lib/Service/FeedServiceV2.php
@@ -212,7 +212,11 @@ class FeedServiceV2 extends Service
                 throw new ServiceNotFoundException($ex->getMessage());
             }
             $this->logger->warning("No valid feed found at URL, attempting auto discovery");
-            $feeds = $this->explorer->discover($feedUrl);
+            try {
+                $feeds = $this->explorer->discover($feedUrl);
+            } catch (\Exception $e) {
+                throw new ServiceNotFoundException($e->getMessage());
+            }
             if ($feeds !== []) {
                 $feedUrl = array_shift($feeds);
             }

--- a/src/dataservices/feed.service.ts
+++ b/src/dataservices/feed.service.ts
@@ -32,18 +32,19 @@ export class FeedService {
 	 * @param param0 Data for the feed
 	 * @param param0.url {String} url of the feed to add
 	 * @param param0.folderId {number} id number of folder to add feed to
+	 * @param param0.autoDiscover {boolean} use auto-discover when adding feed
 	 * @param param0.user {String} http auth username required for accessing feed
 	 * @param param0.password {String} http auth password required for accessing feed
 	 * @return {AxiosResponse} Feed info stored in data.feeds[0] property
 	 */
-	static addFeed({ url, folderId, user, password }: { url: string; folderId: number; user?: string; password?: string }): Promise<AxiosResponse> {
+	static addFeed({ url, folderId, autoDiscover, user, password }: { url: string; folderId: number; autoDiscover: boolean; user?: string; password?: string }): Promise<AxiosResponse> {
 		return axios.post(API_ROUTES.FEED, {
 			url,
 			parentFolderId: folderId,
 			title: null, // TODO: let user define feed title on create?
 			user: user || null,
 			password: password || null,
-			fullDiscover: undefined, // TODO: autodiscover?
+			fullDiscover: autoDiscover,
 		})
 	}
 

--- a/src/store/feed.ts
+++ b/src/store/feed.ts
@@ -63,6 +63,7 @@ export const actions = {
 			feedReq: {
 				url: string;
 				folder?: { id: number; name?: string; },
+				autoDiscover: boolean;
 				user?: string;
 				password?: string;
 			}
@@ -87,6 +88,7 @@ export const actions = {
 			const response = await FeedService.addFeed({
 				url,
 				folderId,
+				autoDiscover: feedReq.autoDiscover,
 				user: feedReq.user,
 				password: feedReq.password,
 			})

--- a/src/store/feed.ts
+++ b/src/store/feed.ts
@@ -83,7 +83,6 @@ export const actions = {
 			folderId = feedReq.folder?.id || 0
 		}
 
-		// Check that url is resolvable
 		try {
 			const response = await FeedService.addFeed({
 				url,
@@ -94,9 +93,12 @@ export const actions = {
 			})
 
 			commit(FEED_MUTATION_TYPES.ADD_FEED, response.data.feeds[0])
+			return response
 		} catch (e) {
-			// TODO: show error to user if failure
-			console.error(e)
+			if (e && typeof e === 'object' && 'response' in e) {
+				return e.response
+			}
+			return { status: undefined }
 		}
 	},
 

--- a/tests/javascript/unit/components/AddFeed.spec.ts
+++ b/tests/javascript/unit/components/AddFeed.spec.ts
@@ -37,11 +37,23 @@ describe('AddFeed.vue', () => {
 	})
 
 	it('should dispatch ADD_FEED action to store', async () => {
+		mockDispatch.mockResolvedValueOnce({ status: 200, data: { message: "ok" }})
 		wrapper.vm.$emit = jest.fn()
 
 		await wrapper.vm.addFeed()
 
 		expect(wrapper.vm.$emit).toBeCalled()
+		expect(mockDispatch).toBeCalled()
+		expect(mockDispatch.mock.calls[0][0]).toEqual(FEED_ACTION_TYPES.ADD_FEED)
+	})
+
+	it('should dispatch ADD_FEED action but not emit close event on non-200 status', async () => {
+		mockDispatch.mockResolvedValueOnce({ status: 422, data: { message: "no found" }})
+		wrapper.vm.$emit = jest.fn()
+
+		await wrapper.vm.addFeed()
+
+		expect(wrapper.vm.$emit).not.toBeCalled()
 		expect(mockDispatch).toBeCalled()
 		expect(mockDispatch.mock.calls[0][0]).toEqual(FEED_ACTION_TYPES.ADD_FEED)
 	})

--- a/tests/javascript/unit/services/feed.service.spec.ts
+++ b/tests/javascript/unit/services/feed.service.spec.ts
@@ -23,7 +23,7 @@ describe('feed.service.ts', () => {
 
 	describe('addFeed', () => {
 		it('should call POST with item id in URL and read param', async () => {
-			await FeedService.addFeed({ url: 'http://example.com', folderId: 0 })
+			await FeedService.addFeed({ url: 'http://example.com', folderId: 0, autoDiscover: false })
 
 			expect(axios.post).toBeCalled()
 			const args = (axios.post as any).mock.calls[0]


### PR DESCRIPTION
## Summary

This PR add an error message to the add feed dialog to show what happens if a feed can't be added.
It also adds error handling to the backend for 403 forbidden errors and errors during auto-discover to give the user reasonable information in the server log and in the web-ui.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
