### PR TITLE
feat: show error message from opml import in web-ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ## [25.x.x]
 ### Changed
 - add explanations for the individual values in the feed information table
+- show error message from `opml` import in web-ui
 
 ### Fixed
 

--- a/lib/Controller/ImportController.php
+++ b/lib/Controller/ImportController.php
@@ -14,6 +14,7 @@
 namespace OCA\News\Controller;
 
 use OCA\News\Service\OpmlService;
+use OCA\News\Service\Exceptions\ServiceValidationException;
 use \OCP\IRequest;
 use OCP\IUserSession;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -38,7 +39,7 @@ class ImportController extends Controller
 
     #[NoCSRFRequired]
     #[NoAdminRequired]
-    public function opml(): void
+    public function opml(): array
     {
         $data = '';
         if (isset($this->request->files['file'])) {
@@ -49,6 +50,21 @@ class ImportController extends Controller
         }
 
 
-        $this->opmlService->import($this->getUserId(), $data);
+        $status = '';
+        $message = '';
+        try {
+            $this->opmlService->import($this->getUserId(), $data);
+            $status = "ok";
+        } catch (ServiceValidationException $e) {
+            $status = "error";
+            $message = $e->getMessage();
+        }
+
+        $response = [
+            'status' => $status,
+            'message' => $message,
+        ];
+
+        return $response;
     }
 }

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -540,7 +540,12 @@ export default Vue.extend({
 				})
 
 				if (response.ok) {
-					showSuccess(t('news', 'File successfully uploaded'))
+					const data = await response.json()
+					if (data.status === 'ok') {
+						showSuccess(t('news', 'File successfully uploaded'))
+					} else {
+						showError(data.message, { timeout: -1 })
+					}
 				} else {
 					showError(t('news', 'Error uploading the opml file'))
 				}


### PR DESCRIPTION
* Related: #3035  

## Summary

Return opml import error message as api response to show it in the web-ui.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
