### PR TITLE
fix: possible race conditions when switching routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 
 ### Fixed
+- Wrong or none items in list after switching feed or folder
 
 
 # Releases

--- a/src/App.vue
+++ b/src/App.vue
@@ -70,8 +70,6 @@ export default defineComponent({
 	},
 
 	async created() {
-		// fetch starred to get starred count
-		await this.$store.dispatch(ACTIONS.FETCH_STARRED)
 		// fetch folders and feeds to build side bar
 		await this.$store.dispatch(ACTIONS.FETCH_FOLDERS)
 		await this.$store.dispatch(ACTIONS.FETCH_FEEDS)

--- a/src/components/routes/All.vue
+++ b/src/components/routes/All.vue
@@ -1,5 +1,6 @@
 <template>
 	<ContentTemplate
+		v-if="!loading"
 		:items="allItems"
 		:fetch-key="'all'"
 		@load-more="fetchMore()">
@@ -25,6 +26,10 @@ export default defineComponent({
 	computed: {
 		allItems(): FeedItem[] {
 			return this.$store.getters.allItems
+		},
+
+		loading() {
+			return this.$store.getters.loading
 		},
 	},
 

--- a/src/components/routes/Feed.vue
+++ b/src/components/routes/Feed.vue
@@ -63,8 +63,6 @@ export default defineComponent({
 
 	created() {
 		this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: undefined })
-		this.fetchMore()
-		this.$watch(() => this.$route.params, this.fetchMore)
 	},
 
 	methods: {

--- a/src/components/routes/Folder.vue
+++ b/src/components/routes/Folder.vue
@@ -1,5 +1,6 @@
 <template>
 	<ContentTemplate
+		v-if="!loading"
 		:items="items"
 		:fetch-key="'folder-' + folderId"
 		@mark-read="markRead()"
@@ -57,6 +58,10 @@ export default defineComponent({
 			return Number(this.folderId)
 		},
 
+		loading() {
+			return this.$store.getters.loading
+		},
+
 		unreadCount(): number {
 			const totalUnread = this.$store.getters.feeds
 				.filter((feed: Feed) => feed.folderId === this.id)
@@ -71,8 +76,6 @@ export default defineComponent({
 
 	created() {
 		this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: undefined })
-		this.fetchMore()
-		this.$watch(() => this.$route.params, this.fetchMore)
 	},
 
 	methods: {

--- a/src/components/routes/Starred.vue
+++ b/src/components/routes/Starred.vue
@@ -1,5 +1,6 @@
 <template>
 	<ContentTemplate
+		v-if="!loading"
 		:items="starred"
 		:fetch-key="'starred'"
 		@load-more="fetchMore()">
@@ -30,6 +31,10 @@ export default defineComponent({
 		...mapState(['items']),
 		starred(): FeedItem[] {
 			return this.$store.getters.starred
+		},
+
+		loading() {
+			return this.$store.getters.loading
 		},
 	},
 

--- a/src/components/routes/Unread.vue
+++ b/src/components/routes/Unread.vue
@@ -1,5 +1,6 @@
 <template>
 	<ContentTemplate
+		v-if="!loading"
 		:items="unread"
 		:fetch-key="'unread'"
 		@load-more="fetchMore()">
@@ -40,6 +41,10 @@ export default defineComponent({
 
 		unread(): FeedItem[] {
 			return this.unreadCache ?? []
+		},
+
+		loading() {
+			return this.$store.getters.loading
 		},
 	},
 

--- a/src/dataservices/item.service.ts
+++ b/src/dataservices/item.service.ts
@@ -2,7 +2,6 @@ import type { AxiosResponse } from '@nextcloud/axios'
 import type { FeedItem } from '../types/FeedItem.ts'
 
 import axios from '@nextcloud/axios'
-import _ from 'lodash'
 import { API_ROUTES } from '../types/ApiRoutes.ts'
 import { FEED_ORDER } from './../enums/index.ts'
 import store from './../store/app.ts'
@@ -17,12 +16,6 @@ export const ITEM_TYPES = {
 }
 
 export class ItemService {
-	static debounceFetchAll = _.debounce(ItemService.fetchAll, 400, { leading: true })
-	static debounceFetchStarred = _.debounce(ItemService.fetchStarred, 400, { leading: true })
-	static debounceFetchUnread = _.debounce(ItemService.fetchUnread, 400, { leading: true })
-	static debounceFetchFeedItems = _.debounce(ItemService.fetchFeedItems, 400, { leading: true })
-	static debounceFetchFolderFeedItems = _.debounce(ItemService.fetchFolderItems, 400, { leading: true })
-
 	/**
 	 * Makes backend call to retrieve all items
 	 *

--- a/src/store/feed.ts
+++ b/src/store/feed.ts
@@ -57,6 +57,10 @@ export const actions = {
 		commit(FEED_ITEM_MUTATION_TYPES.SET_UNREAD_COUNT, (response.data.feeds.reduce((total: number, feed: Feed) => {
 			return total + feed.unreadCount
 		}, 0)))
+
+		if (response?.data.starred) {
+			commit(FEED_ITEM_MUTATION_TYPES.SET_STARRED_COUNT, response?.data.starred)
+		}
 	},
 
 	async [FEED_ACTION_TYPES.ADD_FEED](

--- a/src/store/item.ts
+++ b/src/store/item.ts
@@ -70,6 +70,9 @@ const getters = {
 	},
 }
 
+// timestamp of the latest fetch request
+let latestFetchRequest = 0
+
 export const actions = {
 	/**
 	 * Fetch Unread Items from Backend and call commit to update state
@@ -83,9 +86,18 @@ export const actions = {
 		{ commit }: ActionParams<ItemState>,
 		{ start }: { start: number } = { start: 0 },
 	) {
+		const requestId = Date.now()
+		latestFetchRequest = requestId
+
 		commit(FEED_ITEM_MUTATION_TYPES.SET_FETCHING, { key: 'unread', fetching: true })
 
-		const response = await ItemService.debounceFetchUnread(start || state.lastItemLoaded.unread)
+		const response = await ItemService.fetchUnread(start || state.lastItemLoaded.unread)
+
+		// skip response if outdated
+		if (latestFetchRequest !== requestId) {
+			return
+		}
+
 		if (response?.data.newestItemId && response?.data.newestItemId !== state.newestItemId) {
 			state.syncNeeded = true
 		}
@@ -117,9 +129,18 @@ export const actions = {
 		{ commit }: ActionParams<ItemState>,
 		{ start }: { start: number } = { start: 0 },
 	) {
+		const requestId = Date.now()
+		latestFetchRequest = requestId
+
 		commit(FEED_ITEM_MUTATION_TYPES.SET_FETCHING, { key: 'all', fetching: true })
 
-		const response = await ItemService.debounceFetchAll(start || state.lastItemLoaded.all)
+		const response = await ItemService.fetchAll(start || state.lastItemLoaded.all)
+
+		// skip response if outdated
+		if (latestFetchRequest !== requestId) {
+			return
+		}
+
 		if (response?.data.newestItemId && response?.data.newestItemId !== state.newestItemId) {
 			state.syncNeeded = true
 		}
@@ -151,8 +172,17 @@ export const actions = {
 		{ commit }: ActionParams<ItemState>,
 		{ start }: { start: number } = { start: 0 },
 	) {
+		const requestId = Date.now()
+		latestFetchRequest = requestId
+
 		commit(FEED_ITEM_MUTATION_TYPES.SET_FETCHING, { key: 'starred', fetching: true })
-		const response = await ItemService.debounceFetchStarred(start || state.lastItemLoaded.starred)
+		const response = await ItemService.fetchStarred(start || state.lastItemLoaded.starred)
+
+		// skip response if outdated
+		if (latestFetchRequest !== requestId) {
+			return
+		}
+
 		if (response?.data.newestItemId && response?.data.newestItemId !== state.newestItemId) {
 			state.syncNeeded = true
 		}
@@ -187,8 +217,17 @@ export const actions = {
 		{ commit }: ActionParams<ItemState>,
 		{ feedId, start }: { feedId: number, start: number },
 	) {
+		const requestId = Date.now()
+		latestFetchRequest = requestId
+
 		commit(FEED_ITEM_MUTATION_TYPES.SET_FETCHING, { key: 'feed-' + feedId, fetching: true })
-		const response = await ItemService.debounceFetchFeedItems(feedId, start || state.lastItemLoaded['feed-' + feedId])
+		const response = await ItemService.fetchFeedItems(feedId, start || state.lastItemLoaded['feed-' + feedId])
+
+		// skip response if outdated
+		if (latestFetchRequest !== requestId) {
+			return
+		}
+
 		if (response?.data.newestItemId && response?.data.newestItemId !== state.newestItemId) {
 			state.syncNeeded = true
 		}
@@ -219,8 +258,17 @@ export const actions = {
 		{ commit }: ActionParams<ItemState>,
 		{ folderId, start }: { folderId: number, start: number },
 	) {
+		const requestId = Date.now()
+		latestFetchRequest = requestId
+
 		commit(FEED_ITEM_MUTATION_TYPES.SET_FETCHING, { key: 'folder-' + folderId, fetching: true })
-		const response = await ItemService.debounceFetchFolderFeedItems(folderId, start || state.lastItemLoaded['folder-' + folderId])
+		const response = await ItemService.fetchFolderItems(folderId, start || state.lastItemLoaded['folder-' + folderId])
+
+		// skip response if outdated
+		if (latestFetchRequest !== requestId) {
+			return
+		}
+
 		if (response?.data.newestItemId && response?.data.newestItemId !== state.newestItemId) {
 			state.syncNeeded = true
 		}

--- a/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
@@ -39,14 +39,25 @@ describe('FeedItemDisplayList.vue', () => {
 				items: {
 					allItemsLoaded: {
 						unread: false,
+						all: false,
+						'feed-1': false,
 					},
 					lastItemLoaded: {
 						unread: 0,
+						all: 0,
+						'feed-1': 0,
 					},
 					fetchingItems: {
 						unread: false,
+						all: false,
+						'feed-1': false,
 					},
 					syncNeeded: false,
+				},
+				feeds: {
+					ordering: {
+						'feed-1': 0,
+					},
 				},
 			},
 			actions: {
@@ -86,18 +97,10 @@ describe('FeedItemDisplayList.vue', () => {
 
 		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(1)
 
-		wrapper = mount(FeedItemDisplayList, {
-			attachTo: document.body,
-			props: {
-				items: [mockItem, mockItem],
-				fetchKey: 'unread',
-			},
-			global: {
-				plugins: [store],
-				stubs: {
-					VirtualScroll: false
-				},
-			},
+		// add another unread item
+		await wrapper.setProps({
+			items: [mockItem, mockItem],
+			fetchKey: 'unread',
 		})
 
 		// make sure dom elements are mounted properly
@@ -105,6 +108,30 @@ describe('FeedItemDisplayList.vue', () => {
 		await nextTick()
 
 		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(2)
+
+		// switch route to all with 1 item
+		await wrapper.setProps({
+			items: [mockItem],
+			fetchKey: 'all',
+		})
+
+		// make sure dom elements are mounted properly
+		await nextTick()
+		await nextTick()
+
+		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(1)
+
+		// switch route to feed-1 with 3 items
+		await wrapper.setProps({
+			items: [mockItem, mockItem, mockItem],
+			fetchKey: 'feed-1',
+		})
+
+		// make sure dom elements are mounted properly
+		await nextTick()
+		await nextTick()
+
+		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(3)
 	})
 
 })

--- a/tests/javascript/unit/store/item.spec.ts
+++ b/tests/javascript/unit/store/item.spec.ts
@@ -14,7 +14,7 @@ describe('item.ts', () => {
 			it('should call ItemService and commit items to state', async () => {
 				const fetchMock = vi.fn()
 				fetchMock.mockResolvedValue({ data: { items: [{ id: 123 }] } })
-				ItemService.debounceFetchUnread = fetchMock as any
+				ItemService.fetchUnread = fetchMock as any
 				const commit = vi.fn()
 
 				await (actions[FEED_ITEM_ACTION_TYPES.FETCH_UNREAD] as any)({ commit })
@@ -28,7 +28,7 @@ describe('item.ts', () => {
 			it('should call ItemService and commit items and starred count to state', async () => {
 				const fetchMock = vi.fn()
 				fetchMock.mockResolvedValue({ data: { items: [{ id: 123 }], starred: 3 } })
-				ItemService.debounceFetchStarred = fetchMock as any
+				ItemService.fetchStarred = fetchMock as any
 				const commit = vi.fn()
 
 				await (actions[FEED_ITEM_ACTION_TYPES.FETCH_STARRED] as any)({ commit })
@@ -44,7 +44,7 @@ describe('item.ts', () => {
 				const mockItems = [{ id: 123, title: 'feed item' }]
 				const fetchMock = vi.fn()
 				fetchMock.mockResolvedValue({ data: { items: mockItems } })
-				ItemService.debounceFetchFeedItems = fetchMock as any
+				ItemService.fetchFeedItems = fetchMock as any
 				const commit = vi.fn()
 
 				await (actions[FEED_ITEM_ACTION_TYPES.FETCH_FEED_ITEMS] as any)({ commit }, { feedId: 123 })
@@ -59,7 +59,7 @@ describe('item.ts', () => {
 				const mockItems = [{ id: 123, title: 'feed item' }]
 				const fetchMock = vi.fn()
 				fetchMock.mockResolvedValue({ data: { items: mockItems } })
-				ItemService.debounceFetchFolderFeedItems = fetchMock as any
+				ItemService.fetchFolderItems = fetchMock as any
 				const commit = vi.fn()
 
 				await (actions[FEED_ITEM_ACTION_TYPES.FETCH_FOLDER_FEED_ITEMS] as any)({ commit }, { feedId: 123 })


### PR DESCRIPTION
## Summary

Switching between the individual routes can lead to the item list being either empty or filled with wrong items, which seems to be even worse with vue3.

To fix this I changed the following:

- synchronise watchers to prevent incorrect items from being displayed when changing routes
- remove counterproductive debounce and make sure to skip old responses
- remove the special role of the starred route and update starred counters from feeds fetching response

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
