### PR TITLE
fix: item list not updated by automatic or manual refresh

### DIFF
--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -204,6 +204,7 @@ export default Vue.extend({
 			// refetch starred and feeds
 			await this.$store.dispatch(ACTIONS.FETCH_STARRED)
 			await this.$store.dispatch(ACTIONS.FETCH_FEEDS)
+			this.fetchMore()
 		},
 		refreshItemList() {
 			if (this.items.length > 0) {

--- a/src/components/feed-display/VirtualScroll.vue
+++ b/src/components/feed-display/VirtualScroll.vue
@@ -24,8 +24,6 @@ export default Vue.extend({
 			viewport: null,
 			scrollTop: 0,
 			scrollHeight: 500,
-			initialLoadingSkeleton: false,
-			initialLoadingTimeout: null,
 			elementToShow: null,
 			elementToFocus: null,
 			debouncedMarkRead: null,
@@ -66,7 +64,7 @@ export default Vue.extend({
 		this.debouncedMarkRead = _.debounce(this.markReadOnScroll, 500)
 	},
 	mounted() {
-		this.onScroll()
+		this.loadMore()
 		this.$nextTick(() => {
 			if (this.$el && this.$el.getBoundingClientRect) {
 				this.viewport = this.$el.getBoundingClientRect()
@@ -79,6 +77,7 @@ export default Vue.extend({
 		window.removeEventListener('resize', this.onScroll)
 	},
 	updated() {
+		this.$nextTick(this.loadMore)
 		if (!this.$store.getters.preventReadOnScroll) {
 			this.addToSeen(this._lastRendered)
 		}


### PR DESCRIPTION
## Summary

This is a hotfix for the last virtual scroll changes in  #3153 , where the scroll list is not updated by automatic or manual refresh.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
