### PR TITLE
Fix bats integration opml test

### DIFF
--- a/tests/command/opml.bats
+++ b/tests/command/opml.bats
@@ -1,6 +1,10 @@
 #!/usr/bin/env bats
 
-load "helpers/settings"
+setup(){
+  load "../test_helper/bats-support/load"
+  load "../test_helper/bats-assert/load"
+  load "helpers/settings"
+}
 
 TESTSUITE="OPML"
 
@@ -12,15 +16,13 @@ teardown() {
 }
 
 @test "[$TESTSUITE] Export" {
-  run ./occ news:feed:add "$user" "https://nextcloud.com/blog/static-feed/"  --title "Something-${BATS_SUITE_TEST_NUMBER}"
-  [ "$status" -eq 0 ]
+  run ./occ news:feed:add "$user" "$NC_FEED" --title "Something-${BATS_SUITE_TEST_NUMBER}"
+  assert_success
 
   run ./occ news:opml:export "$user"
-  [ "$status" -eq 0 ]
+  assert_success
 
-  if ! echo "$output" | grep "https://nextcloud.com/"; then
-    ret_status=$?
-    echo "Feed not exported"
-    return $ret_status
+  if ! echo "$output" | grep "Something-${BATS_SUITE_TEST_NUMBER}"; then
+    assert_output --partial "Feed not exported"
   fi
 }

--- a/tests/command/opml.bats
+++ b/tests/command/opml.bats
@@ -15,6 +15,18 @@ teardown() {
   done
 }
 
+@test "[$TESTSUITE] Import" {
+  run ./occ news:opml:import "$user" apps/news/tests/test_helper/feeds/Nextcloud.opml
+  assert_success
+
+  run ./occ news:feed:list "$user"
+  assert_success
+
+  if ! echo "$output" | grep "title.*Nextcloud"; then
+    assert_output --partial "Feed not imported"
+  fi
+}
+
 @test "[$TESTSUITE] Export" {
   run ./occ news:feed:add "$user" "$NC_FEED" --title "Something-${BATS_SUITE_TEST_NUMBER}"
   assert_success

--- a/tests/test_helper/feeds/Nextcloud.opml
+++ b/tests/test_helper/feeds/Nextcloud.opml
@@ -1,0 +1,9 @@
+<opml version="2.0">
+  <head>
+    <title>Subscriptions</title>
+  </head>
+  <body>
+    <outline title="Nextcloud" text="Nextcloud" type="rss" xmlUrl="http://localhost:8090/Nextcloud.rss" htmlUrl="https://nextcloud.com/"/>
+  </body>
+</opml>
+


### PR DESCRIPTION
## Summary

The  integration tests currently fails because the external feed https://nextcloud.com/blog/static-feed/ used in the opml test is actual not valid.

Changes:
* use local feed like the other tests
* add opml import test

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
