### PR TITLE
fix: enable title scrolling in compact mode on mobile only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [26.x.x]
 ### Changed
+- enable title scrolling in compact mode on mobile only
 
 ### Fixed
 

--- a/src/components/feed-display/FeedItemRow.vue
+++ b/src/components/feed-display/FeedItemRow.vue
@@ -32,7 +32,7 @@
 		<div class="main-container" :class="{ compact: compactMode }">
 			<h1
 				class="title-container"
-				:class="{ compact: compactMode, unread: item.unread }"
+				:class="{ compact: compactMode, mobile: isMobile, unread: item.unread }"
 				:dir="item.rtl && 'rtl'">
 				{{ item.title }}
 			</h1>
@@ -102,6 +102,7 @@
 import type { Feed } from '../../types/Feed.ts'
 import type { FeedItem } from '../../types/FeedItem.ts'
 
+import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import { defineComponent } from 'vue'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActions from '@nextcloud/vue/components/NcActions'
@@ -162,6 +163,7 @@ export default defineComponent({
 
 	data: () => {
 		return {
+			isMobile: useIsMobile(),
 			showShareMenu: false,
 			shareItem: undefined,
 		}
@@ -278,9 +280,12 @@ export default defineComponent({
 	.feed-item-row .title-container.compact {
 		flex: 0 1 auto;
 		overflow-y: unset;
-		overflow-x: scroll;
 		max-width: 100%;
 		text-overflow: clip;
+	}
+
+	.feed-item-row .title-container.mobile {
+		overflow-x: scroll;
 	}
 
 	.feed-item-row .intro-container {


### PR DESCRIPTION
* Resolves: #3204
* Related: #3061

## Summary

Enable title scrolling in compact mode on mobile only as it was originally intended (https://github.com/nextcloud/news/commit/d3719e8023c681d494c65e55fdf075aeb322ca8d)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
