### PR TITLE
Limit the max nextUpdateTime delay to 24 hour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ## [25.x.x]
 ### Changed
 - Set mobileLayout to `horizontal-split` and add nav buttons for articles in mobile view
+- set the duration after which a feed is considered sleepy to 7 days when using `nextUpdateTime`
+- limit the time to the next update to a maximum of 24 hours when using `nextUpdateTime`
+
 ### Fixed
 - Show error on folders only if at least one feed has more than eight errors
 

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -65,6 +65,6 @@ The new value is only applied after the next run of the updater.
 
 Starting with News 25.2.0, the app can dynamically adjust update schedules based on feed activity. This feature, disabled by default, can be enabled by the Nextcloud administrator.
 
-By analyzing feed data, the app can optimize update frequencies, potentially reducing server load and network traffic. However, this feature may not work correctly with all feeds.
+By analyzing feed data, the app can optimize update frequencies, potentially reducing server load and network traffic. The time until the next calculated update point is limited to a maximum of 24 hours. However, this feature may not work correctly with all feeds.
 
 Users can check the calculated next update time in the app's settings. This information will only be displayed when the dynamic update scheduling feature is enabled.

--- a/lib/Config/FetcherConfig.php
+++ b/lib/Config/FetcherConfig.php
@@ -72,7 +72,7 @@ class FetcherConfig
      * Duration after which the feed is considered sleepy.
      * @var int
      */
-    public const SLEEPY_DURATION = 86400;
+    public const SLEEPY_DURATION = 7 * 86400;
 
     /**
      * Logger

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -149,9 +149,10 @@ class FeedFetcher implements IFeedFetcher
             $location
         );
 
-        $feed->setNextUpdateTime(nextUpdateTime: $resource->getNextUpdate(
+        // Set the next calculated update time, but maximum 24 hours from now
+        $feed->setNextUpdateTime(nextUpdateTime: min($resource->getNextUpdate(
             sleepyDuration: $this->fetcherConfig::SLEEPY_DURATION
-        )?->getTimestamp());
+        )?->getTimestamp(), time() + 86400));
 
         $this->logger->debug(
             'Feed {url} was parsed and nextUpdateTime is {nextUpdateTime}',


### PR DESCRIPTION
## Summary

As discussed in #3013 the nextUpdateTime feed-io calculates is not always accurate and can push the next update too far in the future.
https://github.com/alexdebril/feed-io/pull/434 will fix some problems, but for feeds with sporadic articles an accurate calculation is impossible.
Therefore, the maximum next update time should be limited to 24 hours, which is also the value used when a feed is recognized as sleeping.
This PR also sets the sleepy feed detection to the default of 7 days, which should work for most feeds. A small value like one or two days can cause feeds that have for example no posts on the weekend, not being downloaded until monday evening.


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
