### PR TITLE
disable new setting nextUpdateTime by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 - add explanations for the individual values in the feed information table
 - show error message from `opml` import in web-ui
+- disable new setting "nextUpdateTime" introduced in #2999 by default
 
 ### Fixed
 - fix proxy port removed if standard port for the protocol (#3027)

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -63,6 +63,8 @@ The update interval is used to determine when the next update of all feeds shoul
 By default, the value is set to 3600 seconds (1 hour) You can configure this interval as an administrator.
 The new value is only applied after the next run of the updater.
 
-Since News 25.2.0 News no longer will update all feeds instead it will make a individual decision based on when an update for the feed will make sense. Therefore this interval is now only to be understood as the check if an update should be done.
+Starting with News 25.2.0, the app can dynamically adjust update schedules based on feed activity. This feature, disabled by default, can be enabled by the Nextcloud administrator.
 
-This behavior can be disabled in the Settings although we generally do not recommend that.
+By analyzing feed data, the app can optimize update frequencies, potentially reducing server load and network traffic. However, this feature may not work correctly with all feeds.
+
+Users can check the calculated next update time in the app's settings. This information will only be displayed when the dynamic update scheduling feature is enabled.

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -67,7 +67,7 @@ class Application extends App implements IBootstrap
         'useCronUpdates'           => true,
         'exploreUrl'               => '',
         'updateInterval'           => 3600,
-        'useNextUpdateTime'        => true,
+        'useNextUpdateTime'        => false,
     ];
 
     public function __construct(array $urlParams = [])


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Due to the potential issues and complaining by users I prefer to disable this feature by default.
For me it works as is and reduces the fetching of the feeds that are less active.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
