### PR TITLE
fix: first selected item can disappear from the list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 
 ### Fixed
+- since `26.0.0-beta.4` the first selected item can disappear from the list if you change from another type of route, e.g. from feed to folder
 
 
 # Releases

--- a/src/components/routes/Unread.vue
+++ b/src/components/routes/Unread.vue
@@ -29,7 +29,7 @@ export default defineComponent({
 
 	data() {
 		return {
-			unreadCache: undefined,
+			unreadCache: [],
 		}
 	},
 
@@ -51,25 +51,20 @@ export default defineComponent({
 	watch: {
 		newestItemId(clearCache) {
 			if (clearCache) {
-				this.unreadCache = undefined
+				this.unreadCache = []
 			}
 		},
 
 		// need cache so we aren't always removing items when they get read
 		'$store.getters.unread': {
 			handler(newItems) {
-				const cachedItems = this.unreadCache ?? []
-
-				const cachedItemIds = new Set(cachedItems.map((item) => item.id))
-				const newUnreadCache = [...cachedItems]
+				const cachedItemIds = new Set(this.unreadCache.map((item) => item.id))
 
 				for (const item of newItems) {
 					if (!cachedItemIds.has(item.id)) {
-						newUnreadCache.push(item)
+						this.unreadCache.push(item)
 					}
 				}
-
-				this.unreadCache = newUnreadCache
 			},
 
 			immediate: true,

--- a/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
@@ -1,37 +1,88 @@
-import Vuex, { Store } from 'vuex'
-import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils'
-import { beforeAll, describe, expect, it, vi } from 'vitest'
-
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import Vuex, { Store } from 'vuex'
 import FeedItemDisplayList from '../../../../../src/components/feed-display/FeedItemDisplayList.vue'
-import VirtualScroll from '../../../../../src/components/feed-display/VirtualScroll.vue'
 import FeedItemRow from '../../../../../src/components/feed-display/FeedItemRow.vue'
+import VirtualScroll from '../../../../../src/components/feed-display/VirtualScroll.vue'
+import { FEED_ORDER } from '../../../../../src/enums/index.ts'
+import { ACTIONS, MUTATIONS } from '../../../../../src/store/index.ts'
 
 vi.mock('@nextcloud/axios')
 
 describe('FeedItemDisplayList.vue', () => {
 	'use strict'
+
+	let oldestFirst = false
+	let selectedItem = null
+	let showAll = false
+	let store: Store<any>
 	let wrapper: any
 
-	const mockItem = {
+	const mockItem1 = {
+		id: 1,
 		feedId: 1,
-		title: 'feed item',
+		title: 'feed item 1',
+		pubDate: Date.now() / 1000,
+		unread: true,
+		starred: true,
+	}
+
+	const mockItem2 = {
+		id: 2,
+		feedId: 1,
+		title: 'feed item 2 ',
+		pubDate: Date.now() / 1000,
+		unread: true,
+		starred: true,
+	}
+
+	const mockItem3 = {
+		id: 3,
+		feedId: 1,
+		title: 'feed item 3 ',
 		pubDate: Date.now() / 1000,
 		unread: true,
 	}
-        const mockFeed = {
-                id: 1,
-        }
 
-	let store: Store<any>
-	beforeAll(() => {
+	const mockItem4 = {
+		id: 4,
+		feedId: 1,
+		title: 'feed item 4 ',
+		pubDate: Date.now() / 1000,
+		unread: true,
+	}
+
+	const mockFeed = {
+		id: 1,
+		folderId: 1,
+	}
+
+	const mockFolder = {
+		id: 1,
+	}
+
+	const commitStub = vi.fn((mutation, param) => {
+		if (mutation === MUTATIONS.SET_SELECTED_ITEM) {
+			selectedItem = param.id
+		}
+	})
+
+	const dispatchStub = vi.fn((action, param) => {
+		if (action === ACTIONS.MARK_READ) {
+			param.item.unread = false
+		}
+	})
+
+	beforeEach(() => {
+		HTMLElement.prototype.scrollIntoView = vi.fn()
 		HTMLElement.prototype.getBoundingClientRect = vi.fn(() => ({
 			width: 500,
 			height: 500,
 			top: 0,
 			left: 0,
 			bottom: 500,
-			right: 500
+			right: 500,
 		}))
 
 		store = new Vuex.Store({
@@ -40,53 +91,63 @@ describe('FeedItemDisplayList.vue', () => {
 					allItemsLoaded: {
 						unread: false,
 						all: false,
+						starred: false,
 						'feed-1': false,
 					},
 					lastItemLoaded: {
 						unread: 0,
 						all: 0,
+						starred: 0,
 						'feed-1': 0,
 					},
 					fetchingItems: {
 						unread: false,
 						all: false,
+						starred: false,
 						'feed-1': false,
 					},
 					syncNeeded: false,
 				},
 				feeds: {
 					ordering: {
-						'feed-1': 0,
+						'feed-1': FEED_ORDER.DEFAULT,
 					},
 				},
 			},
-			actions: {
-			},
 			getters: {
 				feeds: () => [mockFeed],
-				unread: () => [mockItem, mockItem],
-				showAll: () => { return true },
-				oldestFirst: () => { return true },
+				folders: () => [mockFolder],
+				unread: () => [mockItem1, mockItem2, mockItem3, mockItem4],
+				showAll: () => showAll,
+				oldestFirst: () => oldestFirst,
+				selected: () => selectedItem,
 			},
 		})
-
-		store.dispatch = vi.fn()
-		store.commit = vi.fn()
-
-
+		store.commit = commitStub
+		store.dispatch = dispatchStub
+		// reset unread status
+		mockItem1.unread = true
+		mockItem2.unread = true
+		mockItem3.unread = true
+		mockItem4.unread = true
 	})
 
-	it('should create FeedItemRow items from input', async () => {
+	/*
+	 * This test checks whether the correct items are displayed when the route is changed.
+	 * It also tests whether items marked as read remain available and only disappear after
+	 * the route has been changed.
+	 */
+	it('should create FeedItemRow items when switching route', async () => {
 		wrapper = mount(FeedItemDisplayList, {
 			attachTo: document.body,
 			props: {
-				items: [mockItem],
+				items: [mockItem1],
 				fetchKey: 'unread',
 			},
 			global: {
 				plugins: [store],
 				stubs: {
-					VirtualScroll: false
+					VirtualScroll: false,
 				},
 			},
 		})
@@ -95,43 +156,282 @@ describe('FeedItemDisplayList.vue', () => {
 		await nextTick()
 		await nextTick()
 
-		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(1)
+		expect(
+			(wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length,
+			'should create one FeedItemRow item from input',
+		).toEqual(1)
 
-		// add another unread item
+		// select first item from unread route
+		expect(selectedItem).toEqual(undefined)
+		await wrapper.vm.clickItem(mockItem1)
+		expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem1 })
+		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id })
+		expect(selectedItem).toEqual(1)
+		expect(
+			(wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length,
+			'should select first FeedItemRow item from unread route',
+		).toEqual(1)
+
+		// add two unread items
 		await wrapper.setProps({
-			items: [mockItem, mockItem],
+			items: [mockItem1, mockItem2, mockItem3],
 			fetchKey: 'unread',
 		})
+		expect(
+			(wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length,
+			'should create three FeedItemRow items from input without removing read mockItem1',
+		).toEqual(3)
 
-		// make sure dom elements are mounted properly
-		await nextTick()
-		await nextTick()
-
-		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(2)
-
-		// switch route to all with 1 item
+		// add one unread item
 		await wrapper.setProps({
-			items: [mockItem],
+			items: [mockItem1, mockItem2, mockItem3, mockItem4],
+			fetchKey: 'unread',
+		})
+		expect(
+			(wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length,
+			'should create four FeedItemRow items from input without removing read mockItem1',
+		).toEqual(4)
+
+		// switch to all route with four items
+		await wrapper.setProps({
+			items: [mockItem1, mockItem2, mockItem3, mockItem4],
 			fetchKey: 'all',
 		})
+		expect(
+			(wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length,
+			'should create four FeedItemRow items from input after switching route to all',
+		).toEqual(4)
 
-		// make sure dom elements are mounted properly
-		await nextTick()
-		await nextTick()
+		// select first item from all route
+		expect(selectedItem).toEqual(undefined)
+		await wrapper.vm.clickItem(mockItem1)
+		expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem1 })
+		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id })
+		expect(selectedItem).toEqual(1)
+		expect(
+			(wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length,
+			'should select first FeedItemRow item from all route',
+		).toEqual(4)
 
-		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(1)
-
-		// switch route to feed-1 with 3 items
+		// switch to feed 1 route with three unread and one read item
 		await wrapper.setProps({
-			items: [mockItem, mockItem, mockItem],
+			items: [mockItem1, mockItem2, mockItem3, mockItem4],
 			fetchKey: 'feed-1',
+		})
+		expect(
+			(wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length,
+			'should create three unread FeedItemRow items from input after switching route to feed 1 without read mockItem1',
+		).toEqual(3)
+
+		// select first unread item mockitem2
+		expect(selectedItem).toEqual(undefined)
+		await wrapper.vm.clickItem(mockItem2)
+		expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem2 })
+		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem2.id })
+		expect(selectedItem).toEqual(2)
+		expect(
+			(wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length,
+			'should select first unread FeedItemRow item from feed-1 route',
+		).toEqual(3)
+
+		// switch to folder 1 route with two unread and two read items
+		await wrapper.setProps({
+			items: [mockItem1, mockItem2, mockItem3, mockItem4],
+			fetchKey: 'folder-1',
+		})
+		expect(
+			(wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length,
+			'should create two FeedItemRow items from input after switching route to folder 1 without read mockItem1 and mockItem2',
+		).toEqual(2)
+
+		// select first unread item mockitem3
+		expect(selectedItem).toEqual(undefined)
+		await wrapper.vm.clickItem(mockItem3)
+		expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem3 })
+		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem3.id })
+		expect(selectedItem).toEqual(3)
+		expect(
+			(wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length,
+			'should select first unread FeedItemRow item from folder-1 route',
+		).toEqual(2)
+
+		// switch to starred route with two starred items
+		await wrapper.setProps({
+			items: [mockItem1, mockItem2],
+			fetchKey: 'starred',
+		})
+		expect(
+			(wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length,
+			'should create two FeedItemRow items from input after switching route to starred',
+		).toEqual(2)
+
+		// select first starred item
+		expect(selectedItem).toEqual(undefined)
+		await wrapper.vm.clickItem(mockItem1)
+		expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem1 })
+		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id })
+		expect(selectedItem).toEqual(1)
+		expect(
+			(wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length,
+			'should select first FeedItemRow item',
+		).toEqual(2)
+	})
+
+	it('should create four FeedItemRow items from input sorted newest first (global ordering)', async () => {
+		oldestFirst = false
+		wrapper = mount(FeedItemDisplayList, {
+			attachTo: document.body,
+			props: {
+				items: [mockItem1, mockItem2, mockItem3, mockItem4],
+				fetchKey: 'feed-1',
+			},
+			global: {
+				plugins: [store],
+				stubs: {
+					VirtualScroll: false,
+				},
+			},
 		})
 
 		// make sure dom elements are mounted properly
 		await nextTick()
 		await nextTick()
 
-		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(3)
+		expect(wrapper.vm.$store.getters.oldestFirst).toEqual(false)
+
+		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(4)
+		expect(wrapper.vm.filteredItemcache[0]).toEqual(mockItem4)
 	})
 
+	it('should create four FeedItemRow items from input sorted oldest first (global ordering)', async () => {
+		oldestFirst = true
+		wrapper = mount(FeedItemDisplayList, {
+			attachTo: document.body,
+			props: {
+				items: [mockItem1, mockItem2, mockItem3, mockItem4],
+				fetchKey: 'feed-1',
+			},
+			global: {
+				plugins: [store],
+				stubs: {
+					VirtualScroll: false,
+				},
+			},
+		})
+
+		// make sure dom elements are mounted properly
+		await nextTick()
+		await nextTick()
+
+		expect(wrapper.vm.$store.getters.oldestFirst).toEqual(true)
+
+		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(4)
+		expect(wrapper.vm.filteredItemcache[0]).toEqual(mockItem1)
+	})
+
+	it('should create four FeedItemRow items from input sorted newest first (feed ordering)', async () => {
+		store.state.feeds.ordering['feed-1'] = FEED_ORDER.NEWEST
+		oldestFirst = true
+		wrapper = mount(FeedItemDisplayList, {
+			attachTo: document.body,
+			props: {
+				items: [mockItem1, mockItem2, mockItem3, mockItem4],
+				fetchKey: 'feed-1',
+			},
+			global: {
+				plugins: [store],
+				stubs: {
+					VirtualScroll: false,
+				},
+			},
+		})
+
+		// make sure dom elements are mounted properly
+		await nextTick()
+		await nextTick()
+
+		expect(wrapper.vm.$store.getters.oldestFirst).toEqual(true)
+
+		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(4)
+		expect(wrapper.vm.filteredItemcache[0]).toEqual(mockItem4)
+	})
+
+	it('should create four FeedItemRow items from input sorted oldest first (feed ordering)', async () => {
+		store.state.feeds.ordering['feed-1'] = FEED_ORDER.OLDEST
+		oldestFirst = false
+		wrapper = mount(FeedItemDisplayList, {
+			attachTo: document.body,
+			props: {
+				items: [mockItem1, mockItem2, mockItem3, mockItem4],
+				fetchKey: 'feed-1',
+			},
+			global: {
+				plugins: [store],
+				stubs: {
+					VirtualScroll: false,
+				},
+			},
+		})
+
+		// make sure dom elements are mounted properly
+		await nextTick()
+		await nextTick()
+
+		expect(wrapper.vm.$store.getters.oldestFirst).toEqual(false)
+
+		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(4)
+		expect(wrapper.vm.filteredItemcache[0]).toEqual(mockItem1)
+	})
+
+	it('should create four FeedItemRow items with showAll set', async () => {
+		showAll = true
+		mockItem1.unread = false
+		mockItem2.unread = false
+		wrapper = mount(FeedItemDisplayList, {
+			attachTo: document.body,
+			props: {
+				items: [mockItem1, mockItem2, mockItem3, mockItem4],
+				fetchKey: 'feed-1',
+			},
+			global: {
+				plugins: [store],
+				stubs: {
+					VirtualScroll: false,
+				},
+			},
+		})
+
+		// make sure dom elements are mounted properly
+		await nextTick()
+		await nextTick()
+
+		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(4)
+	})
+
+	it('should clear read FeedItemRow items from input after refresh', async () => {
+		wrapper = mount(FeedItemDisplayList, {
+			attachTo: document.body,
+			props: {
+				items: [mockItem1, mockItem2, mockItem3, mockItem4],
+				fetchKey: 'unread',
+			},
+			global: {
+				plugins: [store],
+				stubs: {
+					VirtualScroll: false,
+				},
+			},
+		})
+
+		// make sure dom elements are mounted properly
+		await nextTick()
+		await nextTick()
+
+		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(4)
+		mockItem1.unread = false
+		mockItem2.unread = false
+		wrapper.vm.refreshApp()
+		await nextTick()
+		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(2)
+	})
 })

--- a/tests/javascript/unit/components/routes/All.spec.ts
+++ b/tests/javascript/unit/components/routes/All.spec.ts
@@ -1,6 +1,6 @@
 import Vuex, { Store } from 'vuex'
 import { shallowMount } from '@vue/test-utils'
-import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import All from '../../../../../src/components/routes/All.vue'
 import ContentTemplate from '../../../../../src/components/ContentTemplate.vue'
@@ -47,19 +47,23 @@ describe('All.vue', () => {
 		})
 	})
 
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
 	it('should get all items from state', () => {
 		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(3)
 	})
 
 	it('should dispatch FETCH_ITEMS action if not fetchingItems.all', () => {
-		(wrapper.vm as any).$store.state.items.fetchingItems.all = true;
-
-		(wrapper.vm as any).fetchMore()
-		expect(store.dispatch).not.toBeCalled();
-
 		(wrapper.vm as any).$store.state.items.fetchingItems.all = false;
-
 		(wrapper.vm as any).fetchMore()
 		expect(store.dispatch).toBeCalled()
+	})
+
+	it('should not dispatch FETCH_ITEMS action if fetchingItems.all', () => {
+		(wrapper.vm as any).$store.state.items.fetchingItems.all = true;
+		(wrapper.vm as any).fetchMore()
+		expect(store.dispatch).not.toBeCalled()
 	})
 })

--- a/tests/javascript/unit/components/routes/Feed.spec.ts
+++ b/tests/javascript/unit/components/routes/Feed.spec.ts
@@ -1,6 +1,6 @@
 import Vuex, { Store } from 'vuex'
 import { shallowMount } from '@vue/test-utils'
-import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import Feed from '../../../../../src/components/routes/Feed.vue'
 import ContentTemplate from '../../../../../src/components/ContentTemplate.vue'
@@ -10,6 +10,12 @@ vi.mock('@nextcloud/axios')
 describe('Feed.vue', () => {
 	'use strict'
 	let wrapper: any
+
+	const mockFeed = {
+		id: 123,
+		title: 'feed name',
+		unreadCount: 2,
+	}
 
 	let store: Store<any>
 	beforeAll(() => {
@@ -31,6 +37,7 @@ describe('Feed.vue', () => {
 			actions: {
 			},
 			getters: {
+				feeds: () => [mockFeed],
 			},
 		})
 
@@ -52,12 +59,28 @@ describe('Feed.vue', () => {
 		})
 	})
 
-	it('should get starred items from state', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('should get feed items from state', () => {
 		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(2)
 	})
 
-	it('should dispatch FETCH_FEED_ITEMS action if not fetchingItems.starred', () => {
+	it('should dispatch FETCH_FEED_ITEMS action if not fetchingItems.feed-123', () => {
+		(wrapper.vm as any).$store.state.items.fetchingItems['feed-123'] = false;
 		(wrapper.vm as any).fetchMore()
+		expect(store.dispatch).toBeCalled()
+	})
+
+	it('should not dispatch FETCH_FEED_ITEMS action if fetchingItems.feed-123', () => {
+		(wrapper.vm as any).$store.state.items.fetchingItems['feed-123'] = true;
+		(wrapper.vm as any).fetchMore()
+		expect(store.dispatch).not.toBeCalled()
+	})
+
+	it('should dispatch FEED_MARK_READ action', () => {
+		(wrapper.vm as any).markRead()
 		expect(store.dispatch).toBeCalled()
 	})
 })

--- a/tests/javascript/unit/components/routes/Folder.spec.ts
+++ b/tests/javascript/unit/components/routes/Folder.spec.ts
@@ -1,6 +1,6 @@
 import Vuex, { Store } from 'vuex'
 import { shallowMount } from '@vue/test-utils'
-import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import Folder from '../../../../../src/components/routes/Folder.vue'
 import ContentTemplate from '../../../../../src/components/ContentTemplate.vue'
@@ -25,6 +25,11 @@ describe('Folder.vue', () => {
 		folderId: 123,
 	}
 
+	const mockFolder = {
+		id: 123,
+		name: 'foldername',
+	}
+
 	let store: Store<any>
 	beforeAll(() => {
 		store = new Vuex.Store({
@@ -46,6 +51,7 @@ describe('Folder.vue', () => {
 			},
 			getters: {
 				feeds: () => [mockFeed, mockFeed2],
+				folders: () => [mockFolder],
 			},
 		})
 
@@ -67,12 +73,32 @@ describe('Folder.vue', () => {
 		})
 	})
 
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
 	it('should get folder items from state', () => {
 		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(2)
 	})
 
-	it('should dispatch FETCH_FOLDER_FEED_ITEMS action on fetchMore', () => {
+	it('should dispatch FETCH_FOLDER_FEED_ITEMS action on fetchMore if not fetchingItems.folder-123', () => {
+		(wrapper.vm as any).$store.state.items.fetchingItems['folder-123'] = false;
 		(wrapper.vm as any).fetchMore()
 		expect(store.dispatch).toBeCalled()
+	})
+
+	it('should not dispatch FETCH_FOLDER_FEED_ITEMS action on fetchMore if fetchingItems.folder-123', () => {
+		(wrapper.vm as any).$store.state.items.fetchingItems['folder-123'] = true;
+		(wrapper.vm as any).fetchMore()
+		expect(store.dispatch).not.toBeCalled()
+	})
+
+	it('should dispatch FEED_MARK_READ action on markRead', () => {
+		(wrapper.vm as any).markRead()
+		expect(store.dispatch).toBeCalledTimes(2)
+	})
+
+	it('should return folder unread count', () => {
+		expect((wrapper.vm as any).unreadCount).toEqual(4)
 	})
 })

--- a/tests/javascript/unit/components/routes/Starred.spec.ts
+++ b/tests/javascript/unit/components/routes/Starred.spec.ts
@@ -1,6 +1,6 @@
 import Vuex, { Store } from 'vuex'
 import { shallowMount } from '@vue/test-utils'
-import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import Starred from '../../../../../src/components/routes/Starred.vue'
 import ContentTemplate from '../../../../../src/components/ContentTemplate.vue'
@@ -47,12 +47,23 @@ describe('Starred.vue', () => {
 		})
 	})
 
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
 	it('should get starred items from state', () => {
 		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(1)
 	})
 
 	it('should dispatch FETCH_STARRED action if not fetchingItems.starred', () => {
+                (wrapper.vm as any).$store.state.items.fetchingItems.starred = false;
 		(wrapper.vm as any).fetchMore()
 		expect(store.dispatch).toBeCalled()
+	})
+
+	it('should not dispatch FETCH_STARRED action if fetchingItems.starred', () => {
+                (wrapper.vm as any).$store.state.items.fetchingItems.starred = true;
+		(wrapper.vm as any).fetchMore()
+		expect(store.dispatch).not.toBeCalled()
 	})
 })

--- a/tests/javascript/unit/components/routes/Unread.spec.ts
+++ b/tests/javascript/unit/components/routes/Unread.spec.ts
@@ -76,6 +76,6 @@ describe('Unread.vue', () => {
 		store.state.items.newestItemId = 0;
 
 		(wrapper.vm as any).$options.watch.newestItemId.call(wrapper.vm, wrapper.vm.newestItemId)
-		expect((wrapper.vm as any).unreadCache).toBeUndefined()
+		expect((wrapper.vm as any).unreadCache).toEqual([])
 	})
 })

