### PR TITLE
feat: add swipe down gesture to refresh item list on mobile devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - explore `url` does not work when called directly
 - radio switches in add feed dialog not working
 - incorrect feed `url` in article view when navigating in merged routes such as unread or a folder
+- `mark read on scroll` can keep some items unread after refreshing item list
 
 # Releases
 ## [26.0.1] - 2025-06-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ## [26.x.x]
 ### Changed
 - implement item navigation when showing details in no-split mode
+- add swipe down event to refresh item list for mobile devices
 
 ### Fixed
 - style fixes for `<blockquote>`, `<pre>` and `<code>` in articles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 - implement item navigation when showing details in no-split mode
 - add swipe down event to refresh item list for mobile devices
+- use three dot menu for `star`, `unread` and `share` button in item list on small devices
 
 ### Fixed
 - style fixes for `<blockquote>`, `<pre>` and `<code>` in articles

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nextcloud/password-confirmation": "^6.0.0-rc.0",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/vue": "^9.0.0-rc.3",
+        "@vueuse/core": "^13.4.0",
         "lodash": "^4.17.21",
         "vue": "^3.5.17",
         "vue-material-design-icons": "^5.3.1",
@@ -3710,7 +3711,7 @@
         "vue": "^3.5.0"
       }
     },
-    "node_modules/@vueuse/core": {
+    "node_modules/@vueuse/components/node_modules/@vueuse/core": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.1.0.tgz",
       "integrity": "sha512-PAauvdRXZvTWXtGLg8cPUFjiZEddTqmogdwYpnn60t08AA5a8Q4hZokBnpTOnVNqySlFlTcRYIC8OqreV4hv3Q==",
@@ -3727,10 +3728,48 @@
         "vue": "^3.5.0"
       }
     },
-    "node_modules/@vueuse/metadata": {
+    "node_modules/@vueuse/components/node_modules/@vueuse/metadata": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.1.0.tgz",
       "integrity": "sha512-+TDd7/a78jale5YbHX9KHW3cEDav1lz1JptwDvep2zSG8XjCsVE+9mHIzjTOaPbHUAk5XiE4jXLz51/tS+aKQw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/core": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.4.0.tgz",
+      "integrity": "sha512-OnK7zW3bTq/QclEk17+vDFN3tuAm8ONb9zQUIHrYQkkFesu3WeGUx/3YzpEp+ly53IfDAT9rsYXgGW6piNZC5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "13.4.0",
+        "@vueuse/shared": "13.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/core/node_modules/@vueuse/shared": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.4.0.tgz",
+      "integrity": "sha512-+AxuKbw8R1gYy5T21V5yhadeNM7rJqb4cPaRI9DdGnnNl3uqXh+unvQ3uCaA2DjYLbNr1+l7ht/B4qEsRegX6A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.4.0.tgz",
+      "integrity": "sha512-CPDQ/IgOeWbqItg1c/pS+Ulum63MNbpJ4eecjFJqgD/JUCJ822zLfpw6M9HzSvL6wbzMieOtIAW/H8deQASKHg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@nextcloud/password-confirmation": "^6.0.0-rc.0",
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/vue": "^9.0.0-rc.3",
+    "@vueuse/core": "^13.4.0",
     "lodash": "^4.17.21",
     "vue": "^3.5.17",
     "vue-material-design-icons": "^5.3.1",

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -174,6 +174,7 @@ export default defineComponent({
 		 */
 		async refreshApp() {
 			this.$refs.virtualScroll.scrollTop = 0
+			this.$refs.virtualScroll._seenItems = new Map()
 			// remove all loaded items
 			this.$store.commit(MUTATIONS.RESET_ITEM_STATES)
 			// refetch feeds

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -40,6 +40,7 @@
 import type { FeedItem } from '../../types/FeedItem.ts'
 
 import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
+import { useSwipe } from '@vueuse/core'
 import { defineComponent } from 'vue'
 import FeedItemDisplay from './FeedItemDisplay.vue'
 import FeedItemRow from './FeedItemRow.vue'
@@ -82,6 +83,7 @@ export default defineComponent({
 		return {
 			selectedItem: undefined as FeedItem | undefined,
 			debouncedClickItem: null,
+			swiping: {},
 		}
 	},
 
@@ -144,7 +146,32 @@ export default defineComponent({
 		}
 	},
 
+	mounted() {
+		this.swiping = useSwipe(this.$el, {
+			onSwipeEnd: this.handleSwipe,
+		})
+	},
+
 	methods: {
+		/**
+		 * handle the swipe event
+		 *
+		 * @param {TouchEvent} e The touch event
+		 * @param {import('@vueuse/core').SwipeDirection} direction The swipe direction of the event
+		 */
+		handleSwipe(e, direction) {
+			const minSwipeY = 70
+			const touchZone = 300
+			if (Math.abs(this.swiping.lengthY) > minSwipeY) {
+				if (this.swiping.coordsStart.y < (touchZone / 2) && direction === 'down') {
+					this.refreshApp()
+				}
+			}
+		},
+
+		/**
+		 * reset item states and sync feed counters
+		 */
 		async refreshApp() {
 			this.$refs.virtualScroll.scrollTop = 0
 			// remove all loaded items

--- a/src/components/feed-display/FeedItemRow.vue
+++ b/src/components/feed-display/FeedItemRow.vue
@@ -52,7 +52,7 @@
 		</div>
 
 		<div class="button-container" @click="$event.stopPropagation()">
-			<NcActions :inline="3">
+			<NcActions :inline="isMobile ? 0 : 3">
 				<NcActionButton
 					:title="t('news', 'Toggle star article')"
 					@click="toggleStarred(item)">


### PR DESCRIPTION
* Resolves: #2826 

## Summary

This PR enables the swipe down gesture to refresh the item list (credits to @nextcloud/vue for the handleSwipe function).

It have also moved the action buttons to a three dot menu on small devices, so that the headlines have more space.
<img src=https://github.com/user-attachments/assets/ea3cd5b4-f077-4fde-bbfa-88c53077449d width=350>

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
