### PR TITLE
Release 25.2.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,19 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [25.x.x]
 ### Changed
+
+### Fixed
+
+# Releases
+## [25.2.0-beta.1] - 2024-12-30
+### Changed
 - API add new field to Feed that indicates when the next update will be done "nextUpdateTime" (#2993)
 - Change logic to update feed only if the nextUpdateTime has been reached (#2999)
 - Add setting to disable the usage of nextUpdateTime (#2999)
 
 ### Fixed
-- `TypeError: this.$refs.actions.$refs.menuButton is undefined` when tabbing through feeds and folders
+- `TypeError: this.$refs.actions.$refs.menuButton is undefined` when tabbing through feeds and folders (#3004)
 
-# Releases
 ## [25.1.2] - 2024-12-22
 ### Changed
 - show error message in add feed dialog and keep it open if the feed could not be added (#2988)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>25.2.0</version>
+    <version>25.2.0-beta.1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
## Summary

Releasing this as beta because I'm quite confident that it will work fine but who knows.
Also for the first time the version pattern is according to the docs of nextcloud and what most apps use, plus this release will not be marked as nightly, see https://github.com/nextcloud/news/pull/2894

Changed
- API add new field to Feed that indicates when the next update will be done "nextUpdateTime" (#2993)
- Change logic to update feed only if the nextUpdateTime has been reached (#2999)
- Add setting to disable the usage of nextUpdateTime (#2999)

Fixed
- `TypeError: this.$refs.actions.$refs.menuButton is undefined` when tabbing through feeds and folders (#3004)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
