### PR TITLE
fix: only use Last-Modified header if a feed supports it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 
 ### Fixed
+- only use Last-Modified header if a feed supports it
 
 # Releases
 ## [26.0.2] - 2025-06-29

--- a/lib/Fetcher/Client/FeedIoClient.php
+++ b/lib/Fetcher/Client/FeedIoClient.php
@@ -48,13 +48,18 @@ class FeedIoClient implements ClientInterface
      */
     public function getResponse(string $url, ?DateTime $modifiedSince = null) : ResponseInterface
     {
-        $modifiedSince->setTimezone(new \DateTimeZone('GMT'));
         try {
             $options = [
-                'headers' => [
-                    'If-Modified-Since' => $modifiedSince->format('D, d M Y H:i:s e')
-                ]
+                'headers' => []
             ];
+
+            if ($modifiedSince !== null) {
+                $modifiedSince->setTimezone(new \DateTimeZone('GMT'));
+
+                if ($modifiedSince->format('U') >= 0) {
+                    $options['headers']['If-Modified-Since'] = $modifiedSince->format('D, d M Y H:i:s') . ' GMT';
+                }
+            }
 
             $start = microtime(true);
             $psrResponse = $this->guzzleClient->request('get', $url, $options);

--- a/lib/Fetcher/Client/FeedIoClient.php
+++ b/lib/Fetcher/Client/FeedIoClient.php
@@ -53,12 +53,9 @@ class FeedIoClient implements ClientInterface
                 'headers' => []
             ];
 
-            if ($modifiedSince !== null) {
+            if ($modifiedSince !== null && $modifiedSince->format('U') >= 0) {
                 $modifiedSince->setTimezone(new \DateTimeZone('GMT'));
-
-                if ($modifiedSince->format('U') >= 0) {
-                    $options['headers']['If-Modified-Since'] = $modifiedSince->format('D, d M Y H:i:s') . ' GMT';
-                }
+                $options['headers']['If-Modified-Since'] = $modifiedSince->format('D, d M Y H:i:s') . ' GMT';
             }
 
             $start = microtime(true);

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -111,6 +111,25 @@ class FeedFetcher implements IFeedFetcher
         return true;
     }
 
+    /**
+     * Check if the feed server send the Last-Modified header
+     *
+     * @param string $url The URL to check
+     *
+     * @return bool
+     */
+    public function hasLastModifiedHeader(string $url): bool
+    {
+        $hasLastModified = false;
+        try {
+            $client = new Client(['base_uri' => $url]);
+            $response = $client->request('HEAD');
+            $hasLastModified = $response->hasHeader('Last-Modified');
+        } catch (\Exception) {
+            $this->logger->warning('Check for Last-Modified header failed for ' . $url);
+        }
+        return $hasLastModified;
+    }
 
     /**
      * Fetch a feed from remote

--- a/lib/Service/FeedServiceV2.php
+++ b/lib/Service/FeedServiceV2.php
@@ -208,7 +208,9 @@ class FeedServiceV2 extends Service
         bool $full_discover = true,
         ?string $httpLastModified = null
     ): Entity {
-        $httpLastModified ??= (new DateTime("-1 year"))->format(DateTime::RSS);
+        if ($this->feedFetcher->hasLastModifiedHeader($feedUrl)) {
+            $httpLastModified ??= (new DateTime("-1 year"))->format(DateTime::RSS);
+        }
         try {
             /**
              * @var Feed   $feed


### PR DESCRIPTION
* Resolves: #3199

## Summary

This PR changes that the If-Modified-Since Header is only set on feed creation if the feed server supports it and in general the header is only set when it is a valid date, which fixes problems with reddit and maybe other content providers.

This helps also with the forced modfiedSince Date '1800-01-01' from feed-io workaround (#676, https://github.com/alexdebril/feed-io/issues/308).

Since news actual uses a local copy of the FeedIo Client, this also should be done in feedio, if we switch to the originally client someday.
Also feedio uses '1970-01-01' when discover a feed, which also will have that issue.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
