### PR TITLE
show url directly in log message

### DIFF
--- a/lib/Service/FeedServiceV2.php
+++ b/lib/Service/FeedServiceV2.php
@@ -299,7 +299,7 @@ class FeedServiceV2 extends Service
             $tolerance = 10 * 60; // 10 minutes tolerance
 
             if ($nextUpdateTime !== null && ($currentTime + $tolerance) < $nextUpdateTime) {
-                $this->logger->info('Feed update skipped. Next update time not reached.', [
+                $this->logger->info('Update for {feedURL} skipped. Next update time not reached.', [
                     'feedUrl' => $feed->getUrl(),
                     'nextUpdateTime' => $nextUpdateTime,
                     'currentTime' => $currentTime,


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

I noticed that the current logger will show the variables only in the details hidden in a menu.
Which is fine for the timestamps I guess.
But I think at least the url should show up in the logs.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
