### PR TITLE
fix: radio switches in add feed dialog not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - style fixes for `<blockquote>`, `<pre>` and `<code>` in articles
 - keep action bar position when scrolling article
 - explore `url` does not work when called directly
+- radio switches in add feed dialog not working
 
 # Releases
 ## [26.0.1] - 2025-06-04

--- a/src/components/AddFeed.vue
+++ b/src/components/AddFeed.vue
@@ -48,7 +48,7 @@
 							style="flex-grow: 1; padding: 22px 12px; margin: 0px;"
 							required>
 
-						<NcCheckboxRadioSwitch v-model:checked="createNewFolder" type="switch">
+						<NcCheckboxRadioSwitch v-model="createNewFolder" type="switch">
 							{{ t("news", "New folder") }}?
 						</NcCheckboxRadioSwitch>
 					</div>
@@ -70,7 +70,7 @@
 					</p>
 
 					<div style="display: flex">
-						<NcCheckboxRadioSwitch v-model:checked="withBasicAuth" type="switch" style="flex-grow: 1;">
+						<NcCheckboxRadioSwitch v-model="withBasicAuth" type="switch" style="flex-grow: 1;">
 							{{ t("news", "Credentials") }}?
 						</NcCheckboxRadioSwitch>
 
@@ -93,7 +93,7 @@
 						</div>
 					</div>
 
-					<NcCheckboxRadioSwitch v-model:checked="autoDiscover" type="switch">
+					<NcCheckboxRadioSwitch v-model="autoDiscover" type="switch">
 						{{ t("news", "Auto discover Feed") }}?
 					</NcCheckboxRadioSwitch>
 


### PR DESCRIPTION
## Summary

The radio switches in the add feed dialog cannot currently be switched.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
