### PR TITLE
Switch to useHotKey from @nextcloud/vue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 
 ### Fixed
+- respect global `disable all keyboard shortcuts` setting
+- disable shortcuts in input fields from global overlays (e.g. Nextcloud assistant)
 
 # Releases
 ## [25.3.1] - 2025-03-25

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "lodash": "^4.17.21",
         "vue": "^2.7.16",
         "vue-router": "^3.5.3",
-        "vue-shortkey": "^3.1.7",
         "vuex": "^3.6.2"
       },
       "devDependencies": {
@@ -7886,12 +7885,6 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
-    "node_modules/custom-event-polyfill": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz",
-      "integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w==",
-      "license": "MIT"
-    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -8527,12 +8520,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.88.tgz",
       "integrity": "sha512-K3C2qf1o+bGzbilTDCTBhTQcMS9KW60yTAaTeeXsfvQuTDDwlokLam/AdqlqcSy9u4UainDgsHV23ksXAOgamw==",
       "license": "ISC"
-    },
-    "node_modules/element-matches": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/element-matches/-/element-matches-0.1.2.tgz",
-      "integrity": "sha512-yWh1otcs3OKUWDvu/IxyI36ZI3WNaRZlI0uG/DK6fu0pap0VYZ0J5pEGTk1zakme+hT0OKHwhlHc0N5TJhY6yQ==",
-      "license": "MIT (https://jelmer.mit-license.org/)"
     },
     "node_modules/elliptic": {
       "version": "6.6.1",
@@ -20642,16 +20629,6 @@
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.6.5.tgz",
       "integrity": "sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ==",
       "license": "MIT"
-    },
-    "node_modules/vue-shortkey": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/vue-shortkey/-/vue-shortkey-3.1.7.tgz",
-      "integrity": "sha512-Wm/vPXXS+4Wl/LoYpD+cZc0J0HIoVlY8Ep0JLIqqswmAya3XUBtsqKbhzEf9sXo+3rZ5p1YsUyZfXas8XD7YjQ==",
-      "license": "MIT",
-      "dependencies": {
-        "custom-event-polyfill": "^1.0.7",
-        "element-matches": "^0.1.2"
-      }
     },
     "node_modules/vue-style-loader": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "lodash": "^4.17.21",
     "vue": "^2.7.16",
     "vue-router": "^3.5.3",
-    "vue-shortkey": "^3.1.7",
     "vuex": "^3.6.2"
   },
   "browserslist": [

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -139,18 +139,6 @@
 					<EarthIcon />
 				</template>
 			</NcAppNavigationItem>
-			<button v-shortkey="['d']" class="hidden" @shortkey="nextFeed('prev')">
-				prevFeed
-			</button>
-			<button v-shortkey="['f']" class="hidden" @shortkey="nextFeed('next')">
-				nextFeed
-			</button>
-			<button v-shortkey="['c']" class="hidden" @shortkey="nextFolder('prev')">
-				prevFolder
-			</button>
-			<button v-shortkey="['v']" class="hidden" @shortkey="nextFolder('next')">
-				nextFolder
-			</button>
 		</template>
 		<template #footer>
 			<NcAppNavigationSettings :name="t('news', 'Settings')">
@@ -283,6 +271,7 @@ import NcAppNavigationSettings from '@nextcloud/vue/dist/Components/NcAppNavigat
 import NcCounterBubble from '@nextcloud/vue/dist/Components/NcCounterBubble.js'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
 
 import RssIcon from 'vue-material-design-icons/Rss.vue'
 import FolderIcon from 'vue-material-design-icons/Folder.vue'
@@ -486,6 +475,11 @@ export default Vue.extend({
 				this.$store.dispatch(ACTIONS.FETCH_FEEDS)
 			}, 60000)
 		}
