### PR TITLE
Add feature to Group starred Items per Feed

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -41,7 +41,23 @@
 					<RssIcon />
 				</template>
 			</NcAppNavigationItem>
-			<NcAppNavigationItem :name="t('news', 'Starred')" icon="icon-starred" :to="{ name: ROUTES.STARRED }">
+			<NcAppNavigationItem :name="t('news', 'Starred')" icon="icon-starred" :to="{ name: ROUTES.STARRED }" :allow-collapse="true" :force-menu="true">
+				<template v-for="(group, index) in GroupedStars">
+					<NcAppNavigationItem
+						:key="group.feed.name"
+						:ref="'starredfeed-' + group.feed.id"
+						:name="group.feed.title"
+						:icon="''"
+						:to="{ name: ROUTES.STARREDFEED, params: { feedId: group.feed.id.toString() } }">
+						<template #icon>
+							<RssIcon v-if="!group.feed.faviconLink" />
+							<span v-if="group.feed.faviconLink" style="width: 16px; height: 16px; background-size: contain;" :style="{ 'backgroundImage': 'url(' + group.feed.faviconLink + ')' }" />
+						</template>
+						<template #counter>
+							<NcCounterBubble>{{ group.items.length }}</NcCounterBubble>
+						</template>
+					</NcAppNavigationItem>
+				</template>
 				<template #counter>
 					<NcCounterBubble :count="items.starredCount" />
 				</template>
@@ -283,6 +299,7 @@ import HelpModal from './modals/HelpModal.vue'
 import FeedInfoTable from './modals/FeedInfoTable.vue'
 import { Folder } from '../types/Folder'
 import { Feed } from '../types/Feed'
+import { FeedItem } from '../types/FeedItem'
 
 export default Vue.extend({
 	components: {
@@ -370,6 +387,23 @@ export default Vue.extend({
 			]
 
 			return navItems
+		},
+		GroupedStars(): Array<FeedItem> {
+			const GroupedStars = this.$store.getters.starred.reduce((groups, item: FeedItem) => {
+				const groupKey = item.feedId
+				if (!groups[groupKey]) {
+					let feed: Feed = this.$store.getters.feeds.find((feed: Feed) => feed.id === groupKey)
+					if (feed == undefined)
+						feed = {
+							id: groupKey,
+							title: t('news', 'Unknown feed')
+						}
+					groups[groupKey] = {items: [], feed}
+				}
+				groups[groupKey].items.push(item)
+				return groups
+			}, {})
+			return Object.values(GroupedStars);
 		},
 		loading: {
 			get() {

--- a/src/components/routes/Starred.vue
+++ b/src/components/routes/Starred.vue
@@ -25,9 +25,18 @@ export default Vue.extend({
 		ContentTemplate,
 		NcCounterBubble,
 	},
+	props: {
+		feedId: {
+			type: String,
+			required: false,
+		},
+	},
 	computed: {
 		...mapState(['items']),
 		starred(): FeedItem[] {
+			if (this.feedId) {
+				return this.$store.getters.starred.filter((item: FeedItem) => item.feedId == Number(this.feedId));
+			}
 			return this.$store.getters.starred
 		},
 	},

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -12,6 +12,7 @@ import store from './../store/app'
 export const ROUTES = {
 	EXPLORE: 'explore',
 	STARRED: 'starred',
+	STARREDFEED: 'starredfeed',
 	UNREAD: 'unread',
 	FEED: 'feed',
 	FOLDER: 'folder',
@@ -36,6 +37,9 @@ const getInitialRoute = function() {
 		}
 	case '2':
 		return { name: ROUTES.STARRED }
+	case '2.5':
+		params.feedId = store.state.lastViewedFeedId
+		return { name: ROUTES.STARREDFEED, params }
 	case '3':
 		return { name: ROUTES.ALL }
 	case '5':
@@ -62,6 +66,12 @@ const routes = [
 	{
 		name: ROUTES.STARRED,
 		path: '/starred',
+		component: StarredPanel,
+		props: true,
+	},
+	{
+		name: ROUTES.STARREDFEED,
+		path: '/starredfeeds/:feedId',
 		component: StarredPanel,
 		props: true,
 	},


### PR DESCRIPTION
## Summary

Add Ability to Group Starred Items per Feed. Grouped Feeds are visible under the collapse of starred items. Per Grouped Feed a count of Starred Items is listed. 

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
