### PR TITLE
Release 26.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 
 ### Fixed
-- content splitter position not recognised when reloading app
-- feed/folder action menu does not close when clicked outside
-- fix feed url in details view
+
 
 # Releases
+## [26.0.0] - 2025-05-29
+### Fixed
+- content splitter position not recognized when reloading app (#3193)
+- feed/folder action menu does not close when clicked outside (#3193)
+- fix feed url in details view (#3193)
+
 ## [26.0.0-beta.5] - 2025-05-23
 ### Changed
 - show intro and date if enough space in compact mode (#3186)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>26.0.0-beta.5</version>
+    <version>26.0.0</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
## Summary

### Fixed
- content splitter position not recognized when reloading app (#3193)
- feed/folder action menu does not close when clicked outside (#3193)
- fix feed url in details view (#3193)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
