### PR TITLE
Fix move feed dialog closes unexpectedly and small style fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Fixed
 - adding feed via web-ui always use auto-discover
 - show 403 forbidden errors when fetching feeds
+- prevent move feed dialog from being closed unexpectedly
 
 # Releases
 ## [25.1.1] - 2024-12-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ## [25.x.x]
 ### Changed
 - show error message in add feed dialog and keep it open if the feed could not be added
+- keep margins the same even if an article does not use max width
 
 ### Fixed
 - adding feed via web-ui always use auto-discover

--- a/src/components/MoveFeed.vue
+++ b/src/components/MoveFeed.vue
@@ -1,7 +1,6 @@
 <template>
 	<NcModal @close="$emit('close')">
 		<div class="modal__content">
-			<h2>{{ t("news", "Move feed to folder") }}</h2>
 			<div class="form-group">
 				<NcSelect v-if="folders"
 					v-model="folder"
@@ -9,7 +8,8 @@
 					:placeholder="'-- ' + t('news', 'No folder') + ' --'"
 					required
 					track-by="id"
-					label="name" />
+					label="name"
+					style="width: 90%;" />
 			</div>
 			<NcButton :wide="true"
 				type="primary"
@@ -87,12 +87,9 @@ export default Vue.extend({
 .invalid {
 	border: 1px solid rgb(251, 72, 72) !important;
 }
-.modal__content {
-	margin: 50px;
-}
 
-.modal__content h2 {
-	text-align: center;
+.modal__content {
+	margin: 16px;
 }
 
 .form-group {

--- a/src/components/MoveFeed.vue
+++ b/src/components/MoveFeed.vue
@@ -53,7 +53,7 @@ export default Vue.extend({
 	},
 	data: (): MoveFeedState => {
 		return {
-			folder: undefined,
+			folder: null,
 		}
 	},
 	computed: {
@@ -61,7 +61,7 @@ export default Vue.extend({
 			return this.$store.state.folders.folders
 		},
 		disableMoveFeed(): boolean {
-			return (this.folder !== undefined && this.folder.id === this.feed.folderId)
+			return (this.folder && this.folder.id === this.feed.folderId)
 		},
 	},
 	methods: {

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,11 +1,12 @@
 <template>
 	<NcAppNavigation>
-		<AddFeed v-if="showAddFeed" @close="closeShowAddFeed()" />
+		<AddFeed v-if="showAddFeed" @close="closeAddFeed()" />
+		<MoveFeed v-if="showMoveFeed" :feed="feedToMove" @close="closeMoveFeed()" />
 		<NcAppNavigationNew :text="t('news', 'Subscribe')"
 			button-id="new-feed-button"
 			button-class="icon-add"
 			:icon="''"
-			@click="showShowAddFeed()">
+			@click="addFeed()">
 			<template #icon>
 				<PlusIcon />
 			</template>
@@ -87,7 +88,7 @@
 							</template>
 
 							<template #actions>
-								<SidebarFeedLinkActions :feed-id="feed.id" />
+								<SidebarFeedLinkActions :feed-id="feed.id" @move-feed="moveFeed(feed)" />
 							</template>
 						</NcAppNavigationItem>
 					</template>
@@ -112,7 +113,9 @@
 						</NcCounterBubble>
 					</template>
 					<template #actions>
-						<SidebarFeedLinkActions v-if="topLevelItem.name === undefined && !topLevelItem.url.includes('news/sharedwithme')" :feed-id="topLevelItem.id" />
+						<SidebarFeedLinkActions v-if="topLevelItem.name === undefined && !topLevelItem.url.includes('news/sharedwithme')"
+							:feed-id="topLevelItem.id"
+							@move-feed="moveFeed(topLevelItem)" />
 						<NcActionButton v-if="topLevelItem.name !== undefined"
 							icon="icon-checkmark"
 							:close-after-click="true"
@@ -282,6 +285,7 @@ import { ROUTES } from '../routes'
 import { ACTIONS, MUTATIONS } from '../store'
 
 import AddFeed from './AddFeed.vue'
+import MoveFeed from './MoveFeed.vue'
 import SidebarFeedLinkActions from './SidebarFeedLinkActions.vue'
 
 import HelpModal from './modals/HelpModal.vue'
@@ -299,6 +303,7 @@ export default Vue.extend({
 		NcActionButton,
 		NcButton,
 		AddFeed,
+		MoveFeed,
 		RssIcon,
 		FolderIcon,
 		EyeIcon,
@@ -314,6 +319,8 @@ export default Vue.extend({
 	data: () => {
 		return {
 			showAddFeed: false,
+			showMoveFeed: false,
+			feedToMove: undefined,
 			ROUTES,
 			showHelp: false,
 			polling: null,
@@ -602,12 +609,20 @@ export default Vue.extend({
 				this.$store.dispatch(ACTIONS.DELETE_FOLDER, { folder })
 			}
 		},
-		showShowAddFeed() {
+		addFeed() {
 			this.showAddFeed = true
 		},
-		closeShowAddFeed() {
+		closeAddFeed() {
 			this.showAddFeed = false
 		},
+		moveFeed(feed) {
+			this.feedToMove = feed
+			this.showMoveFeed = true
+		},
+		closeMoveFeed() {
+			this.showMoveFeed = false
+		},
+
 		isFolder(item: Feed | Folder) {
 			return (item as Folder).name !== undefined
 		},

--- a/src/components/SidebarFeedLinkActions.vue
+++ b/src/components/SidebarFeedLinkActions.vue
@@ -81,7 +81,7 @@
 		</NcActionButton>
 		<NcActionButton icon="icon-arrow"
 			:close-after-click="true"
-			@click="move()">
+			@click="$emit('move-feed')">
 			<template #icon>
 				<ArrowRightIcon />
 			</template>
@@ -98,7 +98,6 @@
 				<RssIcon />
 			</template>
 		</NcAppNavigationItem>
-		<MoveFeed v-if="showMoveFeed" :feed="feed" @close="closeShowMoveFeed()" />
 	</span>
 </template>
 
@@ -120,13 +119,11 @@ import ArrowRightIcon from 'vue-material-design-icons/ArrowRight.vue'
 
 import { ACTIONS } from '../store'
 import { Feed } from '../types/Feed'
-import MoveFeed from './MoveFeed.vue'
 import UnreadSvg from '../../img/updatemodeunread.svg'
 import IgnoreSvg from '../../img/updatemodedefault.svg'
 
 export default Vue.extend({
 	components: {
-		MoveFeed,
 		NcActionButton,
 		NcAppNavigationItem,
 		RssIcon,
@@ -148,7 +145,6 @@ export default Vue.extend({
 			FEED_UPDATE_MODE,
 			UnreadSvg,
 			IgnoreSvg,
-			showMoveFeed: false,
 		}
 	},
 
@@ -182,12 +178,6 @@ export default Vue.extend({
 			if (title !== null) {
 				this.$store.dispatch(ACTIONS.FEED_SET_TITLE, { feed: this.feed, title })
 			}
-		},
-		move() {
-			this.showMoveFeed = true
-		},
-		closeShowMoveFeed() {
-			this.showMoveFeed = false
 		},
 		deleteFeed() {
 			const shouldDelete = window.confirm(t('news', 'Are you sure you want to delete?'))

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -299,6 +299,7 @@ export default Vue.extend({
 
 	.article {
 		padding: 0 50px 50px 50px;
+		width: 100%;
 		height: 100%;
 		max-width: 1024px;
 		margin-left: auto;

--- a/tests/javascript/unit/components/Sidebar.spec.ts
+++ b/tests/javascript/unit/components/Sidebar.spec.ts
@@ -90,12 +90,12 @@ describe('Sidebar.vue', () => {
 		})
 
 		it('should set showAddFeed to true', () => {
-			(wrapper.vm as any).showShowAddFeed()
+			(wrapper.vm as any).addFeed()
 			expect(wrapper.vm.$data.showAddFeed).toBeTruthy()
 		})
 
 		it('should set showAddFeed to false', () => {
-			(wrapper.vm as any).closeShowAddFeed()
+			(wrapper.vm as any).closeAddFeed()
 			expect(wrapper.vm.$data.showAddFeed).toBeFalsy()
 		})
 


### PR DESCRIPTION
## Summary

This PR prevents the move feed dialog from closing unexpectedly and change the style to match the other modals.
It also change that articles which doesn't use the full article width will be further centered, so all articles align same.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
