### PR TITLE
fix 3114, proxy url without schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 
 ### Fixed
+- Fix proxy configuration without schema -> default http:// (#3115)
 
 # Releases
 ## [25.3.0] - 2025-03-05

--- a/lib/Config/FetcherConfig.php
+++ b/lib/Config/FetcherConfig.php
@@ -125,9 +125,16 @@ class FetcherConfig
             $url = $url->withUserInfo($auth[0], $auth[1]);
         }
 
+        // prevent broken scheme '//'
+        $scheme = $url->getScheme();
+
+        if ($scheme !== 'http' && $scheme !== 'https') {
+            $url = $url->withScheme('http');
+            $scheme = $url->getScheme();
+        }
+
         //Uri removes standard ports by default, therefore we add it manually
         $url_string = (string) $url;
-        $scheme = $url->getScheme();
         $port = $url->getPort();
 
         if ($port === null && $scheme === 'http') {

--- a/tests/Unit/Config/FetcherConfigTest.php
+++ b/tests/Unit/Config/FetcherConfigTest.php
@@ -177,6 +177,33 @@ class FetcherConfigTest extends TestCase
         $this->assertEquals($expected, $response);
     }
 
+    public function testProxyIPNoSchema()
+    {
+        $this->config->expects($this->exactly(2))
+            ->method('getValueInt')
+            ->willReturnMap([
+                ['news', 'feedFetcherTimeout', 60, false, 60],
+                ['news', 'maxRedirects', 10, false, 10]
+            ]);
+
+        $this->appmanager->expects($this->exactly(1))
+            ->method('getAppVersion')
+            ->willReturn('1.0');
+
+        $this->sysconfig->expects($this->exactly(2))
+            ->method('getSystemValue')
+            ->willReturnMap([
+                ['proxy', null, '192.168.178.1:8080'],
+                ['proxyuserpwd', null, null]
+            ]);
+
+        $this->class = new FetcherConfig($this->config, $this->sysconfig, $this->appmanager, $this->logger);
+
+        $expected = 'http://192.168.178.1:8080';
+        $response = $this->class->getProxy();
+        $this->assertEquals($expected, $response);
+    }
+
     public function testProxyWithAuth()
     {
         $this->config->expects($this->exactly(2))
@@ -200,6 +227,60 @@ class FetcherConfigTest extends TestCase
         $this->class = new FetcherConfig($this->config, $this->sysconfig, $this->appmanager, $this->logger);
 
         $expected = 'https://admin:password@192.168.178.1:443';
+        $response = $this->class->getProxy();
+        $this->assertEquals($expected, $response);
+    }
+
+    public function testDomainProxy()
+    {
+        $this->config->expects($this->exactly(2))
+            ->method('getValueInt')
+            ->willReturnMap([
+                ['news', 'feedFetcherTimeout', 60, false, 60],
+                ['news', 'maxRedirects', 10, false, 10]
+            ]);
+
+        $this->appmanager->expects($this->exactly(1))
+            ->method('getAppVersion')
+            ->willReturn('1.0');
+
+        $this->sysconfig->expects($this->exactly(2))
+            ->method('getSystemValue')
+            ->willReturnMap([
+                ['proxy', null, 'apt.domain.net:3142'],
+                ['proxyuserpwd', null, null]
+            ]);
+
+        $this->class = new FetcherConfig($this->config, $this->sysconfig, $this->appmanager, $this->logger);
+
+        $expected = 'http://apt.domain.net:3142';
+        $response = $this->class->getProxy();
+        $this->assertEquals($expected, $response);
+    }
+
+    public function testDomainProxyWithAuth()
+    {
+        $this->config->expects($this->exactly(2))
+            ->method('getValueInt')
+            ->willReturnMap([
+                ['news', 'feedFetcherTimeout', 60, false, 60],
+                ['news', 'maxRedirects', 10, false, 10]
+            ]);
+
+        $this->appmanager->expects($this->exactly(1))
+            ->method('getAppVersion')
+            ->willReturn('1.0');
+
+        $this->sysconfig->expects($this->exactly(2))
+            ->method('getSystemValue')
+            ->willReturnMap([
+                ['proxy', null, 'apt.domain.net:3142'],
+                ['proxyuserpwd', null, 'admin:password']
+            ]);
+
+        $this->class = new FetcherConfig($this->config, $this->sysconfig, $this->appmanager, $this->logger);
+
+        $expected = 'http://admin:password@apt.domain.net:3142';
         $response = $this->class->getProxy();
         $this->assertEquals($expected, $response);
     }


### PR DESCRIPTION
* Resolves: #3114

## Summary

If guzzle finds no schema it only adds // therefore we default to http

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