+		// create shortcuts for feed/folder navigation
+		useHotKey('d', this.prevFeed)
+		useHotKey('f', this.nextFeed)
+		useHotKey('c', this.prevFolder)
+		useHotKey('v', this.nextFolder)
 	},
 	mounted() {
 		subscribe('news:global:toggle-help-dialog', () => {
@@ -708,7 +702,7 @@ export default Vue.extend({
 				return direction === 'prev' ? folderIndex - 1 : folderIndex + 1
 			}
 		},
-		nextFeed(direction) {
+		switchFeed(direction) {
 			const newIndex = this.getFeedIndex(direction)
 			if (newIndex >= 0 && newIndex < this.navFeeds.length) {
 				const feedId = this.navFeeds[newIndex].id.toString()
@@ -717,13 +711,25 @@ export default Vue.extend({
 
 			}
 		},
-		nextFolder(direction) {
+		prevFeed() {
+			this.switchFeed('prev')
+		},
+		nextFeed() {
+			this.switchFeed('next')
+		},
+		switchFolder(direction) {
 			const newIndex = this.getFolderIndex(direction)
 			if (newIndex >= 0 && newIndex < this.navFolder.length) {
 				const folderId = this.navFolder[newIndex].id.toString()
 				this.$router.push({ name: 'folder', params: { folderId } })
 				this.$refs['folder-' + folderId][0].$el.scrollIntoView({ behavior: 'auto', block: 'nearest' })
 			}
+		},
+		prevFolder() {
+			this.switchFolder('prev')
+		},
+		nextFolder() {
+			this.switchFolder('next')
 		},
 	},
 })

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -34,7 +34,7 @@
 					</template>
 				</NcActionButton>
 				<NcActionButton :title="t('news', 'Toggle star article')"
-					@click="toggleStarred(item)">
+					@click="toggleStarred">
 					{{ t('news', 'Toggle star article') }}
 					<template #icon>
 						<StarIcon :class="{'starred': item.starred }" :size="24" />
@@ -42,7 +42,7 @@
 				</NcActionButton>
 				<NcActionButton v-if="item.unread"
 					:title="t('news', 'Mark read')"
-					@click="toggleRead(item)">
+					@click="toggleRead">
 					{{ t('news', 'Mark read') }}
 					<template #icon>
 						<EyeIcon :size="24" />
@@ -50,7 +50,7 @@
 				</NcActionButton>
 				<NcActionButton v-if="!item.unread"
 					:title="t('news', 'Mark unread')"
-					@click="toggleRead(item)">
+					@click="toggleRead">
 					{{ t('news', 'Mark unread') }}
 					<template #icon>
 						<EyeCheckIcon :size="24" />
@@ -65,24 +65,6 @@
 					</template>
 				</NcActionButton>
 			</NcActions>
-			<button v-if="splitModeOff"
-				v-shortkey="{s: ['s'], l: ['l'], i: ['i']}"
-				class="hidden"
-				@shortkey="toggleStarred(item)">
-				toggleStarred
-			</button>
-			<button v-if="splitModeOff"
-				v-shortkey="['u']"
-				class="hidden"
-				@shortkey="toggleRead(item)">
-				toggleRead
-			</button>
-			<button v-if="splitModeOff && !screenReaderMode"
-				v-shortkey="['esc']"
-				class="hidden"
-				@shortkey="$emit('show-details')">
-				closeDetails
-			</button>
 		</div>
 		<div class="article">
 			<div class="heading">
@@ -175,6 +157,7 @@ import ArrowRightThickIcon from 'vue-material-design-icons/ArrowRightThick.vue'
 
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
+import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
 
 import ShareItem from '../ShareItem.vue'
 
@@ -229,6 +212,16 @@ export default Vue.extend({
 			return this.$store.getters.splitmode === '2'
 		},
 	},
+	created() {
+		// create shortcuts
+		if (this.splitModeOff) {
+			useHotKey(['s', 'l', 'i'], this.toggleStarred)
+			useHotKey('u', this.toggleRead)
+		}
+		if (this.splitModeOff && !this.screenReaderMode) {
+			useHotKey('Escape', this.closeDetails)
+		}
+	},
 	methods: {
 		/**
 		 * Sends message to state to clear the selectedId number
@@ -266,18 +259,16 @@ export default Vue.extend({
 		},
 		/**
 		 * Sends message to change the items starred property to the opposite value
-		 *
-		 * @param {FeedItem} item item to toggle starred status on
 		 */
-		toggleStarred(item: FeedItem): void {
-			this.$store.dispatch(item.starred ? ACTIONS.UNSTAR_ITEM : ACTIONS.STAR_ITEM, { item })
+		toggleStarred(): void {
+			this.$store.dispatch(this.item.starred ? ACTIONS.UNSTAR_ITEM : ACTIONS.STAR_ITEM, { item: this.item })
 		},
 
-		toggleRead(item: FeedItem): void {
-			if (!item.keepUnread && item.unread) {
-				this.$store.dispatch(ACTIONS.MARK_READ, { item })
+		toggleRead(): void {
+			if (!this.item.keepUnread && this.item.unread) {
+				this.$store.dispatch(ACTIONS.MARK_READ, { item: this.item })
 			} else {
-				this.$store.dispatch(ACTIONS.MARK_UNREAD, { item })
+				this.$store.dispatch(ACTIONS.MARK_UNREAD, { item: this.item })
 			}
 		},
 
@@ -302,6 +293,9 @@ export default Vue.extend({
 			for (let i = 0; i < audioElements.length; i++) {
 				audioElements[i].pause()
 			}
+		},
+		closeDetails() {
+			this.$emit('show-details')
 		},
 	},
 })

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,5 @@
 import Vue from 'vue'
 import VueRouter from 'vue-router'
-import VueShortKey from 'vue-shortkey'
 import Vuex, { Store } from 'vuex'
 import axios from '@nextcloud/axios'
 
@@ -17,7 +16,6 @@ Vue.prototype.OCA = OCA
 
 Vue.use(Vuex)
 Vue.use(VueRouter)
-Vue.use(VueShortKey, { prevent: ['input', 'textarea'] })
 
 Vue.directive('tooltip', Tooltip)
 


### PR DESCRIPTION
Related: #2916

## Summary

Switching to useHotKey solves several problems with text-input fields, it also respects the  `disable all keyboard shortcuts` accessibility setting and is vue3 ready due the upcoming nextcloud/vue v9 update.


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
