### PR TITLE
fix: show error on folders only if at least one feed has more than eight errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 # Unreleased
 ## [25.x.x]
+### Changed
 
+### Fixed
+- Show error on folders only if at least one feed has more than eight errors
 
 # Releases
-## [25.0.0] - 2025-01-10
+## [25.2.0] - 2025-01-10
 ### Changed
 - add explanations for the individual values in the feed information table (#3031)
 - show error message from `opml` import in web-ui (#3036)

--- a/src/store/folder.ts
+++ b/src/store/folder.ts
@@ -100,7 +100,9 @@ export const mutations = {
 			if (folder) {
 				folder.feeds.push(it)
 				folder.feedCount += it.unreadCount
-				folder.updateErrorCount += it.updateErrorCount
+				if (it.updateErrorCount > 8) {
+					folder.updateErrorCount += it.updateErrorCount
+				}
 			}
 		})
 		state.folders = updatedFolders


### PR DESCRIPTION
* Resolves: #3064 

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
