### PR TITLE
Limit the delay for an update to "in one day"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [25.x.x]
 ### Changed
-
+- Set maximum delay for updates to "in one day" (#3015)
 ### Fixed
 - OPML import use text field for title if title field is missing (#3016) 
 

--- a/lib/Config/FetcherConfig.php
+++ b/lib/Config/FetcherConfig.php
@@ -68,6 +68,12 @@ class FetcherConfig
                            'text/xml;q=0.4, */*;q=0.2';
 
     /**
+     * Duration after which the feed is considered sleepy.
+     * @var int
+     */
+    public const SLEEPY_DURATION = 86400;
+    
+    /**
      * FetcherConfig constructor.
      *
      * @param IAppConfig $config    App configuration

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -145,7 +145,10 @@ class FeedFetcher implements IFeedFetcher
             $location
         );
 
-        $feed->setNextUpdateTime($resource->getNextUpdate()?->getTimestamp());
+        $feed->setNextUpdateTime(nextUpdateTime: $resource->getNextUpdate(
+            sleepyDuration: $this->fetcherConfig::SLEEPY_DURATION
+        )?->getTimestamp());
+
         $this->logger->debug(
             'Feed {url} was parsed and nextUpdateTime is {nextUpdateTime}',
             [

--- a/tests/updater/update.bats
+++ b/tests/updater/update.bats
@@ -88,13 +88,8 @@ teardown() {
 
   UpdateTime2=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/feeds | jq '.feeds | .[0].nextUpdateTime')
 
-  # Check if UpdateTime2 is within the expected range and print it if not
-  if [[ $UpdateTime2 -lt $expected_time_min || $UpdateTime2 -gt $expected_time_max ]]; then
-    echo "UpdateTime2 is out of range: $UpdateTime2"
-  fi
-
-  # Assert that UpdateTime2 is within the expected range
-  run bash -c "[[ $UpdateTime2 -ge $expected_time_min && $UpdateTime2 -le $expected_time_max ]]"
+  # Assert that UpdateTime2 is within the expected range and print the timestamp if not
+  run bash -c "[[ \$UpdateTime2 -ge \$expected_time_min && \$UpdateTime2 -le \$expected_time_max ]] || echo \"UpdateTime2 is out of range: \$UpdateTime2\""
   assert_success
 
 }
@@ -127,34 +122,6 @@ teardown() {
   assert_not_equal "${ID_LIST1[*]}" "${ID_LIST2[*]}"
   assert_output --partial "${ID_LIST1[*]}"
 }
-
-# older date is not a thing anymore
-#@test "[$TESTSUITE] Test feed with 'outdated' items https://github.com/nextcloud/news/issues/2236 " {
-# # Create Feed, for the first fetch a timestamp today -1 year is used.
-#  FEEDID=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} POST ${BASE_URLv1}/feeds url=$TEST_FEED | grep -Po '"id":\K([0-9]+)')
-#
-#  sleep 2
-#
-#  # Get Items
-#  ID_LIST1=($(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/items | grep -Po '"id":\K([0-9]+)' | tr '\n' ' '))
-#
-#  # Generate Feed with older items (-o yes)
-#  php ${BATS_TEST_DIRNAME}/../test_helper/php-feed-generator/feed-generator.php -a 15 -s 9 -f ${BATS_TEST_DIRNAME}/../test_helper/feeds/test.xml -o yes
-#
-#  # Trigger Update
-#  http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/feeds/update userId=${user} feedId=$FEEDID
-#
-#  sleep 2
-#
-#  # Get Items again
-#  ID_LIST2=($(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/items | grep -Po '"id":\K([0-9]+)' | tr '\n' ' '))
-#
-#  output="${ID_LIST2[*]}"
-#
-#  # Check that they are not equal but that they match partially.
-#  assert_not_equal "${ID_LIST1[*]}" "${ID_LIST2[*]}"
-#  assert_output --partial "${ID_LIST1[*]}"
-#}
 
 @test "[$TESTSUITE] Test purge with small feed" {
   # Disable useNextUpdateTime

--- a/tests/updater/update.bats
+++ b/tests/updater/update.bats
@@ -76,9 +76,9 @@ teardown() {
   # Get the current time
   current_time=$(date +%s)
 
-  # Calculate the expected time range (+1 hour with some tolerance)
-  expected_time_min=$((current_time + 3600 - 60)) # 1 hour - 1 minute tolerance
-  expected_time_max=$((current_time + 3600 + 60)) # 1 hour + 1 minute tolerance
+  # Calculate the expected time range (+1 day with some tolerance)
+  expected_time_min=$((current_time + 86400 - 60)) # 1 hour - 1 minute tolerance
+  expected_time_max=$((current_time + 86400 + 60)) # 1 hour + 1 minute tolerance
 
   php ${BATS_TEST_DIRNAME}/../test_helper/php-feed-generator/feed-generator.php -a 15 -s 9 -f ${BATS_TEST_DIRNAME}/../test_helper/feeds/test.xml
   # Trigger Update
@@ -87,6 +87,11 @@ teardown() {
   sleep 2
 
   UpdateTime2=$(http --ignore-stdin -b -a ${user}:${APP_PASSWORD} GET ${BASE_URLv1}/feeds | jq '.feeds | .[0].nextUpdateTime')
+
+  # Check if UpdateTime2 is within the expected range and print it if not
+  if [[ $UpdateTime2 -lt $expected_time_min || $UpdateTime2 -gt $expected_time_max ]]; then
+    echo "UpdateTime2 is out of range: $UpdateTime2"
+  fi
 
   # Assert that UpdateTime2 is within the expected range
   run bash -c "[[ $UpdateTime2 -ge $expected_time_min && $UpdateTime2 -le $expected_time_max ]]"


### PR DESCRIPTION
## Summary

The calculations feed-io does can lead to high values that would delay the next update for too long.
Maybe the calculations done in feed-io could be improved but this provides a simple fix by limiting the delay to maximum one day.

Adds SLEEPY_DURATION to FetcherConfig and use it for the nextUpdateTime calculation.

[#3013](https://github.com/nextcloud/news/discussions/3013)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
