### PR TITLE
feat: show feed info table during opml import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [26.x.x]
 ### Changed
+- Open the feed info table during opml import to show what has been imported after completion
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 ### Fixed
 - Wrong or none items in list after switching feed or folder
+- opml import/export not working after vue router changes
 
 
 # Releases

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -232,7 +232,7 @@
 							{{ t('news', 'Disable automatic refresh') }}
 						</label>
 					</div>
-					<h2>{{ t('news', 'Abonnements (OPML)') }}</h2>
+					<h3>{{ t('news', 'Abonnements (OPML)') }}</h3>
 					<div class="button-container">
 						<NcButton
 							aria-label="UploadOpml"
@@ -567,6 +567,7 @@ export default defineComponent({
 			}
 
 			this.$store.commit(MUTATIONS.SET_LOADING, { value: true })
+			this.showFeedInfoTable = true
 			const formData = new FormData()
 			formData.append('file', this.selectedFile)
 

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -272,7 +272,7 @@ import type { Folder } from '../types/Folder.ts'
 import axios from '@nextcloud/axios'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { subscribe } from '@nextcloud/event-bus'
-import { generateOcsUrl } from '@nextcloud/router'
+import { generateOcsUrl, generateUrl } from '@nextcloud/router'
 import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
 import { defineComponent } from 'vue'
 import { mapState } from 'vuex'
@@ -571,7 +571,7 @@ export default defineComponent({
 			formData.append('file', this.selectedFile)
 
 			try {
-				const response = await fetch('import/opml', {
+				const response = await fetch(generateUrl('/apps/news/import/opml'), {
 					method: 'POST',
 					body: formData,
 				})
@@ -600,7 +600,7 @@ export default defineComponent({
 
 		async exportOpml() {
 			try {
-				const response = await fetch('export/opml')
+				const response = await fetch(generateUrl('/apps/news/export/opml'))
 				if (response.ok) {
 					const formattedDate = new Date().toISOString().split('T')[0]
 					const blob = await response.blob()

--- a/src/components/modals/FeedInfoTable.vue
+++ b/src/components/modals/FeedInfoTable.vue
@@ -7,7 +7,13 @@
 		size="large"
 		@close="$emit('close')">
 		<div class="table-modal">
-			<h2>{{ t('news', 'Article feed information') }}</h2>
+			<div class="modal-header">
+				<h2>{{ t('news', 'Article feed information') }}</h2>
+				<div v-if="loading" class="loading-message">
+					<NcLoadingIcon size="36" />
+					<h1>{{ t('news', 'Importing feeds') }}...{{ t('news', 'Please wait') }}</h1>
+				</div>
+			</div>
 			<table>
 				<tbody>
 					<tr>
@@ -137,6 +143,7 @@
 
 <script>
 import { mapState } from 'vuex'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcModal from '@nextcloud/vue/components/NcModal'
 import SortAscIcon from 'vue-material-design-icons/SortAscending.vue'
 import SortDescIcon from 'vue-material-design-icons/SortDescending.vue'
@@ -144,6 +151,7 @@ import SortDescIcon from 'vue-material-design-icons/SortDescending.vue'
 export default {
 	name: 'FeedInfoTable',
 	components: {
+		NcLoadingIcon,
 		NcModal,
 		SortAscIcon,
 		SortDescIcon,
@@ -164,6 +172,10 @@ export default {
 		...mapState({
 			feeds: (state) => state.feeds.feeds,
 		}),
+
+		loading() {
+			return this.$store.getters.loading
+		},
 
 		sortedFeeds() {
 			const sorted = [...this.feeds]
@@ -217,6 +229,18 @@ export default {
 		h2 {
 			font-weight: bold;
 		}
+	}
+
+	.modal-header {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+	}
+
+	.loading-message {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
 	}
 
 	table {


### PR DESCRIPTION
* Resolves: #3117 

## Summary

To clarify the opml import process for users that have the default setting to not show all articles, the feed info table is opened during import with a loading icon. Once the import is complete, all imported feeds can be seen in the table.

Also the import/export URLs that are broken since #3159 have been fixed.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
