### PR TITLE
refactor: Feed item list filtering and sorting

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -438,7 +438,7 @@ export default defineComponent({
 			},
 
 			set(newValue) {
-				this.$store.dispatch(ACTIONS.RESET_LAST_ITEM_LOADED)
+				this.$store.commit(MUTATIONS.RESET_ITEM_STATES)
 				this.saveSetting('oldestFirst', newValue)
 			},
 		},
@@ -459,6 +459,7 @@ export default defineComponent({
 			},
 
 			set(newValue) {
+				this.$store.commit(MUTATIONS.RESET_ITEM_STATES)
 				this.saveSetting('showAll', newValue)
 			},
 		},

--- a/src/components/SidebarFeedLinkActions.vue
+++ b/src/components/SidebarFeedLinkActions.vue
@@ -128,7 +128,7 @@ import RssIcon from 'vue-material-design-icons/Rss.vue'
 import TextLongIcon from 'vue-material-design-icons/TextLong.vue'
 import TextShortIcon from 'vue-material-design-icons/TextShort.vue'
 import { FEED_ORDER, FEED_UPDATE_MODE } from '../enums/index.ts'
-import { ACTIONS } from '../store/index.ts'
+import { ACTIONS, MUTATIONS } from '../store/index.ts'
 
 export default defineComponent({
 	/*
@@ -190,6 +190,7 @@ export default defineComponent({
 		},
 
 		setOrdering(ordering: FEED_ORDER) {
+			this.$store.commit(MUTATIONS.SET_LAST_ITEM_LOADED, { key: 'feed-' + String(this.feedId), lastItem: undefined })
 			this.$store.dispatch(ACTIONS.FEED_SET_ORDERING, { feed: this.feed, ordering })
 		},
 

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -279,18 +279,9 @@ export default defineComponent({
 			this.$emit('show-details')
 		},
 
-		outOfScopeFilter(item: FeedItem): boolean {
-			const lastItemLoaded = this.$store.state.items.lastItemLoaded[this.fetchKey]
-			return (this.listOrdering ? lastItemLoaded >= item.id : lastItemLoaded <= item.id)
-		},
-
 		filterSortedItems(): FeedItem[] {
-			let response = [...this.items] as FeedItem[]
+			const response = [...this.items] as FeedItem[]
 
-			// filter items that are already loaded but do not yet match the current view
-			if (this.$store.state.items.lastItemLoaded[this.fetchKey] > 0) {
-				response = response.filter(this.outOfScopeFilter)
-			}
 			return response.sort(this.sort)
 		},
 

--- a/src/components/feed-display/VirtualScroll.vue
+++ b/src/components/feed-display/VirtualScroll.vue
@@ -7,6 +7,7 @@
 import _ from 'lodash'
 import { defineComponent, Fragment, h } from 'vue'
 import { ACTIONS } from '../../store/index.ts'
+import { getOldestFirst } from '../../utils/itemFilter.ts'
 
 const GRID_ITEM_HEIGHT = 200 + 10
 
@@ -72,7 +73,11 @@ export default defineComponent({
 
 		reachedEnd: {
 			handler() {
-				if (!this.reachedEnd) {
+				/*
+				 * When sorting oldest to newest show new items when they arrive
+				 */
+				const oldestFirst = getOldestFirst(this.$store, this.fetchKey)
+				if (oldestFirst && !this.reachedEnd) {
 					this.loadMore()
 				}
 			},

--- a/src/components/routes/All.vue
+++ b/src/components/routes/All.vue
@@ -16,6 +16,7 @@ import type { FeedItem } from '../../types/FeedItem.ts'
 import { defineComponent } from 'vue'
 import ContentTemplate from '../ContentTemplate.vue'
 import { ACTIONS } from '../../store/index.ts'
+import { outOfScopeFilter } from '../../utils/itemFilter.ts'
 
 export default defineComponent({
 	name: 'RoutesAll',
@@ -25,7 +26,7 @@ export default defineComponent({
 
 	computed: {
 		allItems(): FeedItem[] {
-			return this.$store.getters.allItems
+			return outOfScopeFilter(this.$store, this.$store.getters.allItems, 'all')
 		},
 
 		loading() {

--- a/src/components/routes/All.vue
+++ b/src/components/routes/All.vue
@@ -15,8 +15,8 @@ import type { FeedItem } from '../../types/FeedItem.ts'
 
 import { defineComponent } from 'vue'
 import ContentTemplate from '../ContentTemplate.vue'
-import { ACTIONS } from '../../store/index.ts'
-import { outOfScopeFilter } from '../../utils/itemFilter.ts'
+import { ACTIONS, MUTATIONS } from '../../store/index.ts'
+import { outOfScopeFilter, sortedFeedItems } from '../../utils/itemFilter.ts'
 
 export default defineComponent({
 	name: 'RoutesAll',
@@ -26,12 +26,31 @@ export default defineComponent({
 
 	computed: {
 		allItems(): FeedItem[] {
-			return outOfScopeFilter(this.$store, this.$store.getters.allItems, 'all')
+			let items = this.$store.getters.allItems
+			/*
+			 * Sorting items is needed because the allItems array can contain
+			 * different orderings due to possible individual feed sorting
+			 */
+			items = sortedFeedItems(items, this.oldestFirst)
+			return outOfScopeFilter(this.$store, items, 'all')
 		},
 
 		loading() {
 			return this.$store.getters.loading
 		},
+
+		oldestFirst() {
+			return this.$store.getters.oldestFirst
+		},
+	},
+
+	created() {
+		/*
+		 * When sorting newest to oldest lastItemLoaded needs to be reset to get new items for this route
+		 */
+		if (this.oldestFirst === false) {
+			this.$store.commit(MUTATIONS.SET_LAST_ITEM_LOADED, { key: 'all', lastItem: undefined })
+		}
 	},
 
 	methods: {

--- a/src/components/routes/All.vue
+++ b/src/components/routes/All.vue
@@ -15,7 +15,7 @@ import type { FeedItem } from '../../types/FeedItem.ts'
 
 import { defineComponent } from 'vue'
 import ContentTemplate from '../ContentTemplate.vue'
-import { ACTIONS, MUTATIONS } from '../../store/index.ts'
+import { ACTIONS } from '../../store/index.ts'
 
 export default defineComponent({
 	name: 'RoutesAll',
@@ -31,10 +31,6 @@ export default defineComponent({
 		loading() {
 			return this.$store.getters.loading
 		},
-	},
-
-	created() {
-		this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: undefined })
 	},
 
 	methods: {

--- a/src/components/routes/Feed.vue
+++ b/src/components/routes/Feed.vue
@@ -22,6 +22,7 @@ import { mapState } from 'vuex'
 import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import ContentTemplate from '../ContentTemplate.vue'
 import { ACTIONS } from '../../store/index.ts'
+import { outOfScopeFilter } from '../../utils/itemFilter.ts'
 import { updateUnreadCache } from '../../utils/unreadCache.ts'
 
 export default defineComponent({
@@ -55,7 +56,7 @@ export default defineComponent({
 		},
 
 		items(): FeedItem[] {
-			return this.feedItems ?? []
+			return outOfScopeFilter(this.$store, this.feedItems, 'feed-' + this.feedId) ?? []
 		},
 
 		id(): number {

--- a/src/components/routes/Feed.vue
+++ b/src/components/routes/Feed.vue
@@ -20,7 +20,7 @@ import { defineComponent } from 'vue'
 import { mapState } from 'vuex'
 import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import ContentTemplate from '../ContentTemplate.vue'
-import { ACTIONS, MUTATIONS } from '../../store/index.ts'
+import { ACTIONS } from '../../store/index.ts'
 
 export default defineComponent({
 	name: 'RoutesFeed',
@@ -59,10 +59,6 @@ export default defineComponent({
 		loading() {
 			return this.$store.getters.loading
 		},
-	},
-
-	created() {
-		this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: undefined })
 	},
 
 	methods: {

--- a/src/components/routes/Folder.vue
+++ b/src/components/routes/Folder.vue
@@ -21,7 +21,7 @@ import { defineComponent } from 'vue'
 import { mapState } from 'vuex'
 import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import ContentTemplate from '../ContentTemplate.vue'
-import { ACTIONS, MUTATIONS } from '../../store/index.ts'
+import { ACTIONS } from '../../store/index.ts'
 
 export default defineComponent({
 	name: 'RoutesFolder',
@@ -72,10 +72,6 @@ export default defineComponent({
 
 			return totalUnread
 		},
-	},
-
-	created() {
-		this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: undefined })
 	},
 
 	methods: {

--- a/src/components/routes/Folder.vue
+++ b/src/components/routes/Folder.vue
@@ -23,6 +23,7 @@ import { mapState } from 'vuex'
 import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import ContentTemplate from '../ContentTemplate.vue'
 import { ACTIONS } from '../../store/index.ts'
+import { outOfScopeFilter } from '../../utils/itemFilter.ts'
 import { updateUnreadCache } from '../../utils/unreadCache.ts'
 
 export default defineComponent({
@@ -55,7 +56,7 @@ export default defineComponent({
 		},
 
 		items(): FeedItem[] {
-			return this.folderItems ?? []
+			return outOfScopeFilter(this.$store, this.folderItems, 'folder-' + this.folderId) ?? []
 		},
 
 		id(): number {

--- a/src/components/routes/Starred.vue
+++ b/src/components/routes/Starred.vue
@@ -18,8 +18,8 @@ import { defineComponent } from 'vue'
 import { mapState } from 'vuex'
 import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import ContentTemplate from '../ContentTemplate.vue'
-import { ACTIONS } from '../../store/index.ts'
-import { outOfScopeFilter } from '../../utils/itemFilter.ts'
+import { ACTIONS, MUTATIONS } from '../../store/index.ts'
+import { outOfScopeFilter, sortedFeedItems } from '../../utils/itemFilter.ts'
 
 export default defineComponent({
 	name: 'RoutesStarred',
@@ -31,12 +31,31 @@ export default defineComponent({
 	computed: {
 		...mapState(['items']),
 		starred(): FeedItem[] {
-			return outOfScopeFilter(this.$store, this.$store.getters.starred, 'starred')
+			let items = this.$store.getters.starred
+			/*
+			 * Sorting items is needed because the allItems array can contain
+			 * different orderings due to possible individual feed sorting
+			 */
+			items = sortedFeedItems(items, this.oldestFirst)
+			return outOfScopeFilter(this.$store, items, 'starred')
 		},
 
 		loading() {
 			return this.$store.getters.loading
 		},
+
+		oldestFirst() {
+			return this.$store.getters.oldestFirst
+		},
+	},
+
+	created() {
+		/*
+		 * When sorting newest to oldest lastItemLoaded needs to be reset to get new items for this route
+		 */
+		if (this.oldestFirst === false) {
+			this.$store.commit(MUTATIONS.SET_LAST_ITEM_LOADED, { key: 'starred', lastItem: undefined })
+		}
 	},
 
 	methods: {

--- a/src/components/routes/Starred.vue
+++ b/src/components/routes/Starred.vue
@@ -18,7 +18,7 @@ import { defineComponent } from 'vue'
 import { mapState } from 'vuex'
 import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import ContentTemplate from '../ContentTemplate.vue'
-import { ACTIONS, MUTATIONS } from '../../store/index.ts'
+import { ACTIONS } from '../../store/index.ts'
 
 export default defineComponent({
 	name: 'RoutesStarred',
@@ -36,10 +36,6 @@ export default defineComponent({
 		loading() {
 			return this.$store.getters.loading
 		},
-	},
-
-	created() {
-		this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: undefined })
 	},
 
 	methods: {

--- a/src/components/routes/Starred.vue
+++ b/src/components/routes/Starred.vue
@@ -19,6 +19,7 @@ import { mapState } from 'vuex'
 import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import ContentTemplate from '../ContentTemplate.vue'
 import { ACTIONS } from '../../store/index.ts'
+import { outOfScopeFilter } from '../../utils/itemFilter.ts'
 
 export default defineComponent({
 	name: 'RoutesStarred',
@@ -30,7 +31,7 @@ export default defineComponent({
 	computed: {
 		...mapState(['items']),
 		starred(): FeedItem[] {
-			return this.$store.getters.starred
+			return outOfScopeFilter(this.$store, this.$store.getters.starred, 'starred')
 		},
 
 		loading() {

--- a/src/components/routes/Unread.vue
+++ b/src/components/routes/Unread.vue
@@ -19,6 +19,7 @@ import { mapState } from 'vuex'
 import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import ContentTemplate from '../ContentTemplate.vue'
 import { ACTIONS } from '../../store/index.ts'
+import { outOfScopeFilter } from '../../utils/itemFilter.ts'
 import { updateUnreadCache } from '../../utils/unreadCache.ts'
 
 export default defineComponent({
@@ -41,7 +42,7 @@ export default defineComponent({
 		},
 
 		unread(): FeedItem[] {
-			return this.unreadCache ?? []
+			return outOfScopeFilter(this.$store, this.unreadCache, 'unread') ?? []
 		},
 
 		loading() {

--- a/src/components/routes/Unread.vue
+++ b/src/components/routes/Unread.vue
@@ -18,7 +18,7 @@ import { defineComponent } from 'vue'
 import { mapState } from 'vuex'
 import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import ContentTemplate from '../ContentTemplate.vue'
-import { ACTIONS, MUTATIONS } from '../../store/index.ts'
+import { ACTIONS } from '../../store/index.ts'
 
 export default defineComponent({
 	name: 'RoutesUnread',
@@ -69,13 +69,6 @@ export default defineComponent({
 
 			immediate: true,
 		},
-	},
-
-	created() {
-		this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: undefined })
-		if (this.unread === undefined) {
-			this.$store.dispatch(ACTIONS.FETCH_UNREAD)
-		}
 	},
 
 	methods: {

--- a/src/components/routes/Unread.vue
+++ b/src/components/routes/Unread.vue
@@ -19,6 +19,7 @@ import { mapState } from 'vuex'
 import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import ContentTemplate from '../ContentTemplate.vue'
 import { ACTIONS } from '../../store/index.ts'
+import { updateUnreadCache } from '../../utils/unreadCache.ts'
 
 export default defineComponent({
 	name: 'RoutesUnread',
@@ -58,13 +59,7 @@ export default defineComponent({
 		// need cache so we aren't always removing items when they get read
 		'$store.getters.unread': {
 			handler(newItems) {
-				const cachedItemIds = new Set(this.unreadCache.map((item) => item.id))
-
-				for (const item of newItems) {
-					if (!cachedItemIds.has(item.id)) {
-						this.unreadCache.push(item)
-					}
-				}
+				updateUnreadCache(newItems, this.unreadCache)
 			},
 
 			immediate: true,

--- a/src/components/routes/Unread.vue
+++ b/src/components/routes/Unread.vue
@@ -18,8 +18,8 @@ import { defineComponent } from 'vue'
 import { mapState } from 'vuex'
 import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import ContentTemplate from '../ContentTemplate.vue'
-import { ACTIONS } from '../../store/index.ts'
-import { outOfScopeFilter } from '../../utils/itemFilter.ts'
+import { ACTIONS, MUTATIONS } from '../../store/index.ts'
+import { outOfScopeFilter, sortedFeedItems } from '../../utils/itemFilter.ts'
 import { updateUnreadCache } from '../../utils/unreadCache.ts'
 
 export default defineComponent({
@@ -41,12 +41,26 @@ export default defineComponent({
 			return this.$store.state.items.newestItemId === 0
 		},
 
+		lastItemLoaded() {
+			return this.$store.state.items.lastItemLoaded.unread
+		},
+
 		unread(): FeedItem[] {
-			return outOfScopeFilter(this.$store, this.unreadCache, 'unread') ?? []
+			let items = this.unreadCache ?? []
+			/*
+			 * Sorting items is needed because the allItems array can contain
+			 * different orderings due to possible individual feed sorting
+			 */
+			items = sortedFeedItems(items, this.oldestFirst)
+			return outOfScopeFilter(this.$store, items, 'unread')
 		},
 
 		loading() {
 			return this.$store.getters.loading
+		},
+
+		oldestFirst() {
+			return this.$store.getters.oldestFirst
 		},
 	},
 
@@ -65,6 +79,15 @@ export default defineComponent({
 
 			immediate: true,
 		},
+	},
+
+	created() {
+		/*
+		 * When sorting newest to oldest lastItemLoaded needs to be reset to get new items for this route
+		 */
+		if (this.oldestFirst === false) {
+			this.$store.commit(MUTATIONS.SET_LAST_ITEM_LOADED, { key: 'unread', lastItem: undefined })
+		}
 	},
 
 	methods: {

--- a/src/store/item.ts
+++ b/src/store/item.ts
@@ -17,7 +17,6 @@ export const FEED_ITEM_ACTION_TYPES = {
 	FETCH_FEED_ITEMS: 'FETCH_FEED_ITEMS',
 	FETCH_FOLDER_FEED_ITEMS: 'FETCH_FOLDER_FEED_ITEMS',
 	FETCH_ITEMS: 'FETCH_ITEMS',
-	RESET_LAST_ITEM_LOADED: 'RESET_LAST_ITEM_LOADED',
 }
 
 export type ItemState = {
@@ -370,19 +369,6 @@ export const actions = {
 		item.starred = false
 		commit(FEED_ITEM_MUTATION_TYPES.UPDATE_ITEM, { item })
 		commit(FEED_ITEM_MUTATION_TYPES.SET_STARRED_COUNT, state.starredCount - 1)
-	},
-
-	/**
-	 * Reset lastItemsLoaded counters
-	 *
-	 * @param param0 ActionParams
-	 * @param param0.commit Commit action
-	 * @param param0.state ItemState
-	 */
-	[FEED_ITEM_ACTION_TYPES.RESET_LAST_ITEM_LOADED]({ commit, state }: ActionParams<ItemState>) {
-		Object.entries(state.lastItemLoaded).forEach(([key]) => {
-			commit(FEED_ITEM_MUTATION_TYPES.SET_LAST_ITEM_LOADED, { key, lastItem: undefined })
-		})
 	},
 }
 

--- a/src/utils/itemFilter.ts
+++ b/src/utils/itemFilter.ts
@@ -1,0 +1,33 @@
+import { FEED_ORDER } from '../enums/index.ts'
+/**
+ * filter out items that are already loaded but not in view range
+ *
+ * @param store - The vuex store instance containing application state
+ * @param items - An array of feed items to be filtered
+ * @param fetchKey - A key used for the selected route
+ * @return The filtered array of feed items.
+ */
+export function outOfScopeFilter(store, items: FeedItem[], fetchKey: string): FeedItem[] {
+	const lastItemLoaded = store.state.items.lastItemLoaded?.[fetchKey]
+	const feedOrdering = store.state.feeds?.ordering?.[fetchKey]
+	let oldestFirst = false
+
+	if (!lastItemLoaded) {
+		return items
+	}
+
+	/*
+	 * feeds can have different sorting
+	 */
+	if (!fetchKey.startsWith('feed-') || feedOrdering === FEED_ORDER.DEFAULT) {
+		oldestFirst = store.getters.oldestFirst
+	} else if (feedOrdering === FEED_ORDER.OLDEST) {
+		oldestFirst = true
+	} else if (feedOrdering === FEED_ORDER.NEWEST) {
+		oldestFirst = false
+	}
+
+	return items.filter((item) => {
+		return (oldestFirst ? lastItemLoaded >= item.id : lastItemLoaded <= item.id)
+	})
+}

--- a/src/utils/unreadCache.ts
+++ b/src/utils/unreadCache.ts
@@ -1,0 +1,15 @@
+/**
+ * updates unread cache
+ *
+ * @param newItems latest unread items from store
+ * @param unreadCache cache array to update
+ */
+export function updateUnreadCache(newItems, unreadCache) {
+	const cachedItemIds = new Set(unreadCache.map((item) => item.id))
+
+	for (const item of newItems) {
+		if (!cachedItemIds.has(item.id)) {
+			unreadCache.push(item)
+		}
+	}
+}

--- a/tests/javascript/unit/components/SidebarFeedLinkActions.spec.ts
+++ b/tests/javascript/unit/components/SidebarFeedLinkActions.spec.ts
@@ -32,6 +32,7 @@ describe('SidebarFeedLinkActions.vue', () => {
 							feeds,
 						},
 						dispatch: vi.fn(),
+						commit: vi.fn(),
 					},
 				},
 			},

--- a/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
@@ -215,7 +215,7 @@ describe('FeedItemDisplayList.vue', () => {
 
 		// switch to feed 1 route with three unread and one read item
 		await wrapper.setProps({
-			items: [mockItem1, mockItem2, mockItem3, mockItem4],
+			items: [mockItem2, mockItem3, mockItem4],
 			fetchKey: 'feed-1',
 		})
 		expect(
@@ -234,9 +234,9 @@ describe('FeedItemDisplayList.vue', () => {
 			'should select first unread FeedItemRow item from feed-1 route',
 		).toEqual(3)
 
-		// switch to folder 1 route with two unread and two read items
+		// switch to folder 1 route with two unread
 		await wrapper.setProps({
-			items: [mockItem1, mockItem2, mockItem3, mockItem4],
+			items: [mockItem3, mockItem4],
 			fetchKey: 'folder-1',
 		})
 		expect(
@@ -408,7 +408,7 @@ describe('FeedItemDisplayList.vue', () => {
 		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(4)
 	})
 
-	it('should clear read FeedItemRow items from input after refresh', async () => {
+	it('should commit RESET_ITEM_STATES and dispatch FETCH_FEEDS when refreshing app', () => {
 		wrapper = mount(FeedItemDisplayList, {
 			attachTo: document.body,
 			props: {
@@ -423,15 +423,9 @@ describe('FeedItemDisplayList.vue', () => {
 			},
 		})
 
-		// make sure dom elements are mounted properly
-		await nextTick()
-		await nextTick()
-
-		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(4)
-		mockItem1.unread = false
-		mockItem2.unread = false
 		wrapper.vm.refreshApp()
-		await nextTick()
-		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(2)
+		expect(store.commit).toBeCalledWith(MUTATIONS.RESET_ITEM_STATES)
+		expect(store.dispatch).toBeCalledWith(ACTIONS.FETCH_FEEDS)
 	})
+
 })

--- a/tests/javascript/unit/components/routes/All.spec.ts
+++ b/tests/javascript/unit/components/routes/All.spec.ts
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue'
 import Vuex, { Store } from 'vuex'
 import { shallowMount } from '@vue/test-utils'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -11,11 +12,31 @@ describe('All.vue', () => {
 	'use strict'
 	let wrapper: any
 
-	const mockItem = {
-		feedId: 1,
-		title: 'feed item',
-		pubDate: Date.now() / 1000,
-	}
+	const mockItems = [
+		{
+			id: 1,
+			feedId: 1,
+			title: 'feed item',
+			pubDate: Date.now() / 1000,
+			unread: true,
+		}, {
+			id: 2,
+			feedId: 1,
+			title: 'feed item 2',
+			pubDate: Date.now() / 1000,
+			unread: true,
+		}, {
+			id: 3,
+			feedId: 1,
+			title: 'feed item 3',
+			pubDate: Date.now() / 1000,
+		}, {
+			id: 4,
+			feedId: 1,
+			title: 'feed item 4',
+			pubDate: Date.now() / 1000,
+		}
+	]
 
 	let store: Store<any>
 	beforeAll(() => {
@@ -25,12 +46,22 @@ describe('All.vue', () => {
 					fetchingItems: {
 						all: false,
 					},
+					lastItemLoaded: {
+						all: 1,
+					},
+					allItems: mockItems,
+				},
+				feeds: {
+				},
+				app: {
+					oldestFirst: false,
 				},
 			},
 			actions: {
 			},
 			getters: {
-				allItems: () => [mockItem, mockItem, mockItem],
+				allItems: () => mockItems,
+				oldestFirst: (state) => state.app.oldestFirst,
 			},
 		})
 
@@ -38,9 +69,6 @@ describe('All.vue', () => {
 		store.commit = vi.fn()
 
 		wrapper = shallowMount(All, {
-			props: {
-				item: mockItem,
-			},
 			global: {
 				plugins: [store],
 			},
@@ -52,7 +80,21 @@ describe('All.vue', () => {
 	})
 
 	it('should get all items from state', () => {
-		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(3)
+		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(4)
+	})
+
+	it('should get only first item from state ordering oldest>newest', async () => {
+		(wrapper.vm as any).$store.state.items.lastItemLoaded.all = 1;
+		(wrapper.vm as any).$store.state.app.oldestFirst = true
+		await nextTick
+		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(1)
+	})
+
+	it('should get only first item from state ordering newest>oldest', async () => {
+		(wrapper.vm as any).$store.state.items.lastItemLoaded.all = 4;
+		(wrapper.vm as any).$store.state.app.oldestFirst = false
+		await nextTick
+		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(1)
 	})
 
 	it('should dispatch FETCH_ITEMS action if not fetchingItems.all', () => {

--- a/tests/javascript/unit/components/routes/Feed.spec.ts
+++ b/tests/javascript/unit/components/routes/Feed.spec.ts
@@ -55,7 +55,7 @@ describe('Feed.vue', () => {
                                                 'feed-123': false,
                                         },
                                         lastItemLoaded: {
-                                                'feed-123': 0,
+                                                'feed-123': 1,
                                         },
 					fetchingItems: {
 						'feed-123': false,
@@ -69,11 +69,20 @@ describe('Feed.vue', () => {
 				},
 				app: {
 					loading: false,
-					showAll: true,
+					showAll: false,
 					oldestFirst: false,
 				},
 			},
 			actions: {
+			},
+			mutations: {
+				SET_SHOW_ALL(state, value) {
+					state.app.showAll = value
+					state.items.newestItemId = 0
+				},
+				SET_LAST_ITEM_LOADED(state, { key, lastItem }) {
+					state.items.lastItemLoaded[key] = lastItem
+				},
 			},
 			getters: {
 				feeds: () => [mockFeed],
@@ -84,7 +93,6 @@ describe('Feed.vue', () => {
 		})
 
 		store.dispatch = vi.fn()
-		store.commit = vi.fn()
 	})
 
 	beforeEach(() => {
@@ -98,24 +106,26 @@ describe('Feed.vue', () => {
 				plugins: [store],
 			},
 		})
+		wrapper.vm.$store.state.items.lastItemLoaded['feed-123'] = 1
+		wrapper.vm.$store.state.items.newestItemId = 4
 	})
 
 	it('should get two feed items from state when showAll is disabled', async () => {
-		wrapper.vm.$store.state.app.showAll = false
+		store.commit('SET_SHOW_ALL', false)
 		await nextTick()
 		expect(wrapper.vm.$store.getters.showAll).toEqual(false)
 		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(2)
 	})
 
 	it('should get four feed items from state when showAll is enabled', async () => {
-		wrapper.vm.$store.state.app.showAll = true
+		store.commit('SET_SHOW_ALL', true)
 		await nextTick()
 		expect(wrapper.vm.$store.getters.showAll).toEqual(true)
 		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(4)
 	})
 
 	it('should clear unread cache when changing feed', async () => {
-		wrapper.vm.$store.state.app.showAll = false
+		store.commit('SET_SHOW_ALL', false)
 		await nextTick()
 		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(2)
                 await wrapper.setProps({

--- a/tests/javascript/unit/components/routes/Folder.spec.ts
+++ b/tests/javascript/unit/components/routes/Folder.spec.ts
@@ -41,9 +41,11 @@ describe('Folder.vue', () => {
 					allItems: [{
 						feedId: 789,
 						title: 'feed item',
+						unread: true,
 					}, {
 						feedId: 456,
 						title: 'feed item 2',
+						unread: true,
 					}],
 				},
 			},

--- a/tests/javascript/unit/components/routes/Starred.spec.ts
+++ b/tests/javascript/unit/components/routes/Starred.spec.ts
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue'
 import Vuex, { Store } from 'vuex'
 import { shallowMount } from '@vue/test-utils'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -11,11 +12,35 @@ describe('Starred.vue', () => {
 	'use strict'
 	let wrapper: any
 
-	const mockItem = {
-		feedId: 1,
-		title: 'feed item',
-		pubDate: Date.now() / 1000,
-	}
+	const mockItems = [
+		{
+			id: 1,
+			feedId: 1,
+			title: 'feed item',
+			pubDate: Date.now() / 1000,
+			unread: true,
+			starred: true,
+		}, {
+			id: 2,
+			feedId: 1,
+			title: 'feed item 2',
+			pubDate: Date.now() / 1000,
+			unread: true,
+			starred: true,
+		}, {
+			id: 3,
+			feedId: 1,
+			title: 'feed item 3',
+			pubDate: Date.now() / 1000,
+			starred: true,
+		}, {
+			id: 4,
+			feedId: 1,
+			title: 'feed item 4',
+			pubDate: Date.now() / 1000,
+			starred: true,
+		}
+	]
 
 	let store: Store<any>
 	beforeAll(() => {
@@ -25,12 +50,21 @@ describe('Starred.vue', () => {
 					fetchingItems: {
 						starred: false,
 					},
+					lastItemLoaded: {
+						starred: 1,
+					},
+				},
+				feeds: {
+				},
+				app: {
+					oldestFirst: false,
 				},
 			},
 			actions: {
 			},
 			getters: {
-				starred: () => [mockItem],
+				starred: () => mockItems,
+				oldestFirst: (state) => state.app.oldestFirst,
 			},
 		})
 
@@ -38,9 +72,6 @@ describe('Starred.vue', () => {
 		store.commit = vi.fn()
 
 		wrapper = shallowMount(Starred, {
-			props: {
-				item: mockItem,
-			},
 			global: {
 				plugins: [store],
 			},
@@ -52,6 +83,20 @@ describe('Starred.vue', () => {
 	})
 
 	it('should get starred items from state', () => {
+		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(4)
+	})
+
+	it('should get only first item from state ordering oldest>newest', async () => {
+		(wrapper.vm as any).$store.state.items.lastItemLoaded.starred = 1;
+		(wrapper.vm as any).$store.state.app.oldestFirst = true
+		await nextTick
+		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(1)
+	})
+
+	it('should get only first item from state ordering newest>oldest', async () => {
+		(wrapper.vm as any).$store.state.items.lastItemLoaded.starred = 4;
+		(wrapper.vm as any).$store.state.app.oldestFirst = false
+		await nextTick
 		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(1)
 	})
 

--- a/tests/javascript/unit/components/routes/Unread.spec.ts
+++ b/tests/javascript/unit/components/routes/Unread.spec.ts
@@ -1,3 +1,4 @@
+import { nextTick } from 'vue'
 import Vuex, { Store } from 'vuex'
 import { shallowMount } from '@vue/test-utils'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -11,11 +12,33 @@ describe('Unread.vue', () => {
 	'use strict'
 	let wrapper: any
 
-	const mockItem = {
-		feedId: 1,
-		title: 'feed item',
-		pubDate: Date.now() / 1000,
-	}
+	const mockItems = [
+		{
+			id: 1,
+			feedId: 1,
+			title: 'feed item',
+			pubDate: Date.now() / 1000,
+			unread: true,
+		}, {
+			id: 2,
+			feedId: 1,
+			title: 'feed item 2',
+			pubDate: Date.now() / 1000,
+			unread: true,
+		}, {
+			id: 3,
+			feedId: 1,
+			title: 'feed item 3',
+			pubDate: Date.now() / 1000,
+			unread: true,
+		}, {
+			id: 4,
+			feedId: 1,
+			title: 'feed item 4',
+			pubDate: Date.now() / 1000,
+			unread: true,
+		}
+	]
 
 	let store: Store<any>
 	beforeAll(() => {
@@ -25,15 +48,25 @@ describe('Unread.vue', () => {
 					fetchingItems: {
 						unread: false,
 					},
+					lastItemLoaded: {
+						unread: 1,
+					},
 					newestItemId: {
 						number: 12,
 					},
+					unread: mockItems,
+				},
+				feeds: {
+				},
+				app: {
+					oldestFirst: false,
 				},
 			},
 			actions: {
 			},
 			getters: {
-				unread: () => [mockItem, mockItem],
+				unread: () => mockItems,
+				oldestFirst: (state) => state.app.oldestFirst,
 			},
 		})
 
@@ -41,9 +74,6 @@ describe('Unread.vue', () => {
 		store.commit = vi.fn()
 
 		wrapper = shallowMount(Unread, {
-			props: {
-				item: mockItem,
-			},
 			global: {
 				plugins: [store],
 			},
@@ -55,7 +85,21 @@ describe('Unread.vue', () => {
 	})
 
 	it('should get unread items from state', () => {
-		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(2)
+		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(4)
+	})
+
+	it('should get only first item from state ordering oldest>newest', async () => {
+		(wrapper.vm as any).$store.state.items.lastItemLoaded.unread = 1;
+		(wrapper.vm as any).$store.state.app.oldestFirst = true
+		await nextTick
+		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(1)
+	})
+
+	it('should get only first item from state ordering newest>oldest', async () => {
+		(wrapper.vm as any).$store.state.items.lastItemLoaded.unread = 4;
+		(wrapper.vm as any).$store.state.app.oldestFirst = false
+		await nextTick
+		expect((wrapper.findComponent(ContentTemplate)).props().items.length).toEqual(1)
 	})
 
 	it('should dispatch FETCH_UNREAD action if not fetchingItems.unread', () => {


### PR DESCRIPTION
Related: #3191 

## Summary

This PR moves the sorting and filter logic to the route components, where they actually belong, as sorting or filtering only takes place via the api calls with their parameters like showAll and oldestFirst.

Among other things, this is necessary so that all child components can easier access the same array of feed items. This will also help with implementing keeping details view when switching between feeds and folders in #3191 

The items are filtered and re-sorted in the route component depending on the settings. The sorting is necessary because the array allItems contains blocks of items with different sorting due to possible individual feed sorting.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
