### PR TITLE
fix: close action menu before renaming or deleting navigation item

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -120,10 +120,18 @@
 							@click="markFolderRead(topLevelItem)">
 							{{ t("news", "Mark read") }}
 						</NcActionButton>
-						<NcActionButton v-if="topLevelItem.name !== undefined" icon="icon-rename" @click="renameFolder(topLevelItem)">
+						<NcActionButton
+							v-if="topLevelItem.name !== undefined"
+							icon="icon-rename"
+							:close-after-click="true"
+							@click="renameFolder(topLevelItem)">
 							{{ t("news", "Rename") }}
 						</NcActionButton>
-						<NcActionButton v-if="topLevelItem.name !== undefined" icon="icon-delete" @click="deleteFolder(topLevelItem)">
+						<NcActionButton
+							v-if="topLevelItem.name !== undefined"
+							icon="icon-delete"
+							:close-after-click="true"
+							@click="deleteFolder(topLevelItem)">
 							{{ t("news", "Delete") }}
 						</NcActionButton>
 					</template>

--- a/src/components/SidebarFeedLinkActions.vue
+++ b/src/components/SidebarFeedLinkActions.vue
@@ -83,6 +83,7 @@
 		</NcActionButton>
 		<NcActionButton
 			icon="icon-rename"
+			:close-after-click="true"
 			@click="rename()">
 			{{ t("news", "Rename") }}
 		</NcActionButton>


### PR DESCRIPTION
## Summary

Close action menu before changing navigation item to avoid unexpected errors from the popover component like `TypeError: this.getPopoverContentElement() is undefined`


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
