### PR TITLE
Release 26.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [26.x.x]
 ### Changed
-- enable title scrolling in compact mode on mobile only
 
 ### Fixed
-- prevent incorrect "mark read on scroll" behavior after route change
-
 
 # Releases
+## [26.0.1] - 2025-06-04
+### Changed
+- enable title scrolling in compact mode on mobile only (#3205)
+
+### Fixed
+- prevent incorrect "mark read on scroll" behavior after route change (#3206)
+
 ## [26.0.0] - 2025-05-29
 ### Fixed
 - content splitter position not recognized when reloading app (#3193)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>26.0.0</version>
+    <version>26.0.1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
## Summary

### Changed
- enable title scrolling in compact mode on mobile only (#3205)

### Fixed
- prevent incorrect "mark read on scroll" behavior after route change (#3206)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
