### PR TITLE
Improve mobile view by using `horizontal-split` mobile layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [25.x.x]
 ### Changed
-
+- Set mobileLayout to `horizontal-split` and add nav buttons for articles in mobile view
 ### Fixed
 
 

--- a/src/components/ContentTemplate.vue
+++ b/src/components/ContentTemplate.vue
@@ -1,6 +1,7 @@
 <template>
 	<NcAppContent :layout="layout"
 		:show-details="showDetails"
+		:mobile-layout="'horizontal-split'"
 		:list-max-width="100"
 		@update:showDetails="showItem(false)">
 		<template #list>

--- a/src/components/ContentTemplate.vue
+++ b/src/components/ContentTemplate.vue
@@ -26,7 +26,6 @@
 			<div ref="contentElement" class="feed-item-content-wrapper">
 				<FeedItemDisplay v-if="selectedFeedItem"
 					:item="selectedFeedItem"
-					:hide-item-nav="layout === 'no-split'"
 					@show-details="showItem(false)" />
 				<NcEmptyContent v-else
 					style="margin-top: 20vh"

--- a/src/components/ContentTemplate.vue
+++ b/src/components/ContentTemplate.vue
@@ -26,6 +26,7 @@
 			<div ref="contentElement" class="feed-item-content-wrapper">
 				<FeedItemDisplay v-if="selectedFeedItem"
 					:item="selectedFeedItem"
+					:hide-item-nav="layout === 'no-split'"
 					@show-details="showItem(false)" />
 				<NcEmptyContent v-else
 					style="margin-top: 20vh"

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -7,7 +7,7 @@
 		<ShareItem v-if="showShareMenu" :item-id="item.id" @close="closeShareMenu()" />
 
 		<div class="action-bar">
-			<NcActions v-show="!hideItemNav"
+			<NcActions v-show="!splitModeOff"
 				class="action-bar-nav"
 				:inline="4">
 				<NcActionButton :title="t('news', 'Previous Item')"
