### PR TITLE
Release 26.0.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,17 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [26.x.x]
 ### Changed
-- show intro and date if enough space in compact mode
-
 
 ### Fixed
-- since `26.0.0-beta.4` the first selected item can disappear from the list if you change from another type of route, e.g. from feed to folder
-
 
 # Releases
+## [26.0.0-beta.5] - 2025-05-23
+### Changed
+- show intro and date if enough space in compact mode (#3186)
+
+### Fixed
+- since `26.0.0-beta.4` the first selected item can disappear from the list if you change from another type of route, e.g. from feed to folder (#3178)
+
 ## [26.0.0-beta.4] - 2025-05-17
 ### Changed
 - Open the feed info table during opml import to show what has been imported after completion (#3169)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>26.0.0-beta.4</version>
+    <version>26.0.0-beta.5</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION


* Resolves: # <!-- related github issue -->

## Summary

### Changed
- show intro and date if enough space in compact mode (#3186)

### Fixed
- since `26.0.0-beta.4` the first selected item can disappear from the list if you change from another type of route, e.g. from feed to folder (#3178)


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
