### PR TITLE
catch TypeErrors happening during scraping

### DIFF
--- a/lib/Scraper/Scraper.php
+++ b/lib/Scraper/Scraper.php
@@ -17,6 +17,7 @@ use fivefilters\Readability\ParseException;
 use League\Uri\Exceptions\SyntaxError;
 use Psr\Log\LoggerInterface;
 use OCA\News\Config\FetcherConfig;
+use TypeError;
 
 class Scraper implements IScraper
 {
@@ -76,7 +77,7 @@ class Scraper implements IScraper
 
         try {
             $this->readability->parse($content);
-        } catch (ParseException | SyntaxError $e) {
+        } catch (ParseException | SyntaxError | TypeError $e) {
             $this->logger->error('Unable to parse content from {url}', [
                  'url' => $url,
             ]);


### PR DESCRIPTION
* Resolves: #3102

## Summary
Apparently TypeErrors can happen too if the content is very strange, we catch it so the feed update can continue.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