@@ -212,10 +212,6 @@ export default Vue.extend({
 			type: Number,
 			required: false,
 			default: null,
-		},
-		hideItemNav: {
-			type: Boolean,
-			default: false,
 		},
 	},
 	data: () => {

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -7,7 +7,7 @@
 		<ShareItem v-if="showShareMenu" :item-id="item.id" @close="closeShareMenu()" />
 
 		<div class="action-bar">
-			<NcActions :inline="4" style="flex-grow: 1;" v-show="!hideItemNav">
+			<NcActions class='action-bar-nav' :inline="4" style="flex-grow: 1;" v-show="!hideItemNav">
 				<NcActionButton :title="t('news', 'Previous Item')"
 					@click="$root.$emit('prev-item')">
 					{{ t('news', 'Previous') }}
@@ -310,7 +310,9 @@ export default Vue.extend({
 
 </script>
 
-<style>
+<style lang="scss">
+	$breakpoint-mobile: 1024px;
+
 	.feed-item-display {
 		overflow-y: hidden;
 		display: flex;
@@ -403,7 +405,13 @@ export default Vue.extend({
 		padding: 10px 20px 0px 20px;
 
 		display: flex;
-		justify-content: right
+		justify-content: right;
+	}
+
+	.action-bar-nav {
+		@media only screen and (width > $breakpoint-mobile) {
+			display: none !important;
+		}
 	}
 
 	.feed-item-display .action-bar .button-vue,
@@ -414,4 +422,5 @@ export default Vue.extend({
 		min-height: 30px;
 		height: 30px;
 	}
+
 </style>

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -7,6 +7,22 @@
 		<ShareItem v-if="showShareMenu" :item-id="item.id" @close="closeShareMenu()" />
 
 		<div class="action-bar">
+			<NcActions :inline="4" style="flex-grow: 1;">
+				<NcActionButton :title="t('news', 'Previous Item')"
+					@click="$root.$emit('prev-item')">
+					{{ t('news', 'Previous') }}
+					<template #icon>
+						<ArrowLeftThickIcon />
+					</template>
+				</NcActionButton>
+				<NcActionButton :title="t('news', 'Next Item')"
+					@click="$root.$emit('next-item')">
+					{{ t('news', 'Next') }}
+					<template #icon>
+						<ArrowRightThickIcon />
+					</template>
+				</NcActionButton>
+			</NcActions>
 			<NcActions :inline="4">
 				<NcActionButton :title="t('news', 'Share within Instance')"
 					@click="showShareMenu = true">
@@ -152,6 +168,8 @@ import { mapState } from 'vuex'
 import ShareVariant from 'vue-material-design-icons/ShareVariant.vue'
 import StarIcon from 'vue-material-design-icons/Star.vue'
 import CloseIcon from 'vue-material-design-icons/Close.vue'
+import ArrowLeftThickIcon from 'vue-material-design-icons/ArrowLeftThick.vue'
+import ArrowRightThickIcon from 'vue-material-design-icons/ArrowRightThick.vue'
 
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
@@ -175,6 +193,8 @@ export default Vue.extend({
 		NcActions,
 		NcActionButton,
 		ShareItem,
+		ArrowLeftThickIcon,
+		ArrowRightThickIcon
 	},
 	props: {
 		item: {

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -7,7 +7,9 @@
 		<ShareItem v-if="showShareMenu" :item-id="item.id" @close="closeShareMenu()" />
 
 		<div class="action-bar">
-			<NcActions class='action-bar-nav' :inline="4" style="flex-grow: 1;" v-show="!hideItemNav">
+			<NcActions v-show="!hideItemNav"
+				class="action-bar-nav"
+				:inline="4">
 				<NcActionButton :title="t('news', 'Previous Item')"
 					@click="$root.$emit('prev-item')">
 					{{ t('news', 'Previous') }}
@@ -194,7 +196,7 @@ export default Vue.extend({
 		NcActionButton,
 		ShareItem,
 		ArrowLeftThickIcon,
-		ArrowRightThickIcon
+		ArrowRightThickIcon,
 	},
 	props: {
 		item: {
@@ -213,8 +215,8 @@ export default Vue.extend({
 		},
 		hideItemNav: {
 			type: Boolean,
-			default: false
-		}
+			default: false,
+		},
 	},
 	data: () => {
 		return {
@@ -409,6 +411,8 @@ export default Vue.extend({
 	}
 
 	.action-bar-nav {
+		flex-grow: 1;
+
 		@media only screen and (width > $breakpoint-mobile) {
 			display: none !important;
 		}

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -7,7 +7,7 @@
 		<ShareItem v-if="showShareMenu" :item-id="item.id" @close="closeShareMenu()" />
 
 		<div class="action-bar">
-			<NcActions :inline="4" style="flex-grow: 1;">
+			<NcActions :inline="4" style="flex-grow: 1;" v-show="!hideItemNav">
 				<NcActionButton :title="t('news', 'Previous Item')"
 					@click="$root.$emit('prev-item')">
 					{{ t('news', 'Previous') }}
@@ -211,6 +211,10 @@ export default Vue.extend({
 			required: false,
 			default: null,
 		},
+		hideItemNav: {
+			type: Boolean,
+			default: false
+		}
 	},
 	data: () => {
 		return {

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -225,6 +225,8 @@ export default Vue.extend({
 	mounted() {
 		this.mounted = true
 		this.setupDebouncedClick()
+		this.$root.$on('next-item',this.jumpToNextItem)
+		this.$root.$on('prev-item',this.jumpToPreviousItem)
 	},
 	methods: {
 		async refreshApp() {

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -320,12 +320,12 @@ export default Vue.extend({
 			const element = componentInstance ? componentInstance.$el : undefined
 
 			if (element) {
-				this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: item.id })
-				this.$store.dispatch(ACTIONS.MARK_READ, { item })
 				const virtualScroll = this.$refs.virtualScroll
 				virtualScroll.showElement(element)
-
 			}
+
+			this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: item.id })
+			this.$store.dispatch(ACTIONS.MARK_READ, { item })
 		},
 		currentIndex(items: FeedItem[]): number {
 			return this.selectedItem ? items.findIndex((item: FeedItem) => item.id === this.selectedItem.id) || 0 : -1

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -225,8 +225,8 @@ export default Vue.extend({
 	mounted() {
 		this.mounted = true
 		this.setupDebouncedClick()
-		this.$root.$on('next-item',this.jumpToNextItem)
-		this.$root.$on('prev-item',this.jumpToPreviousItem)
+		this.$root.$on('next-item', this.jumpToNextItem)
+		this.$root.$on('prev-item', this.jumpToPreviousItem)
 	},
 	methods: {
 		async refreshApp() {

--- a/src/components/feed-display/FeedItemRow.vue
+++ b/src/components/feed-display/FeedItemRow.vue
@@ -275,7 +275,10 @@ export default Vue.extend({
 
 	.feed-item-row .title-container.compact {
 		flex: 0 1 auto;
-		overflow: unset;
+		overflow-y: unset;
+		overflow-x: scroll;
+		max-width: 100%;
+		text-overflow: clip;
 	}
 
 	.feed-item-row .intro-container {
@@ -285,7 +288,7 @@ export default Vue.extend({
 	}
 
 	.feed-item-row .intro-container.compact {
-		flex: 1 1 auto;
+		flex: 1 1;
 		height: 26pt !important;
 		align-content: center;
 		text-overflow: ellipsis;


### PR DESCRIPTION
## Summary
Uses new `mobileLayout` prop of `NcAppContent` from https://github.com/nextcloud-libraries/nextcloud-vue/pull/6364 and sets to `horizontal-split`
Adds Navigation Arrows to top of `FeedItemDisplay` to go to next/previous item when in mobile view

Depends on https://github.com/nextcloud-libraries/nextcloud-vue/pull/6364

## Checklist

- [x] Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Changelog entry added for all important changes.
