### PR TITLE
fix: sort feeds case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [25.x.x]
 ### Changed
+- Sort feeds case-insensitive
 
 ### Fixed
 - Fix proxy configuration without schema -> default http:// (#3115)

--- a/src/store/feed.ts
+++ b/src/store/feed.ts
@@ -218,12 +218,16 @@ export const mutations = {
 		state: FeedState,
 		feeds: Feed[],
 	) {
-		feeds.forEach(it => {
+		state.feeds = feeds.sort((a, b) => {
+			if (!a.title) return -1 // sort undefined title at top
+			if (!b.title) return 1
+			return a.title.localeCompare(b.title, undefined, { sensitivity: 'base' })
+		}).map(it => {
 			if (typeof it?.ordering === 'number') {
 				state.ordering['feed-' + it.id] = it.ordering
 			}
+			return it
 		})
-		state.feeds = [...feeds]
 	},
 
 	[FEED_MUTATION_TYPES.ADD_FEED](


### PR DESCRIPTION
* Resolves: #3097

## Summary

Actual the frontend gets the feeds sorted from the backend, but because the default for case sensitivity depends on the used database and the nextcloud QueryBuilder seems to have no option, sort the feeds in the frontend.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
