### PR TITLE
Fix issue that proxy port is removed if it matches the standard port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - add explanations for the individual values in the feed information table
 
 ### Fixed
+- fix proxy port removed if standard port for the protocol (#3027)
 
 
 # Releases

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,7 +33,13 @@ It should show something like this:
 CONTAINER ID   IMAGE                  COMMAND                  CREATED         STATUS         PORTS                                       NAMES
 a1b2c3d4e5f6   nextcloud-news-app     "docker-entrypoint.…"   2 hours ago     Up 2 hours     0.0.0.0:8081->80/tcp                        nextcloud-news-app
 ```
-To open a shell run
+
+To open a shell as www-data which you need to run occ commands run:
+``` bash
+docker exec -u www-data -it nextcloud-news-app /bin/bash
+```
+
+To open a shell as root run
 ``` bash
 docker exec -it nextcloud-news-app /bin/bash
 ```

--- a/lib/Config/FetcherConfig.php
+++ b/lib/Config/FetcherConfig.php
@@ -125,11 +125,11 @@ class FetcherConfig
             $url->setUserinfo($auth[0], $auth[1]);
         }
 
-        $this->proxy = $url->getNormalizedURL();
+        $this->proxy = $url->getURL();
 
         $this->logger->debug(
             'Proxy configuration finalized: {proxy}',
-            ['proxy' => $proxy]
+            ['proxy' => $this->proxy]
         );
 
         return $this;
@@ -197,5 +197,15 @@ class FetcherConfig
         }
 
         return 'NextCloud-News/' . $this->version;
+    }
+
+    /**
+     * Get the proxy configuration
+     *
+     * @return string|null
+     */
+    public function getProxy(): ?string
+    {
+        return $this->proxy;
     }
 }

--- a/tests/Unit/Config/FetcherConfigTest.php
+++ b/tests/Unit/Config/FetcherConfigTest.php
@@ -27,6 +27,7 @@ use OCP\IConfig;
 use OCP\App\IAppManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class FetcherConfigTest
@@ -49,6 +50,9 @@ class FetcherConfigTest extends TestCase
     /** @var FetcherConfig */
     protected $class;
 
+    /** @var MockObject|LoggerInterface */
+    protected $logger;
+
     protected function setUp(): void
     {
         $this->config = $this->getMockBuilder(IAppConfig::class)
@@ -62,6 +66,11 @@ class FetcherConfigTest extends TestCase
         $this->appmanager = $this->getMockBuilder(IAppManager::class)
                                  ->disableOriginalConstructor()
                                  ->getMock();
+
+        $this->logger = $this->getMockBuilder(LoggerInterface::class)
+                                ->disableOriginalConstructor()
+                                ->getMock();
+
     }
 
     /**
@@ -69,7 +78,7 @@ class FetcherConfigTest extends TestCase
      */
     public function testGetClient()
     {
-        $this->class = new FetcherConfig($this->config, $this->sysconfig, $this->appmanager);
+        $this->class = new FetcherConfig($this->config, $this->sysconfig, $this->appmanager, $this->logger);
 
         $this->assertInstanceOf(FeedIoClient::class, $this->class->getClient());
     }
@@ -87,7 +96,7 @@ class FetcherConfigTest extends TestCase
                          ->method('getAppVersion')
                          ->willReturn('123.45');
 
-        $this->class = new FetcherConfig($this->config, $this->sysconfig, $this->appmanager);
+        $this->class = new FetcherConfig($this->config, $this->sysconfig, $this->appmanager, $this->logger);
 
         $expected = 'NextCloud-News/123.45';
         $response = $this->class->getUserAgent();
@@ -107,7 +116,7 @@ class FetcherConfigTest extends TestCase
                          ->method('getAppVersion')
                          ->willReturn('1.0');
 
-        $this->class = new FetcherConfig($this->config, $this->sysconfig, $this->appmanager);
+        $this->class = new FetcherConfig($this->config, $this->sysconfig, $this->appmanager, $this->logger);
 
         $expected = 'NextCloud-News/1.0';
         $response = $this->class->getUserAgent();

--- a/tests/Unit/Config/FetcherConfigTest.php
+++ b/tests/Unit/Config/FetcherConfigTest.php
@@ -122,4 +122,31 @@ class FetcherConfigTest extends TestCase
         $response = $this->class->getUserAgent();
         $this->assertEquals($expected, $response);
     }
+
+    public function testProxyPortPreserved()
+    {
+        $this->config->expects($this->exactly(2))
+                     ->method('getValueInt')
+                     ->willReturnMap([
+                        ['news', 'feedFetcherTimeout', 60, false, 60],
+                        ['news', 'maxRedirects', 10, false, 10]
+                     ]);
+
+        $this->appmanager->expects($this->exactly(1))
+                         ->method('getAppVersion')
+                         ->willReturn('1.0');
+
+        $this->sysconfig->expects($this->exactly(2))
+                        ->method('getSystemValue')
+                        ->willReturnMap([
+                            ['proxy', null, 'http://192.168.178.1:80'],
+                            ['proxyuserpwd', null , null]
+                        ]);
+
+        $this->class = new FetcherConfig($this->config, $this->sysconfig, $this->appmanager, $this->logger);
+        
+        $expected = 'http://192.168.178.1:80';
+        $response = $this->class->getProxy();
+        $this->assertEquals($expected, $response);
+        }
 }


### PR DESCRIPTION
* Related: https://github.com/nextcloud/news/issues/2982

## Summary

Add debug logging for the proxy configuration

And add nano to the docker image to edit files.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
