### PR TITLE
fix: explore url does not work when called directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Fixed
 - style fixes for `<blockquote>`, `<pre>` and `<code>` in articles
 - keep action bar position when scrolling article
+- explore `url` does not work when called directly
 
 # Releases
 ## [26.0.1] - 2025-06-04

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -24,6 +24,7 @@ return ['routes' => [
 ['name' => 'page#settings', 'url' => '/settings', 'verb' => 'GET'],
 ['name' => 'page#update_settings', 'url' => '/settings', 'verb' => 'PUT'],
 ['name' => 'page#manifest', 'url' => '/manifest.webapp', 'verb' => 'GET'],
+['name' => 'page#index', 'url' => '/explore', 'verb' => 'GET', 'postfix' => 'view.explore'],
 ['name' => 'page#explore', 'url' => '/explore/feeds.{lang}.json', 'verb' => 'GET'],
 
 // admin

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -82,7 +82,7 @@ SPDX-Licence-Identifier: AGPL-3.0-or-later
 				@update:model-value="update('exploreUrl', exploreUrl)" />
 		</div>
 		<p class="settings-hint">
-			{{ t("news", "If given, this service's URL will be queried for displaying the feeds in the explore feed section. To fall back to the built in explore service, leave this input empty.") }}
+			{{ t("news", "If provided, the URL of this service will be queried to display the feeds in the explore feed section. To fall back to the built in explore service, leave this input empty.") }}
 		</p>
 
 		<div class="field">


### PR DESCRIPTION
* Resolves: #3216

## Summary

Since the router mode change the explore url can't be called directly.

I also changed the admin setting description to force a new translation. The translation seems to be broken from the beginning. The apostrophe should normally be no problem, maybe a bug when the text was initially be created.

`l10n/en_GB.js:    "If given, this service" : "If given, this service",`


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
