### PR TITLE
Update feed only if nextUpdateTime has been reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ## [25.x.x]
 ### Changed
 - API add new field to Feed that indicates when the next update will be done "nextUpdateTime" (#2993)
+- Change logic to update feed only if the nextUpdateTime has been reached (#2999)
+- Add setting to disable the usage of nextUpdateTime (#2999)
 
 ### Fixed
 - `TypeError: this.$refs.actions.$refs.menuButton is undefined` when tabbing through feeds and folders

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>25.1.2</version>
+    <version>25.2.0</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -63,11 +63,6 @@ The update interval is used to determine when the next update of all feeds shoul
 By default, the value is set to 3600 seconds (1 hour) You can configure this interval as an administrator.
 The new value is only applied after the next run of the updater.
 
-#### What is a good update interval?
+Since News 25.2.0 News no longer will update all feeds instead it will make a individual decision based on when an update for the feed will make sense. Therefore this interval is now only to be understood as the check if an update should be done.
 
-That depends on your individual needs.
-Please keep in mind that the lower you set your update interval, the more traffic is generated.
-
-#### Can I set individual update intervals per feed/user?
-
-No, that is not possible.
+This behavior can be disabled in the Settings although we generally do not recommend that.

--- a/docs/user.md
+++ b/docs/user.md
@@ -1,0 +1,14 @@
+# User
+
+Welcome to the User documentation of News.
+
+# TODO 
+This documentation is work in progress.
+
+# User interface
+
+explain the different options in the UI especially options for feeds and settings
+
+# Using News with Clients
+
+explain sync and link to clients page

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -67,6 +67,7 @@ class Application extends App implements IBootstrap
         'useCronUpdates'           => true,
         'exploreUrl'               => '',
         'updateInterval'           => 3600,
+        'useNextUpdateTime'        => true,
     ];
 
     public function __construct(array $urlParams = [])

--- a/lib/Db/Feed.php
+++ b/lib/Db/Feed.php
@@ -663,10 +663,12 @@ class Feed extends Entity implements IAPI, \JsonSerializable
     /**
      * @param int $nextUpdateTime
      */
-    public function setNextUpdateTime(?int $nextUpdateTime): void
+    public function setNextUpdateTime(?int $nextUpdateTime): Feed
     {
         $this->nextUpdateTime = $nextUpdateTime;
         $this->markFieldUpdated('nextUpdateTime');
+
+        return $this;
     }
 
     public function toAPI(): array

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -146,6 +146,13 @@ class FeedFetcher implements IFeedFetcher
         );
 
         $feed->setNextUpdateTime($resource->getNextUpdate()?->getTimestamp());
+        $this->logger->debug(
+            'Feed {url} was parsed and nextUpdateTime is {nextUpdateTime}',
+            [
+            'url'   => $url,
+            'nextUpdateTime' => $feed->getNextUpdateTime()
+            ]
+        );
 
         if (!is_null($resource->getResponse()->getLastModified())) {
             $feed->setHttpLastModified($resource->getResponse()->getLastModified()->format(DateTime::RSS));
@@ -158,10 +165,11 @@ class FeedFetcher implements IFeedFetcher
         $feedName = $parsedFeed->getTitle();
         $feedAuthor = $parsedFeed->getAuthor();
         $this->logger->debug(
-            'Feed {url} was modified since last fetch. #{count} items',
+            'Feed {url} was modified since last fetch. #{count} items, nextUpdateTime is {nextUpdateTime}',
             [
             'url'   => $url,
             'count' => count($parsedFeed),
+            'nextUpdateTime' => $feed->getNextUpdateTime(),
             ]
         );
 

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -87,6 +87,17 @@ SPDX-Licence-Identifier: AGPL-3.0-or-later
 		<p class="settings-hint">
 			{{ t("news", "Interval in seconds in which the feeds will be updated.") }}
 		</p>
+
+		<div class="field">
+			<NcCheckboxRadioSwitch type="switch"
+				:checked.sync="useNextUpdateTime"
+				@update:checked="update('useNextUpdateTime', useNextUpdateTime)">
+				{{ t("news", "Use next update time for feed updates") }}
+			</NcCheckboxRadioSwitch>
+		</div>
+		<p class="settings-hint">
+			{{ t("news", "Enable this to use the calculated next update time for feed updates. Disable to update feeds based solely on the update interval.") }}
+		</p>
 	</NcSettingsSection>
 </template>
 
@@ -140,6 +151,7 @@ export default {
 			feedFetcherTimeout: loadState('news', 'feedFetcherTimeout'),
 			exploreUrl: loadState('news', 'exploreUrl'),
 			updateInterval: loadState('news', 'updateInterval'),
+			useNextUpdateTime: loadState('news', 'useNextUpdateTime') === '1',
 			relativeTime: moment(lastCron * 1000).fromNow(),
 			lastCron,
 		}
@@ -159,7 +171,7 @@ export default {
 					key,
 				},
 			)
-			if (key === 'useCronUpdates' || key === 'purgeUnread') {
+			if (key === 'useCronUpdates' || key === 'purgeUnread' || key === 'useNextUpdateTime') {
 				value = value ? '1' : '0'
 			}
 			try {

--- a/tests/Unit/Service/FeedServiceTest.php
+++ b/tests/Unit/Service/FeedServiceTest.php
@@ -24,6 +24,7 @@ use OCA\News\Service\FeedServiceV2;
 use OCA\News\Service\ItemServiceV2;
 use OCA\News\Utility\Time;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IAppConfig;
 
 use OCA\News\Db\Feed;
 use OCA\News\Db\Item;
@@ -77,6 +78,11 @@ class FeedServiceTest extends TestCase
      */
     private $explorer;
 
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|IAppConfig
+     */
+    private $config;
+
     private $response;
 
     protected function setUp(): void
@@ -112,14 +118,19 @@ class FeedServiceTest extends TestCase
             ->getMockBuilder(\HTMLPurifier::class)
             ->disableOriginalConstructor()
             ->getMock();
-
+        $this->config = $this
+            ->getMockBuilder(IAppConfig::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        
         $this->class = new FeedServiceV2(
             $this->mapper,
             $this->fetcher,
             $this->itemService,
             $this->explorer,
             $this->purifier,
-            $this->logger
+            $this->logger,
+            $this->config
         );
         $this->uid = 'jack';
     }

--- a/tests/api/feeds.bats
+++ b/tests/api/feeds.bats
@@ -147,5 +147,6 @@ teardown() {
   # run is not working here.
   output=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} POST ${BASE_URLv1}/feeds url=$NC_FEED | jq '.feeds | .[0].nextUpdateTime')
 
-  assert_output '2071387335'
+  # the field nextUpdateTime should be null here since the feed just got created in the DB an the items have not yet been fetched
+  assert_output 'null'
 }

--- a/tests/javascript/unit/components/AdminSettings.spec.ts
+++ b/tests/javascript/unit/components/AdminSettings.spec.ts
@@ -28,7 +28,7 @@ describe('AdminSettings.vue', () => {
 	})
 
 	it('should initialize and fetch settings from state', () => {
-		expect(loadState).toBeCalledTimes(8)
+		expect(loadState).toBeCalledTimes(9)
 	})
 
 	it('should send post with updated settings', async () => {


### PR DESCRIPTION
## Summary

This changes the logic of updating/fetching a feed to check for the nextUpdateTime before the the update is executed.

If that time is not reached yet the feed is not updated. This is mainly a advantage for feeds that are updated rarely and will therefore receive less requests. For the nextcloud instance this is also a benefit because feed updates that are likely not needed are skipped, which saves compute time.

The default minimum for an active feed is "in 1 hour" which means it will be updated in hour again.

Also added a setting to disable this, mostly for testing but I can also imagine that in the beginning or for certain use cases people want to disable this.

Builds on top of #2993 

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