--- a/tests/javascript/unit/components/routes/Unread.spec.ts
+++ b/tests/javascript/unit/components/routes/Unread.spec.ts
@@ -1,6 +1,6 @@
 import Vuex, { Store } from 'vuex'
 import { shallowMount } from '@vue/test-utils'
-import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import Unread from '../../../../../src/components/routes/Unread.vue'
 import ContentTemplate from '../../../../../src/components/ContentTemplate.vue'
@@ -25,6 +25,9 @@ describe('Unread.vue', () => {
 					fetchingItems: {
 						unread: false,
 					},
+					newestItemId: {
+						number: 12,
+					},
 				},
 			},
 			actions: {
@@ -47,19 +50,32 @@ describe('Unread.vue', () => {
 		})
 	})
 
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
 	it('should get unread items from state', () => {
 		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(2)
 	})
 
 	it('should dispatch FETCH_UNREAD action if not fetchingItems.unread', () => {
-		(wrapper.vm as any).$store.state.items.fetchingItems.unread = true;
-
-		(wrapper.vm as any).fetchMore()
-		expect(store.dispatch).not.toBeCalled();
-
 		(wrapper.vm as any).$store.state.items.fetchingItems.unread = false;
 
 		(wrapper.vm as any).fetchMore()
 		expect(store.dispatch).toBeCalled()
+	})
+
+	it('should not dispatch FETCH_UNREAD action if fetchingItems.unread', () => {
+		(wrapper.vm as any).$store.state.items.fetchingItems.unread = true;
+
+		(wrapper.vm as any).fetchMore()
+		expect(store.dispatch).not.toBeCalled()
+	})
+
+	it('should clear unread cache when newestItemId resets', () => {
+		store.state.items.newestItemId = 0;
+
+		(wrapper.vm as any).$options.watch.newestItemId.call(wrapper.vm, wrapper.vm.newestItemId)
+		expect((wrapper.vm as any).unreadCache).toBeUndefined()
 	})
 })


### PR DESCRIPTION
## Summary

The fix in d9575ad only moved the timing problem to another place. Now it can happen that the first selected item could disappear from the list if you change from another type of route, e.g. from feed to folder.
I removed the watch completely and let the item list update though a computed function,which fixed the problem now.

I also add additional unit tests especially for the item list creation, which showed the previous problem.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
