### PR TITLE
fix: style fixes for articles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - enable title scrolling in compact mode on mobile only
 
 ### Fixed
+- style fixes for `<blockquote>`, `<pre>` and `<code>` in articles
+- keep action bar position when scrolling article
 
 
 # Releases

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -340,7 +340,6 @@ export default defineComponent({
 	$breakpoint-mobile: 1024px;
 
 	.feed-item-display {
-		overflow-y: hidden;
 		display: flex;
 		flex-direction: column;
 	}
@@ -402,6 +401,33 @@ export default defineComponent({
 		margin: 7px 0 14px 0;
 	}
 
+	.article .body blockquote {
+		border-inline-start: 2px solid var(--color-border-dark);
+		padding-inline-start: 10px;
+		font-style: italic;
+		margin: 0;
+	}
+
+	.article .body code {
+		background: var(--color-background-hover);
+		font-family: monospace;
+		padding: 0.2em 0.4em;
+		border-radius: 4px;
+	}
+
+	.article .body pre {
+		background: var(--color-background-hover);
+		padding: 1em;
+		border-radius: 4px;
+		max-width: 100%;
+		overflow-x: auto;
+	}
+
+	.article .body pre code {
+		font-family: monospace;
+		color: var(--color-text-lighter);
+	}
+
 	.article .subtitle {
 		color: var(--color-text-lighter);
 		display: flex;
@@ -430,8 +456,11 @@ export default defineComponent({
 	}
 
 	.action-bar {
+		position: sticky;
+		top: 0;
+		z-index: 10;
+		background: var(--color-main-background);
 		padding: 10px 20px 0px 20px;
-
 		display: flex;
 		justify-content: right;
 	}


### PR DESCRIPTION
* Resolves: #3210

## Summary
This PR adds  style fixes for `<blockquote>`, `<pre>` and `<code>` in articles and now keeps the action bar position when scrolling.

![grafik](https://github.com/user-attachments/assets/a1db7143-91ea-4905-95fa-db1c776be094)


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
