### PR TITLE
refactor: use html5 history mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 
 ### Fixed
+- subscribe_to URL path has changed
 
 
 # Releases

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -16,6 +16,11 @@
 return ['routes' => [
 // page
 ['name' => 'page#index', 'url' => '/', 'verb' => 'GET'],
+['name' => 'page#index', 'url' => '/all', 'verb' => 'GET', 'postfix' => 'view.all'],
+['name' => 'page#index', 'url' => '/feed/{feedId}', 'verb' => 'GET', 'postfix' => 'view.feedid'],
+['name' => 'page#index', 'url' => '/folder/{folderId}', 'verb' => 'GET', 'postfix' => 'view.folderid'],
+['name' => 'page#index', 'url' => '/starred', 'verb' => 'GET', 'postfix' => 'view.starred'],
+['name' => 'page#index', 'url' => '/unread', 'verb' => 'GET', 'postfix' => 'view.unread'],
 ['name' => 'page#settings', 'url' => '/settings', 'verb' => 'GET'],
 ['name' => 'page#update_settings', 'url' => '/settings', 'verb' => 'PUT'],
 ['name' => 'page#manifest', 'url' => '/manifest.webapp', 'verb' => 'GET'],

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,4 +1,5 @@
 import VueRouter from 'vue-router'
+import { generateUrl } from '@nextcloud/router'
 
 import ExplorePanel from '../components/routes/Explore.vue'
 import StarredPanel from '../components/routes/Starred.vue'
@@ -46,13 +47,7 @@ const getInitialRoute = function() {
 }
 
 const routes = [
-	// using
-	// { path: '/collections/all', component: CollectionGeneral, alias: '/' },
-	// instead of
 	{ path: '/', redirect: getInitialRoute() },
-	// would also be an option, but it currently does not work
-	// reliably with router-link due to
-	// https://github.com/vuejs/vue-router/issues/419
 	{
 		name: ROUTES.EXPLORE,
 		path: '/explore',
@@ -92,6 +87,8 @@ const routes = [
 ]
 
 export default new VueRouter({
+	mode: 'history',
+	base: generateUrl('/apps/news'),
 	linkActiveClass: 'active',
-	routes, // short for `routes: routes`
+	routes,
 })


### PR DESCRIPTION
* Resolves: #3122

## Summary

To use the html5 history mode, all routes needs to be configured in appinfo/routes.php.

The subscriber url `https://yourdomain.com/nextcloud/index.php/apps/news?subscribe_to=` works again.
The question would be whether we should change this in the future and use a route like /subscribe.

[Different History modes](https://router.vuejs.org/guide/essentials/history-mode)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
