### PR TITLE
feat: implement item navigation when showing details in no-split or mobile mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [26.x.x]
 ### Changed
+- implement item navigation when showing details in no-split mode
 
 ### Fixed
 - style fixes for `<blockquote>`, `<pre>` and `<code>` in articles

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@nextcloud/axios": "^2.5.0",
+        "@nextcloud/browser-storage": "^0.4.0",
         "@nextcloud/dialogs": "^7.0.0-rc.1",
         "@nextcloud/event-bus": "^3.3.2",
         "@nextcloud/initial-state": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "type": "module",
   "dependencies": {
     "@nextcloud/axios": "^2.5.0",
+    "@nextcloud/browser-storage": "^0.4.0",
     "@nextcloud/dialogs": "^7.0.0-rc.1",
     "@nextcloud/event-bus": "^3.3.2",
     "@nextcloud/initial-state": "^2.2.0",

--- a/src/components/ContentTemplate.vue
+++ b/src/components/ContentTemplate.vue
@@ -43,6 +43,11 @@
 					<template #icon>
 						<TextIcon />
 					</template>
+					<template #action>
+						<NcButton v-if="noSplitMode" variant="secondary" @click="showItem(false)">
+							{{ t('news', 'Show all articles') }}
+						</NcButton>
+					</template>
 				</NcEmptyContent>
 			</div>
 		</NcAppContentDetails>
@@ -58,17 +63,19 @@
 
 import type { FeedItem } from '../types/FeedItem.ts'
 
+import { getBuilder } from '@nextcloud/browser-storage'
 import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import {
 	type PropType,
 
-	computed, onBeforeUnmount, onMounted, ref, watch,
+	computed, onBeforeMount, onBeforeUnmount, onMounted, onUpdated, ref, watch,
 } from 'vue'
 import { useStore } from 'vuex'
 import NcAppContent from '@nextcloud/vue/components/NcAppContent'
 import NcAppContentDetails from '@nextcloud/vue/components/NcAppContentDetails'
 import NcAppContentList from '@nextcloud/vue/components/NcAppContentList'
+import NcButton from '@nextcloud/vue/components/NcButton'
 import NcEmptyContent from '@nextcloud/vue/components/NcEmptyContent'
 import TextIcon from 'vue-material-design-icons/Text.vue'
 import FeedItemDisplay from './feed-display/FeedItemDisplay.vue'
@@ -100,9 +107,12 @@ const emit = defineEmits<{
 
 const store = useStore()
 
+const browserStorage = getBuilder('nextcloud-news').persist().build()
+
 const isMobile = useIsMobile()
 
 const showDetails = ref(false)
+const initialSelection = ref(false)
 
 const stopPageUpHotkey = ref(null)
 const stopPageDownHotkey = ref(null)
@@ -138,8 +148,20 @@ const allItemsLoaded = computed(() => {
 	return store.state.items.allItemsLoaded[props.fetchKey] === true
 })
 
+const fetchingItems = computed(() => {
+	return store.state.items.fetchingItems[props.fetchKey] === true
+})
+
+const itemReset = computed(() => {
+	return store.state.items.newestItemId === 0
+})
+
 const noSplitMode = computed(() => {
 	return (layout.value === 'no-split' || isMobile.value)
+})
+
+const detailsView = computed(() => {
+	return noSplitMode.value && showDetails.value
 })
 
 /**
@@ -149,6 +171,10 @@ const noSplitMode = computed(() => {
  */
 function showItem(value) {
 	showDetails.value = value
+	// store show details value in local storage
+	if (noSplitMode.value) {
+		browserStorage.setItem('news.show-details', value)
+	}
 	// scroll to selected item when closing details in no-split mode
 	if (noSplitMode.value && !value) {
 		itemListElement.value?.scrollToItem(currentIndex.value)
@@ -218,11 +244,20 @@ watch(allItemsLoaded, (newVal) => {
 	 * load new items if available and the details of the
 	 * last item are currently displayed in no-split mode
 	 */
-	if (noSplitMode.value
+	if (detailsView.value
 		&& newVal === false
-		&& showDetails.value
 		&& currentIndex.value >= props.items.length - 1) {
 		emit('load-more')
+	}
+})
+
+/*
+ * activate initialSelection when refreshing app
+ * and in details view
+ */
+watch(itemReset, (newVal) => {
+	if (detailsView.value && newVal === true) {
+		initialSelection.value = true
 	}
 })
 
@@ -233,14 +268,15 @@ watch(selectedFeedItem, (newSelectedFeedItem) => {
 		 * load new items if available before reaching end of
 		 * the list while showing details in no-split mode
 		 */
-		if (noSplitMode.value
-			&& showDetails.value
+		if (detailsView.value
 			&& !allItemsLoaded.value
 			&& currentIndex.value >= props.items.length - 5) {
 			emit('load-more')
 		}
 	} else {
-		showItem(false)
+		if (!noSplitMode.value) {
+			showItem(false)
+		}
 	}
 })
 
@@ -252,16 +288,38 @@ watch(displayMode, (newDisplayMode) => {
 	}
 })
 
+onBeforeMount(() => {
+	store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: undefined })
+})
+
 onMounted(() => {
+	// create shortcuts
 	useHotKey(['p', 'k', 'ArrowLeft'], previousItem)
 	useHotKey(['n', 'j', 'ArrowRight'], nextItem)
 	if (displayMode.value === DISPLAY_MODE.SCREENREADER) {
 		enablePageHotkeys()
 	}
+	// get show-details flag from browser storage
+	if (noSplitMode.value) {
+		showItem(browserStorage.getItem('news.show-details') === 'true')
+		if (showDetails.value) {
+			initialSelection.value = true
+		}
+	}
 })
 
 onBeforeUnmount(() => {
 	disablePageHotkeys()
+})
+
+onUpdated(() => {
+	// auto-select first item when in details view and initialSelection is set
+	if (initialSelection.value && detailsView.value && !fetchingItems.value) {
+		if (props.items.length > 0) {
+			selectItem(props.items[0])
+			initialSelection.value = false
+		}
+	}
 })
 
 </script>

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -2,6 +2,7 @@
 	<div
 		class="feed-item-display"
 		:class="{ screenreader: screenReaderMode }"
+		:style="screenReaderItemHeight"
 		v-bind="screenReaderMode ? { 'aria-setsize': itemCount, 'aria-posinset': itemIndex } : {}"
 		@focusin="selectItemOnFocus">
 		<ShareItem v-if="showShareMenu" :item-id="item.id" @close="closeShareMenu()" />
@@ -79,6 +80,7 @@
 			<div class="heading">
 				<h1 :dir="item.rtl && 'rtl'">
 					<a
+						ref="titleLink"
 						target="_blank"
 						rel="noreferrer"
 						:href="item.url"
@@ -177,7 +179,7 @@ import EyeCheckIcon from 'vue-material-design-icons/EyeCheck.vue'
 import ShareVariant from 'vue-material-design-icons/ShareVariant.vue'
 import StarIcon from 'vue-material-design-icons/Star.vue'
 import ShareItem from '../ShareItem.vue'
-import { DISPLAY_MODE, SPLIT_MODE } from '../../enums/index.ts'
+import { DISPLAY_MODE, ITEM_HEIGHT, SPLIT_MODE } from '../../enums/index.ts'
 import { ACTIONS, MUTATIONS } from '../../store/index.ts'
 import { formatDate, formatDateISO } from '../../utils/dateUtils.ts'
 
@@ -225,7 +227,7 @@ export default defineComponent({
 	},
 
 	emits: {
-		'click-item': () => true,
+		'select-item': () => true,
 		'show-details': () => true,
 		'prev-item': () => true,
 		'next-item': () => true,
@@ -248,6 +250,25 @@ export default defineComponent({
 		splitModeOff() {
 			return (this.$store.getters.splitmode === SPLIT_MODE.OFF || this.isMobile)
 		},
+
+		isSelected() {
+			return this.$store.getters.selected === this.item
+		},
+
+		screenReaderItemHeight() {
+			return this.screenReaderMode ? { height: ITEM_HEIGHT.DEFAULT + 'px' } : undefined
+		},
+	},
+
+	watch: {
+		// Focus title link in article to emulate structural heading navigation
+		// with screen readers
+		async isSelected(newSelected) {
+			if (newSelected && this.screenReaderMode) {
+				await this.$nextTick()
+				this.$refs.titleLink.focus()
+			}
+		},
 	},
 
 	created() {
@@ -269,12 +290,11 @@ export default defineComponent({
 		},
 
 		/**
-		 * Use parent click handler to select item when focused,
-		 * needed by screen reader navigation
+		 * Select item when focused needed by screen reader navigation
 		 */
 		selectItemOnFocus(): void {
-			if (this.screenReaderMode && this.$store.getters.selected !== this.item) {
-				this.$emit('click-item')
+			if (this.screenReaderMode && !this.isSelected) {
+				this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: this.item.id })
 			}
 		},
 
@@ -345,7 +365,7 @@ export default defineComponent({
 	}
 
 	.feed-item-display.screenreader {
-		height: 111px;
+		overflow: hidden;
 	}
 
 	.article {

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -2,33 +2,33 @@
 	<div
 		class="feed-item-display"
 		:class="{ screenreader: screenReaderMode }"
-		:aria-posinset="itemIndex"
-		:aria-setsize="itemCount"
+		v-bind="screenReaderMode ? { 'aria-setsize': itemCount, 'aria-posinset': itemIndex } : {}"
 		@focusin="selectItemOnFocus">
 		<ShareItem v-if="showShareMenu" :item-id="item.id" @close="closeShareMenu()" />
-
+		<NcActions
+			v-if="splitModeOff && !screenReaderMode"
+			class="nav-icons"
+			:inline="2">
+			<NcActionButton
+				class="nav-button left"
+				:disabled="itemIndex <= 1"
+				:title="t('news', 'Previous Item')"
+				@click="prevItem">
+				<template #icon>
+					<ChevronLeftIcon :size="32" />
+				</template>
+			</NcActionButton>
+			<NcActionButton
+				class="nav-button right"
+				:disabled="itemIndex >= itemCount"
+				:title="t('news', 'Next Item')"
+				@click="nextItem">
+				<template #icon>
+					<ChevronRightIcon :size="32" />
+				</template>
+			</NcActionButton>
+		</NcActions>
 		<div class="action-bar">
-			<NcActions
-				v-show="!splitModeOff"
-				class="action-bar-nav"
-				:inline="4">
-				<NcActionButton
-					:title="t('news', 'Previous Item')"
-					@click="prevItem">
-					{{ t('news', 'Previous') }}
-					<template #icon>
-						<ArrowLeftThickIcon />
-					</template>
-				</NcActionButton>
-				<NcActionButton
-					:title="t('news', 'Next Item')"
-					@click="nextItem">
-					{{ t('news', 'Next') }}
-					<template #icon>
-						<ArrowRightThickIcon />
-					</template>
-				</NcActionButton>
-			</NcActions>
 			<NcActions :inline="4">
 				<NcActionButton
 					:title="t('news', 'Share within Instance')"
@@ -165,11 +165,12 @@ import type { FeedItem } from '../../types/FeedItem.ts'
 
 import { generateUrl } from '@nextcloud/router'
 import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
+import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import { defineComponent } from 'vue'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActions from '@nextcloud/vue/components/NcActions'
-import ArrowLeftThickIcon from 'vue-material-design-icons/ArrowLeftThick.vue'
-import ArrowRightThickIcon from 'vue-material-design-icons/ArrowRightThick.vue'
+import ChevronLeftIcon from 'vue-material-design-icons/ChevronLeft.vue'
+import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
 import CloseIcon from 'vue-material-design-icons/Close.vue'
 import EyeIcon from 'vue-material-design-icons/Eye.vue'
 import EyeCheckIcon from 'vue-material-design-icons/EyeCheck.vue'
@@ -191,8 +192,8 @@ export default defineComponent({
 		NcActions,
 		NcActionButton,
 		ShareItem,
-		ArrowLeftThickIcon,
-		ArrowRightThickIcon,
+		ChevronLeftIcon,
+		ChevronRightIcon,
 	},
 
 	props: {
@@ -232,6 +233,7 @@ export default defineComponent({
 
 	data: () => {
 		return {
+			isMobile: useIsMobile(),
 			keepUnread: false,
 			showShareMenu: false,
 			feedUrl: undefined,
@@ -244,7 +246,7 @@ export default defineComponent({
 		},
 
 		splitModeOff() {
-			return this.$store.getters.splitmode === SPLIT_MODE.OFF
+			return (this.$store.getters.splitmode === SPLIT_MODE.OFF || this.isMobile)
 		},
 	},
 
@@ -337,8 +339,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-	$breakpoint-mobile: 1024px;
-
 	.feed-item-display {
 		display: flex;
 		flex-direction: column;
@@ -467,10 +467,19 @@ export default defineComponent({
 
 	.action-bar-nav {
 		flex-grow: 1;
+	}
 
-		@media only screen and (width > $breakpoint-mobile) {
-			display: none !important;
-		}
+	.nav-icons .nav-button {
+		position: absolute;
+		top: 50%;
+	}
+
+	.nav-icons .nav-button.left {
+		inset-inline-start: 1rem;
+	}
+
+	.nav-icons .nav-button.right {
+		inset-inline-end: 1rem;
 	}
 
 	.feed-item-display .action-bar .button-vue,

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -102,10 +102,6 @@ export default defineComponent({
 			return this.$store.getters.loading
 		},
 
-		compactMode() {
-			return this.$store.getters.displaymode === DISPLAY_MODE.COMPACT
-		},
-
 		screenReaderMode() {
 			return this.$store.getters.displaymode === DISPLAY_MODE.SCREENREADER
 		},
@@ -124,15 +120,6 @@ export default defineComponent({
 
 		getSelectedItem(newVal) {
 			this.selectedItem = newVal
-		},
-
-		// clear selected item on route change
-		fetchKey: {
-			handler() {
-				this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: undefined })
-			},
-
-			immediate: true,
 		},
 
 		// reset scroll position on item reset

--- a/src/components/feed-display/FeedItemRow.vue
+++ b/src/components/feed-display/FeedItemRow.vue
@@ -5,6 +5,7 @@
 		:aria-label="item.title"
 		:aria-setsize="itemCount"
 		:aria-posinset="itemIndex"
+		:style="{ height: `${itemHeight}px` }"
 		role="button"
 		tabindex="0"
 		@keydown.enter="select()"
@@ -113,7 +114,7 @@ import RssIcon from 'vue-material-design-icons/Rss.vue'
 import ShareVariant from 'vue-material-design-icons/ShareVariant.vue'
 import StarIcon from 'vue-material-design-icons/Star.vue'
 import ShareItem from '../ShareItem.vue'
-import { DISPLAY_MODE, SPLIT_MODE } from '../../enums/index.ts'
+import { DISPLAY_MODE, ITEM_HEIGHT, SPLIT_MODE } from '../../enums/index.ts'
 import { ACTIONS, MUTATIONS } from '../../store/index.ts'
 import { formatDate, formatDateISO, formatDateRelative } from '../../utils/dateUtils.ts'
 
@@ -176,6 +177,10 @@ export default defineComponent({
 
 		verticalSplit() {
 			return this.$store.getters.splitmode === SPLIT_MODE.VERTICAL
+		},
+
+		itemHeight() {
+			return this.compactMode ? ITEM_HEIGHT.COMPACT : ITEM_HEIGHT.DEFAULT
 		},
 	},
 

--- a/src/components/feed-display/VirtualScroll.vue
+++ b/src/components/feed-display/VirtualScroll.vue
@@ -119,7 +119,7 @@ export default defineComponent({
 
 	methods: {
 		addToSeen(children) {
-			if (children) {
+			if (this.$el.offsetParent && children) {
 				children.forEach((child) => {
 					if (child.el && !this._seenItems.has(child.key) && child.props.item) {
 						this._seenItems.set(child.key, { offset: child.el.offsetTop, item: child.props.item })
@@ -158,10 +158,16 @@ export default defineComponent({
 		},
 
 		scrollToItem(currentIndex) {
-			/*
-			 * set scroll positon to current item
-			*/
 			this.$nextTick(() => {
+				/*
+				 * restore view port when closing details view
+				 */
+				if (this.$el.scrollHeight > 0 && this.viewport.height === 0) {
+					this.viewport = this.$el.getBoundingClientRect()
+				}
+				/*
+				 * set scroll position to current item
+				*/
 				this.scrollTop = this.rowHeight * currentIndex
 			})
 		},

--- a/src/enums/index.ts
+++ b/src/enums/index.ts
@@ -20,3 +20,8 @@ export enum SPLIT_MODE {
 	HORIZONTAL = '1',
 	OFF = '2',
 }
+
+export enum ITEM_HEIGHT {
+	DEFAULT = '111',
+	COMPACT = '44',
+}

--- a/tests/javascript/unit/components/ContentTemplate.spec.ts
+++ b/tests/javascript/unit/components/ContentTemplate.spec.ts
@@ -1,0 +1,157 @@
+import { mount } from '@vue/test-utils'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+import Vuex, { Store } from 'vuex'
+import ContentTemplate from '../../../../src/components/ContentTemplate.vue'
+import { ACTIONS, MUTATIONS } from '../../../../src/store/index.ts'
+
+vi.mock('@nextcloud/axios')
+
+describe('ContentTemplate.vue', () => {
+	'use strict'
+
+	let oldestFirst = false
+	let selectedId = ref(null)
+	let showAll = false
+	let store: Store<any>
+	let wrapper: any
+
+	const mockItem1 = {
+		id: 1,
+		feedId: 1,
+		title: 'feed item 1',
+		pubDate: Date.now() / 1000,
+		unread: true,
+		starred: true,
+	}
+
+	const mockItem2 = {
+		id: 2,
+		feedId: 1,
+		title: 'feed item 2 ',
+		pubDate: Date.now() / 1000,
+		unread: true,
+		starred: true,
+	}
+
+	const mockItem3 = {
+		id: 3,
+		feedId: 1,
+		title: 'feed item 3 ',
+		pubDate: Date.now() / 1000,
+		unread: true,
+	}
+
+	const mockItem4 = {
+		id: 4,
+		feedId: 1,
+		title: 'feed item 4 ',
+		pubDate: Date.now() / 1000,
+		unread: true,
+	}
+
+	const mockFeed = {
+		id: 1,
+	}
+
+	const commitStub = vi.fn((mutation, param) => {
+		if (mutation === MUTATIONS.SET_SELECTED_ITEM) {
+			selectedId.value = param.id
+		}
+	})
+
+	const dispatchStub = vi.fn((action, param) => {
+		if (action === ACTIONS.MARK_READ) {
+			param.item.unread = false
+		}
+	})
+
+	beforeAll(() => {
+		HTMLElement.prototype.scrollIntoView = vi.fn()
+		HTMLElement.prototype.getBoundingClientRect = vi.fn(() => ({
+			width: 500,
+			height: 500,
+			top: 0,
+			left: 0,
+			bottom: 500,
+			right: 500,
+		}))
+
+		store = new Vuex.Store({
+			state: {
+				items: {
+					allItemsLoaded: {
+						unread: false,
+					},
+					lastItemLoaded: {
+						unread: 4,
+					},
+					fetchingItems: {
+						unread: false,
+					},
+					allItems: [mockItem1, mockItem2, mockItem3, mockItem4],
+				},
+				feeds: {
+				},
+			},
+			getters: {
+				feeds: () => [mockFeed],
+				selected: () => store.state.items.allItems.find((item: FeedItem) => item.id === selectedId.value),
+			},
+		})
+		store.commit = commitStub
+		store.dispatch = dispatchStub
+	})
+
+	beforeEach(() => {
+		wrapper = mount(ContentTemplate, {
+			attachTo: document.body,
+			props: {
+				items: [mockItem1, mockItem2, mockItem3, mockItem4],
+				fetchKey: 'unread',
+			},
+			global: {
+				plugins: [store],
+			},
+		})
+                vi.clearAllMocks()
+	})
+
+	it('should set selected item id and call mark read if unread', async () => {
+		expect(wrapper.vm.selectedFeedItem).toEqual(undefined)
+		wrapper.vm.selectItem(mockItem1)
+		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id })
+		expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem1 })
+		expect(wrapper.vm.selectedFeedItem).toEqual(mockItem1)
+	})
+
+	it('should set selected item id and do not call mark read if read', async () => {
+		mockItem1.unread = false
+		expect(wrapper.vm.selectedFeedItem).toEqual(undefined)
+		wrapper.vm.selectItem(mockItem1)
+		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id })
+		expect(store.dispatch).not.toHaveBeenCalled()
+		expect(wrapper.vm.selectedFeedItem).toEqual(mockItem1)
+	})
+
+	it('should select previous item', () => {
+		wrapper.vm.selectItem(mockItem2)
+		expect(wrapper.vm.selectedFeedItem).toEqual(mockItem2)
+		wrapper.vm.previousItem()
+		expect(wrapper.vm.selectedFeedItem).toEqual(mockItem1)
+	})
+
+	it('should select next item', () => {
+		wrapper.vm.selectItem(mockItem2)
+		expect(wrapper.vm.selectedFeedItem).toEqual(mockItem2)
+		wrapper.vm.nextItem()
+		expect(wrapper.vm.selectedFeedItem).toEqual(mockItem3)
+	})
+
+	it('should select first item', () => {
+		expect(wrapper.vm.selectedFeedItem).toEqual(undefined)
+		wrapper.vm.nextItem()
+		expect(wrapper.vm.selectedFeedItem).toEqual(mockItem1)
+	})
+
+})

--- a/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
@@ -144,6 +144,7 @@ describe('FeedItemDisplayList.vue', () => {
 		mockItem2.unread = true
 		mockItem3.unread = true
 		mockItem4.unread = true
+		selectedItem = undefined
 
 		wrapper = mount(FeedItemDisplayList, {
 			attachTo: document.body,
@@ -208,6 +209,7 @@ describe('FeedItemDisplayList.vue', () => {
 		).toEqual(4)
 
 		// switch to all route with four items
+		selectedItem = undefined
 		await wrapper.setProps({
 			items: [mockItem1, mockItem2, mockItem3, mockItem4],
 			fetchKey: 'all',
@@ -229,6 +231,7 @@ describe('FeedItemDisplayList.vue', () => {
 		).toEqual(4)
 
 		// switch to feed 1 route with three unread and one read item
+		selectedItem = undefined
 		await wrapper.setProps({
 			items: [mockItem2, mockItem3, mockItem4],
 			fetchKey: 'feed-1',
@@ -250,6 +253,7 @@ describe('FeedItemDisplayList.vue', () => {
 		).toEqual(3)
 
 		// switch to folder 1 route with two unread
+		selectedItem = undefined
 		await wrapper.setProps({
 			items: [mockItem3, mockItem4],
 			fetchKey: 'folder-1',
@@ -271,6 +275,7 @@ describe('FeedItemDisplayList.vue', () => {
 		).toEqual(2)
 
 		// switch to starred route with two starred items
+		selectedItem = undefined
 		await wrapper.setProps({
 			items: [mockItem1, mockItem2],
 			fetchKey: 'starred',

--- a/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
@@ -170,6 +170,7 @@ describe('FeedItemDisplayList.vue', () => {
 			items: [mockItem1],
 			fetchKey: 'unread',
 		})
+
 		expect(
 			(wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length,
 			'should create one FeedItemRow item from input',
@@ -177,7 +178,7 @@ describe('FeedItemDisplayList.vue', () => {
 
 		// select first item from unread route
 		expect(selectedItem).toEqual(undefined)
-		await wrapper.vm.clickItem(mockItem1)
+		await wrapper.vm.$refs.feedItemRow1[0].select()
 		expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem1 })
 		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id })
 		expect(selectedItem).toEqual(1)
@@ -218,7 +219,7 @@ describe('FeedItemDisplayList.vue', () => {
 
 		// select first item from all route
 		expect(selectedItem).toEqual(undefined)
-		await wrapper.vm.clickItem(mockItem1)
+		await wrapper.vm.$refs.feedItemRow1[0].select()
 		expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem1 })
 		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id })
 		expect(selectedItem).toEqual(1)
@@ -239,7 +240,7 @@ describe('FeedItemDisplayList.vue', () => {
 
 		// select first unread item mockitem2
 		expect(selectedItem).toEqual(undefined)
-		await wrapper.vm.clickItem(mockItem2)
+		await wrapper.vm.$refs.feedItemRow2[0].select()
 		expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem2 })
 		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem2.id })
 		expect(selectedItem).toEqual(2)
@@ -260,7 +261,7 @@ describe('FeedItemDisplayList.vue', () => {
 
 		// select first unread item mockitem3
 		expect(selectedItem).toEqual(undefined)
-		await wrapper.vm.clickItem(mockItem3)
+		await wrapper.vm.$refs.feedItemRow3[0].select()
 		expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem3 })
 		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem3.id })
 		expect(selectedItem).toEqual(3)
@@ -281,7 +282,7 @@ describe('FeedItemDisplayList.vue', () => {
 
 		// select first starred item
 		expect(selectedItem).toEqual(undefined)
-		await wrapper.vm.clickItem(mockItem1)
+		await wrapper.vm.$refs.feedItemRow1[0].select()
 		expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem1 })
 		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id })
 		expect(selectedItem).toEqual(1)


### PR DESCRIPTION
* Resolves: #3136
* Related: #2964

## Summary

This PR will allow to navigate between articles when showing details in no-split mode or on mobile devices where no-split mode is forced.
I open this as draft, because it needs some testing with different sorting and settings.

Currently implemented is after selecting an item, you can navigate between the items in the list with the shortcut keys or using the navigation arrows. When reaching the end of the actual loaded batch of items, more items are loaded just as it is when scrolling.
Closing the details view will scroll the list to the currently viewed item.

There are also some open design questions: 

Should there some indicator, where you are in the list? see debug text on right screenshot (x items of x items loaded). The problem here is that the frontend has no access to the info how much items are there in total.   

Should changing the route (feed, folder, etc.) automatically select the first item when navigate from the details view? 

Problematic is also when using the sorting newest->oldest. What to do when at the end of the list, when new items are available. Pressing 'r' would refresh the list and deselect the actual item.
Should pressing 'r' refresh the list and open the first item in the list or simple go back to the list with the new items?

I changed also the icons and the position of the arrows to go in line with other apps with similar functionality like go through pictures in files app.

Old:            |  New:
:-:|:-:
![Screenshot 2025-05-26 at 22-45-02 News - Nextcloud](https://github.com/user-attachments/assets/8b2d17e8-bd17-41af-a188-aa31349c681e)|![Screenshot 2025-05-26 at 22-44-46 News - Nextcloud](https://github.com/user-attachments/assets/1199d80a-8c39-4c18-aa7e-938148904c38)


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
