### PR TITLE
Fix: better handling when job status is unkown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 
 ### Fixed
-- only use Last-Modified header if a feed supports it
+- Only use Last-Modified header if a feed supports it
+- Better handling when job status is unknown
 
 # Releases
 ## [26.0.2] - 2025-06-29

--- a/lib/Service/StatusService.php
+++ b/lib/Service/StatusService.php
@@ -75,11 +75,10 @@ class StatusService
      */
     public function getUpdateTime(): int
     {
-
         $time = 0;
 
         $myJobList = $this->jobList->getJobsIterator(UpdaterJob::class, 1, 0);
-        $time = $myJobList->current()->getLastRun();
+        $time = $myJobList->current()?->getLastRun() ?? 0;
 
         return $time;
     }

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -8,15 +8,19 @@ SPDX-Licence-Identifier: AGPL-3.0-or-later
 		:name="t('news', 'News')"
 		class="news-settings"
 		doc-url="https://nextcloud.github.io/news/admin/">
-		<template v-if="lastCron !== 0">
-			<NcNoteCard v-if="oldExecution" type="error">
-				{{ t('news', 'Last job execution ran {relativeTime}. Something seems wrong.', { relativeTime }) }}
+		<div class="field">
+			<NcNoteCard v-if="lastCron === 0" type="warning">
+				{{ t('news', 'No job execution data available. The cron job may not be running properly.') }}
+			</NcNoteCard>
+
+			<NcNoteCard v-else-if="oldExecution" type="error">
+				{{ t('news', 'Last job execution ran {relativeTime}. Something is wrong.', { relativeTime }) }}
 			</NcNoteCard>
 
 			<NcNoteCard v-else type="success">
 				{{ t('news', 'Last job ran {relativeTime}.', { relativeTime }) }}
 			</NcNoteCard>
-		</template>
+		</div>
 		<div class="field">
 			<NcCheckboxRadioSwitch
 				v-model:model-value="useCronUpdates"


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

The returned value might be null and then we get an error.

Also added new information to the admin page in form of a warning card if news does not find a job execution.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
