### PR TITLE
fix: TypeError: this.$refs.actions.$refs.menuButton is undefined when tabbing through feeds and folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - API add new field to Feed that indicates when the next update will be done "nextUpdateTime" (#2993)
 
 ### Fixed
+- `TypeError: this.$refs.actions.$refs.menuButton is undefined` when tabbing through feeds and folders
 
 # Releases
 ## [25.1.2] - 2024-12-22

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -23,7 +23,7 @@
 		<template #list>
 			<NcAppNavigationItem :name="t('news', 'Unread articles')" icon="icon-rss" :to="{ name: ROUTES.UNREAD }">
 				<template #actions>
-					<NcActionButton icon="icon-checkmark" @click="markAllRead()">
+					<NcActionButton ref="triggerButton" icon="icon-checkmark" @click="markAllRead()">
 						{{ t('news','Mark read') }}
 					</NcActionButton>
 				</template>


### PR DESCRIPTION
* Resolves: #2882
* Resolves: #2920 

## Summary

With Nextcloud Vue 8.22.0 (#3003) the refs for the NcActionButton action menus are fixed, for single action it must be set itself.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
