### PR TITLE
fix: use @nextcloud/moment for formatted date strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Fixed
 - respect global `disable all keyboard shortcuts` setting
 - disable shortcuts in input fields from global overlays (e.g. Nextcloud assistant)
+- fix relative date strings
 
 # Releases
 ## [25.3.1] - 2025-03-25

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -106,7 +106,7 @@ import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadi
 import NcSettingsSection from '@nextcloud/vue/dist/Components/NcSettingsSection.js'
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
-import moment from '@nextcloud/moment'
+import { formatDateRelative } from '../utils/dateUtils'
 import { loadState } from '@nextcloud/initial-state'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
@@ -152,7 +152,7 @@ export default {
 			exploreUrl: loadState('news', 'exploreUrl'),
 			updateInterval: loadState('news', 'updateInterval'),
 			useNextUpdateTime: loadState('news', 'useNextUpdateTime') === '1',
-			relativeTime: moment(lastCron * 1000).fromNow(),
+			relativeTime: formatDateRelative(lastCron),
 			lastCron,
 		}
 	},

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -76,8 +76,8 @@
 						{{ item.title }}
 					</a>
 				</h1>
-				<time class="date" :title="formatDate(item.pubDate*1000, 'yyyy-MM-dd HH:mm:ss')" :datetime="formatDate(item.pubDate*1000, 'yyyy-MM-ddTHH:mm:ssZ')">
-					{{ formatDate(item.pubDate*1000) }}
+				<time class="date" :title="formatDate(item.pubDate)" :datetime="formatDateISO(item.pubDate)">
+					{{ formatDate(item.pubDate) }}
 				</time>
 			</div>
 
@@ -163,6 +163,7 @@ import ShareItem from '../ShareItem.vue'
 
 import { Feed } from '../../types/Feed'
 import { FeedItem } from '../../types/FeedItem'
+import { formatDate, formatDateISO } from '../../utils/dateUtils'
 import { ACTIONS, MUTATIONS } from '../../store'
 import EyeIcon from 'vue-material-design-icons/Eye.vue'
 import EyeCheckIcon from 'vue-material-design-icons/EyeCheck.vue'
