### PR TITLE
Actions dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,22 @@ updates:
       - "dependencies"
       - "Skip-Changelog"
     versioning-strategy: increase
+    groups:
+      vue:
+        patterns:
+          - "vue"
+          - "vuex"
+          - "vue-router"
+          - "@vue/*"
+          - "vue-material-design-icons"
+      vite:
+        patterns:
+          - "vite"
+          - "vitest"
+          - "@vitest/*"
+      types:
+        patterns:
+          - "@types/*"
 
   # Maintain dependencies for Composer
   - package-ecosystem: "composer"

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,8 @@
         "@vue/tsconfig": "^0.7.0",
         "jsdom": "^26.1.0",
         "regenerator-runtime": "^0.14.1",
-        "vitest": "^3.1.2"
+        "vite": "^6.3.5",
+        "vitest": "^3.1.4"
       },
       "engines": {
         "node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@vue/tsconfig": "^0.7.0",
     "jsdom": "^26.1.0",
     "regenerator-runtime": "^0.14.1",
-    "vitest": "^3.1.2"
+    "vite": "^6.3.5",
+    "vitest": "^3.1.4"
   }
 }


### PR DESCRIPTION
## Summary

This PR adds groups to the npm dependabot config to avoid conflicts when updates for coupled  dependencies like `vitest` and `@vitest/coverage-istanbul` are available.

I also added the missing direct dependency for `vite`.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
