### PR TITLE
feat: add recently viewed list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [26.x.x]
 ### Changed
+- add recently viewed list
 
 ### Fixed
 - only use Last-Modified header if a feed supports it

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -19,6 +19,7 @@ return ['routes' => [
 ['name' => 'page#index', 'url' => '/all', 'verb' => 'GET', 'postfix' => 'view.all'],
 ['name' => 'page#index', 'url' => '/feed/{feedId}', 'verb' => 'GET', 'postfix' => 'view.feedid'],
 ['name' => 'page#index', 'url' => '/folder/{folderId}', 'verb' => 'GET', 'postfix' => 'view.folderid'],
+['name' => 'page#index', 'url' => '/recent', 'verb' => 'GET', 'postfix' => 'view.recent'],
 ['name' => 'page#index', 'url' => '/starred', 'verb' => 'GET', 'postfix' => 'view.starred'],
 ['name' => 'page#index', 'url' => '/unread', 'verb' => 'GET', 'postfix' => 'view.unread'],
 ['name' => 'page#settings', 'url' => '/settings', 'verb' => 'GET'],

--- a/src/components/ContentTemplate.vue
+++ b/src/components/ContentTemplate.vue
@@ -32,6 +32,7 @@
 					:item="selectedFeedItem"
 					:item-count="items.length"
 					:item-index="currentIndex + 1"
+					:fetch-key="fetchKey"
 					@prev-item="previousItem"
 					@next-item="nextItem"
 					@show-details="showItem(false)" />
@@ -188,7 +189,7 @@ function showItem(value) {
  * @param item to select
  */
 function selectItem(item: FeedItem) {
-	store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: item.id })
+	store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: item.id, key: props.fetchKey })
 	if (!noSplitMode.value || !showDetails.value) {
 		itemListElement.value?.scrollToItem(currentIndex.value)
 	}

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -41,6 +41,13 @@
 					<RssIcon />
 				</template>
 			</NcAppNavigationItem>
+			<NcAppNavigationItem
+				:name="t('news', 'Recently viewed')"
+				:to="{ name: ROUTES.RECENT }">
+				<template #icon>
+					<HistoryIcon />
+				</template>
+			</NcAppNavigationItem>
 			<NcAppNavigationItem :name="t('news', 'Starred')" icon="icon-starred" :to="{ name: ROUTES.STARRED }">
 				<template #counter>
 					<NcCounterBubble :count="items.starredCount" />
@@ -292,6 +299,7 @@ import EyeIcon from 'vue-material-design-icons/Eye.vue'
 import FolderIcon from 'vue-material-design-icons/Folder.vue'
 import FolderAlertIcon from 'vue-material-design-icons/FolderAlert.vue'
 import FolderPlusIcon from 'vue-material-design-icons/FolderPlus.vue'
+import HistoryIcon from 'vue-material-design-icons/History.vue'
 import PlusIcon from 'vue-material-design-icons/Plus.vue'
 import RssIcon from 'vue-material-design-icons/Rss.vue'
 import UploadIcon from 'vue-material-design-icons/Upload.vue'