@@ -223,6 +224,8 @@ export default Vue.extend({
 		}
 	},
 	methods: {
+		formatDate,
+		formatDateISO,
 		/**
 		 * Sends message to state to clear the selectedId number
 		 */
@@ -238,22 +241,6 @@ export default Vue.extend({
 				this.$emit('click-item')
 			}
 		},
-		/**
-		 * Returns locale formatted date string
-		 *
-		 * @param {number} epoch date value in epoch format
-		 * @return {string} locale formatted date string (based on users browser)
-		 */
-		formatDate(epoch: number): string {
-			return new Date(epoch).toLocaleString()
-		},
-
-		/**
-		 * Retrieve the feed by id number
-		 *
-		 * @param {number} id id of feed to fetch
-		 * @return {Feed} associated Feed
-		 */
 		getFeed(id: number): Feed {
 			return this.$store.getters.feeds.find((feed: Feed) => feed.id === id) || {}
 		},

--- a/src/components/feed-display/FeedItemRow.vue
+++ b/src/components/feed-display/FeedItemRow.vue
@@ -38,8 +38,8 @@
 			</div>
 
 			<div v-if="!compactMode || !verticalSplit" class="date-container" :class="{ 'compact': compactMode }">
-				<time class="date" :title="formatDate(item.pubDate*1000, 'yyyy-MM-dd HH:mm:ss')" :datetime="formatDatetime(item.pubDate*1000, 'yyyy-MM-ddTHH:mm:ssZ')">
-					{{ getRelativeTimestamp(item.pubDate*1000) }}
+				<time class="date" :title="formatDate(item.pubDate)" :datetime="formatDateISO(item.pubDate)">
+					{{ formatDateRelative(item.pubDate) }}
 				</time>
 			</div>
 		</div>
@@ -106,6 +106,7 @@ import ShareItem from '../ShareItem.vue'
 
 import { Feed } from '../../types/Feed'
 import { FeedItem } from '../../types/FeedItem'
+import { formatDate, formatDateRelative, formatDateISO } from '../../utils/dateUtils'
 import { ACTIONS, MUTATIONS } from '../../store'
 
 export default Vue.extend({
@@ -151,41 +152,13 @@ export default Vue.extend({
 		},
 	},
 	methods: {
+		formatDate,
+		formatDateRelative,
+		formatDateISO,
 		select(): void {
 			this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: this.item.id })
 			this.markRead(this.item)
 			this.$emit('show-details')
-		},
-		formatDate(epoch: number): string {
-			return new Date(epoch).toLocaleString()
-		},
-		formatDatetime(epoch: number): string {
-			return new Date(epoch).toISOString()
-		},
-		getRelativeTimestamp(previous: number): string {
-			const current = Date.now()
-
-			const msPerMinute = 60 * 1000
-			const msPerHour = msPerMinute * 60
-			const msPerDay = msPerHour * 24
-			const msPerMonth = msPerDay * 30
-			const msPerYear = msPerDay * 365
-
-			const elapsed = current - previous
-
-			if (elapsed < msPerMinute) {
-				return t('news', '{num} seconds', { num: Math.round(elapsed / 1000) })
-			} else if (elapsed < msPerHour) {
-				return t('news', '{num} minutes ago', { num: Math.round(elapsed / msPerMinute) })
-			} else if (elapsed < msPerDay) {
-				return t('news', '{num} hours ago', { num: Math.round(elapsed / msPerHour) })
-			} else if (elapsed < msPerMonth) {
-				return t('news', '{num} days ago', { num: Math.round(elapsed / msPerDay) })
-			} else if (elapsed < msPerYear) {
-				return t('news', '{num} months ago', { num: Math.round(elapsed / msPerMonth) })
-			} else {
-				return t('news', '{num} years ago', { num: Math.round(elapsed / msPerYear) })
-			}
 		},
 		getFeed(id: number): Feed {
 			return this.$store.getters.feeds.find((feed: Feed) => feed.id === id) || {}

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,31 @@
+import moment from '@nextcloud/moment'
+
+/**
+ * Returns locale formatted date string
+ *
+ * @param {number} epoch date value in epoch format
+ * @return {string} locale formatted date string
+ */
+export function formatDate(epoch: number) {
+	return moment.unix(epoch).format('l, LTS') // e.g. "04/20/2025 18:12:21"
+}
+
+/**
+ * Returns locale relative date string
+ *
+ * @param {number} epoch date value in epoch format
+ * @return {string} locale relative date string
+ */
+export function formatDateRelative(epoch: number) {
+	return moment.unix(epoch).fromNow() // e.g. "one hour ago"
+}
+
+/**
+ * Returns ISO date string
+ *
+ * @param {number} epoch date value in epoch format
+ * @return {string} ISO date string
+ */
+export function formatDateISO(epoch: number) {
+	return moment.unix(epoch).toISOString() // ISO 8601 e.g. "2025-04-20T18:12:21Z"
+}

--- a/tests/javascript/unit/components/feed-display/FeedItemDisplay.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemDisplay.spec.ts
@@ -54,7 +54,7 @@ describe('FeedItemDisplay.vue', () => {
 
 	it('should format date to match locale', () => {
 		const epoch = Date.now() // Provide an epoch timestamp
-		const formattedDate = (wrapper.vm as any).formatDate(epoch)
+		const formattedDate = (wrapper.vm as any).formatDate(epoch / 1000)
 
 		expect(formattedDate).toEqual(new Date(epoch).toLocaleString())
 	})

--- a/tests/javascript/unit/components/feed-display/FeedItemRow.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemRow.spec.ts
@@ -51,14 +51,14 @@ describe('FeedItemRow.vue', () => {
 
 	it('should format date to match locale', () => {
 		const epoch = Date.now() // Provide an epoch timestamp
-		const formattedDate = (wrapper.vm as any).formatDate(epoch)
+		const formattedDate = (wrapper.vm as any).formatDate(epoch / 1000)
 
 		expect(formattedDate).toEqual(new Date(epoch).toLocaleString())
 	})
 
 	it('should format datetime to match international standard', () => {
 		const epoch = Date.now() // Provide an epoch timestamp
-		const formattedDate = (wrapper.vm as any).formatDatetime(epoch)
+		const formattedDate = (wrapper.vm as any).formatDateISO(epoch / 1000)
 
 		expect(formattedDate).toEqual(new Date(epoch).toISOString())
 	})
@@ -67,15 +67,21 @@ describe('FeedItemRow.vue', () => {
 		const currentTimestamp = Date.now()
 		let pastTimestamp = currentTimestamp - 1000 * 10 // 10 seconds ago
 
-		let relativeTimestamp = (wrapper.vm as any).getRelativeTimestamp(pastTimestamp)
+		let relativeTimestamp = (wrapper.vm as any).formatDateRelative(pastTimestamp / 1000)
 
-		expect(relativeTimestamp).toEqual('{num} seconds')
+		expect(relativeTimestamp).toEqual('seconds ago')
 
 		pastTimestamp = currentTimestamp - 1000 * 60 * 10 // 10 minutes ago
 
-		relativeTimestamp = (wrapper.vm as any).getRelativeTimestamp(pastTimestamp)
+		relativeTimestamp = (wrapper.vm as any).formatDateRelative(pastTimestamp / 1000)
 
-		expect(relativeTimestamp).toEqual('{num} minutes ago')
+		expect(relativeTimestamp).toEqual('10 minutes ago')
+
+		pastTimestamp = currentTimestamp - 1000 * 3600 // 1 hour ago
+
+		relativeTimestamp = (wrapper.vm as any).formatDateRelative(pastTimestamp / 1000)
+
+		expect(relativeTimestamp).toEqual('an hour ago')
 	})
 
 	it('should retrieve feed by ID', () => {


### PR DESCRIPTION
* Resolves: #3147

## Summary

This PR fixes incorrect relative date strings like '1 days ago' or '1 years ago'.
It also changes that the nextcloud user settings locale is used, instead of the browser locale.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
