### PR TITLE
OPML If title field does not exist look for text

### DIFF
--- a/.github/workflows/api-integration-tests.yml
+++ b/.github/workflows/api-integration-tests.yml
@@ -142,11 +142,6 @@ jobs:
 
           kill %1
 
-      - name: Prep PHP tests
-        working-directory: ../server/apps/news
-        run: make php-test-dependencies
-
-      - name: Feed tests
+      - name: Check feeds if feeds from explore page are reachable
         working-directory: ../server/apps/news
         run: make feed-test
-

--- a/.github/workflows/api-php-tests.yml
+++ b/.github/workflows/api-php-tests.yml
@@ -13,13 +13,11 @@ jobs:
         nextcloud: ['stable29']
         database: ['sqlite']
         experimental: [false]
-        codecoverage: [false]
         include:
           - php-versions: 8.3
             nextcloud: stable29
             database: sqlite
             experimental: false
-            codecoverage: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,12 +53,7 @@ jobs:
       - name: Prep PHP tests
         working-directory: ../server/apps/news
         run: make php-test-dependencies
+      
       - name: Unittests
         working-directory: ../server/apps/news
         run: make unit-test
-        env:
-          CODECOVERAGE: ${{ matrix.codecoverage }}
-      - name: Upload codecoverage
-        if: ${{ matrix.codecoverage }}
-        working-directory: ../server/apps/news
-        run: bash <(curl -s https://codecov.io/bash) -f build/php-unit.clover -N ${{ github.sha }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 
 ### Fixed
+- OPML import use text field for title if title field is missing (#3016) 
 
 # Releases
 ## [25.2.0-beta.1] - 2024-12-30

--- a/lib/Utility/OPMLImporter.php
+++ b/lib/Utility/OPMLImporter.php
@@ -65,10 +65,12 @@ class OPMLImporter
     private function outlineToItem(DOMElement $outline, ?string $parent = null): void
     {
         if ($outline->getAttribute('type') === 'rss') {
+            // take title if available, otherwise use text #2896
+            $title = $outline->getAttribute('title') ?? $outline->getAttribute('text');
             $feed = [
                 'link' => $outline->getAttribute('htmlUrl'),
                 'url' => $outline->getAttribute('xmlUrl'),
-                'title' => $outline->getAttribute('title'),
+                'title' => $title,
                 'folder' => $parent,
             ];
 


### PR DESCRIPTION
* Resolves: #2896

## Summary

Checked the code and indeed when News exports to opml we set both title and text to the feed title.
So I guess some exporters might choose to only put it in text. So let's check for title first and if that is missing take text :)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
