### PR TITLE
Drop support for Nextcloud 29

### DIFF
--- a/.github/workflows/api-integration-tests.yml
+++ b/.github/workflows/api-integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.2', '8.3']
-        nextcloud: ['stable29']
+        nextcloud: ['stable30']
         database: ['sqlite', 'pgsql', 'mysql']
         experimental: [false]
         include:

--- a/.github/workflows/api-php-static-code-check.yml
+++ b/.github/workflows/api-php-static-code-check.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.2', '8.3' ]
-        nextcloud: [ 'stable29' ]
+        nextcloud: [ 'stable30' ]
         database: [ 'sqlite' ]
         include:
           - php-versions: 8.3

--- a/.github/workflows/api-php-tests.yml
+++ b/.github/workflows/api-php-tests.yml
@@ -10,12 +10,12 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.3']
-        nextcloud: ['stable29']
+        nextcloud: ['stable30']
         database: ['sqlite']
         experimental: [false]
         include:
           - php-versions: 8.3
-            nextcloud: stable29
+            nextcloud: stable30
             database: sqlite
             experimental: false
     steps:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.3']
-        nextcloud: ['stable29']
+        nextcloud: ['stable30']
         database: ['sqlite']
     steps:
       - name: Checkout

--- a/.github/workflows/frontend-nodejs-tests.yml
+++ b/.github/workflows/frontend-nodejs-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.3']
-        nextcloud: ['stable29']
+        nextcloud: ['stable30']
         database: ['sqlite']
         experimental: [false]
     steps:

--- a/.github/workflows/updater-test.yml
+++ b/.github/workflows/updater-test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.3']
-        nextcloud: ['stable29']
+        nextcloud: ['stable30']
         database: ['sqlite']
         experimental: [false]
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 You can also check [on GitHub](https://github.com/nextcloud/news/releases), the release notes there are generated automatically and include every pull request.
 
 # Unreleased
-## [25.x.x]
+## [26.x.x]
 ### Changed
+- Drop support for Nextcloud 29
 
 ### Fixed
 - respect global `disable all keyboard shortcuts` setting

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -55,7 +55,7 @@ Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
         <lib>json</lib>
 
         <owncloud max-version="0" min-version="0"/>
-        <nextcloud min-version="29" max-version="31"/>
+        <nextcloud min-version="30" max-version="31"/>
     </dependencies>
 
     <background-jobs>


### PR DESCRIPTION
## Summary

The change in #3142 don't work with Nextcloud 29, so with the next version no keyboard shortcut will work here.
The upcoming update to nextcloud/vue v9 will also no longer work with Nextcloud 29.
Nextcloud 29 is also EOL this month [Maintenance-and-Release-Schedule](https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
