### PR TITLE
fix: prevent incorrect "mark read on scroll" behavior after route change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - enable title scrolling in compact mode on mobile only
 
 ### Fixed
+- prevent incorrect "mark read on scroll" behavior after route change
 
 
 # Releases

--- a/src/components/feed-display/VirtualScroll.vue
+++ b/src/components/feed-display/VirtualScroll.vue
@@ -102,12 +102,14 @@ export default defineComponent({
 	},
 
 	unmounted() {
+		this.debouncedMarkRead.flush?.()
+		this.debouncedMarkRead.cancel?.()
 		window.removeEventListener('resize', this.onScroll)
 	},
 
 	updated() {
 		this.$nextTick(this.loadMore)
-		if (!this.$store.getters.preventReadOnScroll) {
+		if (!this.$store.getters.preventReadOnScroll && !this.fetching) {
 			this.addToSeen(this._lastRendered)
 		}
 	},


### PR DESCRIPTION
## Summary

This PR makes "mark read on scroll" more robust and prevents a rare case that after changing to a merged route some items have a wrong calculated offset through initial load more items.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
