### PR TITLE
Release 26.0.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,20 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [26.x.x]
 ### Changed
-- Open the feed info table during opml import to show what has been imported after completion
 
 
 ### Fixed
-- Wrong or none items in list after switching feed or folder
-- opml import/export not working after vue router changes
 
 
 # Releases
+## [26.0.0-beta.4] - 2025-05-17
+### Changed
+- Open the feed info table during opml import to show what has been imported after completion (#3169)
+
+### Fixed
+- Wrong or none items in list after switching feed or folder (#3168)
+- opml import/export not working after vue router changes (#3169)
+
 ## [26.0.0-beta.3] - 2025-05-13
 ### Changed
 - Migrate frontend to Vue3 (#3163)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>26.0.0-beta.3</version>
+    <version>26.0.0-beta.4</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

### Changed
- Open the feed info table during opml import to show what has been imported after completion (#3169)

### Fixed
- Wrong or none items in list after switching feed or folder (#3168)
- opml import/export not working after vue router changes (#3169)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
