### PR TITLE
npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3085,9 +3085,9 @@
       }
     },
     "node_modules/@nextcloud/files": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.10.0.tgz",
-      "integrity": "sha512-VvucXNM+Ci/Ej1nK1UAboliiPpAY8az6cDDMoBWxgtfKRL7Q9I0aN2/nl4V9j2JaCm6E4TVWnKXlYDySMPNQKQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.10.1.tgz",
+      "integrity": "sha512-hYUK28ZEU4GTbMXd0/YXTUUKedWnzdr4Eva+6sTxiuJMnACJ4/pZvSzFL9i82fBXvR/0MI5DA6+1gryMyNv1ww==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.4.0",
@@ -3099,7 +3099,7 @@
         "@nextcloud/sharing": "^0.2.3",
         "cancelable-promise": "^4.3.1",
         "is-svg": "^5.1.0",
-        "typedoc-plugin-missing-exports": "^3.0.0",
+        "typedoc-plugin-missing-exports": "^3.1.0",
         "typescript-event-target": "^1.1.1",
         "webdav": "^5.7.1"
       },
@@ -9438,10 +9438,11 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
@@ -9463,7 +9464,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -9478,6 +9479,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/array-flatten": {
@@ -16832,10 +16837,11 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true,
+      "license": "MIT",
       "peer": true
     },
     "node_modules/path-type": {
@@ -24446,9 +24452,9 @@
       }
     },
     "@nextcloud/files": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.10.0.tgz",
-      "integrity": "sha512-VvucXNM+Ci/Ej1nK1UAboliiPpAY8az6cDDMoBWxgtfKRL7Q9I0aN2/nl4V9j2JaCm6E4TVWnKXlYDySMPNQKQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.10.1.tgz",
+      "integrity": "sha512-hYUK28ZEU4GTbMXd0/YXTUUKedWnzdr4Eva+6sTxiuJMnACJ4/pZvSzFL9i82fBXvR/0MI5DA6+1gryMyNv1ww==",
       "requires": {
         "@nextcloud/auth": "^2.4.0",
         "@nextcloud/capabilities": "^1.2.0",
@@ -24459,7 +24465,7 @@
         "@nextcloud/sharing": "^0.2.3",
         "cancelable-promise": "^4.3.1",
         "is-svg": "^5.1.0",
-        "typedoc-plugin-missing-exports": "^3.0.0",
+        "typedoc-plugin-missing-exports": "^3.1.0",
         "typescript-event-target": "^1.1.1",
         "webdav": "^5.7.1"
       },
@@ -29209,9 +29215,9 @@
       }
     },
     "express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -29234,7 +29240,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -34641,9 +34647,9 @@
       "integrity": "sha512-1gJ0WpNIiYcQydgg3Ed8KzvIqTsDpNwq+cjBCssvBtuTWjEqY1AW+i+OepiEMqDCzyro9B2sLAe4RBPajMYFiA=="
     },
     "path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true,
       "peer": true
     },


### PR DESCRIPTION
## Summary

path-to-regexp  <0.1.12
Severity: moderate
Unpatched `path-to-regexp` ReDoS in 0.1.x - https://github.com/advisories/GHSA-rhx6-c78j-4q9w

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
