### PR TITLE
fix: incorrect feed url in article view when navigating in merged routes such as unread or a folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - keep action bar position when scrolling article
 - explore `url` does not work when called directly
 - radio switches in add feed dialog not working
+- incorrect feed `url` in article view when navigating in merged routes such as unread or a folder
 
 # Releases
 ## [26.0.1] - 2025-06-04

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -93,11 +93,11 @@
 
 			<div class="subtitle" :dir="item.rtl && 'rtl'">
 				<span v-if="!item.sharedBy" class="source">
-					<a :href="feedUrl">
-						{{ getFeed(item.feedId).title }}
+					<a :href="feedUrl + feed.id">
+						{{ feed.title }}
 						<img
-							v-if="getFeed(item.feedId).faviconLink"
-							:src="getFeed(item.feedId).faviconLink"
+							v-if="feed.faviconLink"
+							:src="feed.faviconLink"
 							alt="favicon"
 							style="width: 16px">
 					</a>
@@ -234,11 +234,15 @@ export default defineComponent({
 		return {
 			keepUnread: false,
 			showShareMenu: false,
-			feedUrl: undefined,
+			feedUrl: generateUrl('/apps/news/feed/'),
 		}
 	},
 
 	computed: {
+		feed(): Feed {
+			return this.$store.getters.feeds.find((feed: Feed) => feed.id === this.item.feedId) || {}
+		},
+
 		screenReaderMode() {
 			return this.$store.getters.displaymode === DISPLAY_MODE.SCREENREADER
 		},
@@ -253,7 +257,6 @@ export default defineComponent({
 		if (this.splitModeOff && !this.screenReaderMode) {
 			useHotKey('Escape', this.closeDetails)
 		}
-		this.feedUrl = generateUrl('/apps/news/feed/' + this.item.feedId)
 	},
 
 	methods: {
@@ -274,10 +277,6 @@ export default defineComponent({
 			if (this.screenReaderMode && this.$store.getters.selected !== this.item) {
 				this.$emit('click-item')
 			}
-		},
-
-		getFeed(id: number): Feed {
-			return this.$store.getters.feeds.find((feed: Feed) => feed.id === id) || {}
 		},
 
 		/**

--- a/tests/javascript/unit/components/feed-display/FeedItemDisplay.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemDisplay.spec.ts
@@ -61,7 +61,7 @@ describe('FeedItemDisplay.vue', () => {
 	})
 
 	it('should retrieve feed by ID', () => {
-		const feed = (wrapper.vm as any).getFeed(mockFeed.id)
+		const feed = (wrapper.vm as any).feed
 
 		expect(feed).toEqual(mockFeed)
 	})


### PR DESCRIPTION
## Summary

319a8ff fixed the url but set it only initially when showing an article, it don't change in merged routes when navigating between articles.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