@@ -323,6 +331,7 @@ export default defineComponent({
 		EarthIcon,
 		FolderAlertIcon,
 		FolderPlusIcon,
+		HistoryIcon,
 		PlusIcon,
 		UploadIcon,
 		DownloadIcon,

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -224,6 +224,14 @@ export default defineComponent({
 			required: false,
 			default: null,
 		},
+
+		/**
+		 * The name of the view e.g. all, unread, feed-10
+		 */
+		fetchKey: {
+			type: String,
+			required: true,
+		},
 	},
 
 	emits: {
@@ -297,7 +305,7 @@ export default defineComponent({
 		 */
 		selectItemOnFocus(): void {
 			if (this.screenReaderMode && !this.isSelected) {
-				this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: this.item.id })
+				this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: this.item.id, key: this.fetchKey })
 			}
 		},
 

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -19,6 +19,7 @@
 							:item-count="items.length"
 							:item-index="index + 1"
 							:item="item"
+							:fetch-key="fetchKey"
 							:class="{ active: selectedItem && selectedItem.id === item.id }" />
 						<FeedItemRow
 							v-else
@@ -27,6 +28,7 @@
 							:item-count="items.length"
 							:item-index="index + 1"
 							:item="item"
+							:fetch-key="fetchKey"
 							:class="{ active: selectedItem && selectedItem.id === item.id }"
 							@show-details="showDetails" />
 					</template>

--- a/src/components/feed-display/FeedItemRow.vue
+++ b/src/components/feed-display/FeedItemRow.vue
@@ -156,6 +156,14 @@ export default defineComponent({
 			type: Number,
 			required: true,
 		},
+
+		/**
+		 * The name of the view e.g. all, unread, feed-10
+		 */
+		fetchKey: {
+			type: String,
+			required: true,
+		},
 	},
 
 	emits: {
@@ -189,7 +197,7 @@ export default defineComponent({
 		formatDateRelative,
 		formatDateISO,
 		select(): void {
-			this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: this.item.id })
+			this.$store.commit(MUTATIONS.SET_SELECTED_ITEM, { id: this.item.id, key: this.fetchKey })
 			this.markRead(this.item)
 			this.$emit('show-details')
 		},

--- a/src/components/routes/Recent.vue
+++ b/src/components/routes/Recent.vue
@@ -1,0 +1,32 @@
+<template>
+	<ContentTemplate
+		:items="recentItems"
+		fetch-key="recent">
+		<template #header>
+			{{ t('news', 'Recently viewed') }}
+		</template>
+	</ContentTemplate>
+</template>
+
+<script lang="ts">
+import type { FeedItem } from '../../types/FeedItem.ts'
+
+import { defineComponent } from 'vue'
+import ContentTemplate from '../ContentTemplate.vue'
+
+export default defineComponent({
+	name: 'RoutesRecent',
+	components: {
+		ContentTemplate,
+	},
+
+	computed: {
+		recentItems(): FeedItem[] {
+			const items = this.$store.getters.allItems
+			const recentItemIds = this.$store.getters.recentItemIds
+			const map = new Map(items.map((item) => [item.id, item]))
+			return recentItemIds.map((id) => map.get(id)).filter(Boolean)
+		},
+	},
+})
+</script>

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,6 +4,7 @@ import AllPanel from '../components/routes/All.vue'
 import ExplorePanel from '../components/routes/Explore.vue'
 import FeedPanel from '../components/routes/Feed.vue'
 import FolderPanel from '../components/routes/Folder.vue'
+import RecentPanel from '../components/routes/Recent.vue'
 import StarredPanel from '../components/routes/Starred.vue'
 import UnreadPanel from '../components/routes/Unread.vue'
 import store from './../store/app.ts'
@@ -17,6 +18,7 @@ export const ROUTES = {
 	FEED: 'feed',
 	FOLDER: 'folder',
 	ALL: 'all',
+	RECENT: 'recent',
 }
 
 /**
@@ -85,6 +87,12 @@ const routes = [
 		name: ROUTES.ALL,
 		path: '/all',
 		component: AllPanel,
+		props: true,
+	},
+	{
+		name: ROUTES.RECENT,
+		path: '/recent',
+		component: RecentPanel,
 		props: true,
 	},
 ]

--- a/src/store/item.ts
+++ b/src/store/item.ts
@@ -30,6 +30,7 @@ export type ItemState = {
 	unreadCount: number
 
 	allItems: FeedItem[]
+	recentItemIds: string[]
 
 	selectedId?: string
 	playingItem?: FeedItem
@@ -46,6 +47,7 @@ const state: ItemState = reactive({
 	unreadCount: 0,
 
 	allItems: [],
+	recentItemIds: [],
 
 	selectedId: undefined,
 	playingItem: undefined,
@@ -63,6 +65,9 @@ const getters = {
 	},
 	allItems(state: ItemState) {
 		return state.allItems
+	},
+	recentItemIds(state: ItemState) {
+		return state.recentItemIds
 	},
 	newestItemId(state: ItemState) {
 		return state.newestItemId
@@ -375,9 +380,16 @@ export const actions = {
 export const mutations = {
 	[FEED_ITEM_MUTATION_TYPES.SET_SELECTED_ITEM](
 		state: ItemState,
-		{ id }: { id: string },
+		{ id, key }: { id: string, key?: string },
 	) {
 		state.selectedId = id
+		if (id && key !== 'recent') {
+			state.recentItemIds = state.recentItemIds.filter((itemId) => itemId !== id)
+			state.recentItemIds.unshift(id)
+			if (state.recentItemIds.length > 20) {
+				state.recentItemIds.pop()
+			}
+		}
 	},
 
 	[FEED_ITEM_MUTATION_TYPES.SET_PLAYING_ITEM](

--- a/tests/javascript/unit/components/ContentTemplate.spec.ts
+++ b/tests/javascript/unit/components/ContentTemplate.spec.ts
@@ -120,7 +120,7 @@ describe('ContentTemplate.vue', () => {
 	it('should set selected item id and call mark read if unread', async () => {
 		expect(wrapper.vm.selectedFeedItem).toEqual(undefined)
 		wrapper.vm.selectItem(mockItem1)
-		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id })
+		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id, key: 'unread' })
 		expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem1 })
 		expect(wrapper.vm.selectedFeedItem).toEqual(mockItem1)
 	})
@@ -129,7 +129,7 @@ describe('ContentTemplate.vue', () => {
 		mockItem1.unread = false
 		expect(wrapper.vm.selectedFeedItem).toEqual(undefined)
 		wrapper.vm.selectItem(mockItem1)
-		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id })
+		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id, key: 'unread' })
 		expect(store.dispatch).not.toHaveBeenCalled()
 		expect(wrapper.vm.selectedFeedItem).toEqual(mockItem1)
 	})

--- a/tests/javascript/unit/components/feed-display/FeedItemDisplay.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemDisplay.spec.ts
@@ -23,6 +23,7 @@ describe('FeedItemDisplay.vue', () => {
 		wrapper = shallowMount(FeedItemDisplay, {
 			props: {
 				item: mockItem,
+				fetchKey: 'all',
 			},
 			global: {
 				mocks: {

--- a/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
@@ -181,7 +181,7 @@ describe('FeedItemDisplayList.vue', () => {
 		expect(selectedItem).toEqual(undefined)
 		await wrapper.vm.$refs.feedItemRow1[0].select()
 		expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem1 })
-		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id })
+		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id, key: 'unread' })
 		expect(selectedItem).toEqual(1)
 		expect(
 			(wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length,
@@ -223,7 +223,7 @@ describe('FeedItemDisplayList.vue', () => {
 		expect(selectedItem).toEqual(undefined)
 		await wrapper.vm.$refs.feedItemRow1[0].select()
 		expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem1 })
-		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id })
+		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id, key: 'all' })
 		expect(selectedItem).toEqual(1)
 		expect(
 			(wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length,
@@ -245,7 +245,7 @@ describe('FeedItemDisplayList.vue', () => {
 		expect(selectedItem).toEqual(undefined)
 		await wrapper.vm.$refs.feedItemRow2[0].select()
 		expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem2 })
-		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem2.id })
+		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem2.id, key: 'feed-1' })
 		expect(selectedItem).toEqual(2)
 		expect(
 			(wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length,
@@ -267,7 +267,7 @@ describe('FeedItemDisplayList.vue', () => {
 		expect(selectedItem).toEqual(undefined)
 		await wrapper.vm.$refs.feedItemRow3[0].select()
 		expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem3 })
-		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem3.id })
+		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem3.id, key: 'folder-1' })
 		expect(selectedItem).toEqual(3)
 		expect(
 			(wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length,
@@ -289,7 +289,7 @@ describe('FeedItemDisplayList.vue', () => {
 		expect(selectedItem).toEqual(undefined)
 		await wrapper.vm.$refs.feedItemRow1[0].select()
 		expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem1 })
-		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id })
+		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id, key: 'starred' })
 		expect(selectedItem).toEqual(1)
 		expect(
 			(wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length,

--- a/tests/javascript/unit/components/feed-display/FeedItemRow.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemRow.spec.ts
@@ -29,6 +29,7 @@ describe('FeedItemRow.vue', () => {
 				item: mockItem,
 				itemIndex: 1,
 				itemCount: 1,
+				fetchKey: 'all',
 			},
 			global: {
 				mocks: {
@@ -140,7 +141,7 @@ describe('FeedItemRow.vue', () => {
 
 		await wrapper.trigger('click')
 
-		expect(commitStub).toHaveBeenCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem.id })
+		expect(commitStub).toHaveBeenCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem.id, key: 'all' })
 		expect(markReadSpy).toHaveBeenCalledWith(mockItem)
 		expect(wrapper.emitted()).toHaveProperty('show-details')
 	})

--- a/tests/javascript/unit/store/item.spec.ts
+++ b/tests/javascript/unit/store/item.spec.ts
@@ -125,7 +125,7 @@ describe('item.ts', () => {
 	describe('mutations', () => {
 		describe('SET_SELECTED_ITEM', () => {
 			it('should update selectedId on state', async () => {
-				const state = { selectedId: undefined } as any
+				const state = { selectedId: undefined, recentItemIds: [] as any } as any
 				const item = { id: 123 } as any
 				mutations[FEED_ITEM_MUTATION_TYPES.SET_SELECTED_ITEM](state, item as any)
 				expect(state.selectedId).toEqual(123)


### PR DESCRIPTION
## Summary

This PR adds a new list that shows the last 20 recently viewed articles, which will be helpful if you already switched the feed and want to go back to show the article again or if you want to star it for example.
This is a temporary list which only relies on the frontend and is reset when reloading the app in the browser or by pressing 'r'.

<img width="848" height="430" alt="grafik" src="https://github.com/user-attachments/assets/8ba3e579-fa26-44fd-b986-5543c2554880" />


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
