### PR TITLE
feat: add refresh button to list header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [26.x.x]
 ### Changed
+- add refresh button to list header
 
 
 ### Fixed

--- a/src/components/ContentTemplate.vue
+++ b/src/components/ContentTemplate.vue
@@ -9,6 +9,8 @@
 				<FeedItemDisplayList
 					ref="itemListElement"
 					:items="items"
+					:list-name="listName"
+					:list-count="listCount"
 					:fetch-key="fetchKey"
 					role="region"
 					:aria-label="t('news', 'Article list')"
@@ -98,6 +100,24 @@ const props = defineProps({
 	fetchKey: {
 		type: String,
 		required: true,
+	},
+
+	/**
+	 * The name of the list
+	 */
+	listName: {
+		type: String,
+		required: false,
+		default: '',
+	},
+
+	/**
+	 * The counter value of the list
+	 */
+	listCount: {
+		type: Number,
+		required: false,
+		default: 0,
 	},
 })
 

--- a/src/components/feed-display/FeedItemDisplayList.vue
+++ b/src/components/feed-display/FeedItemDisplayList.vue
@@ -2,8 +2,21 @@
 	<div class="feed-item-display-list">
 		<div class="header">
 			<div class="header-content">
-				<slot name="header" />
+				<div class="header-text">
+					{{ listName }}
+				</div>
+				<NcCounterBubble v-if="listCount > 0" class="header-counter" :count="listCount" />
 			</div>
+			<NcButton
+				v-if="!isMobile"
+				class="header-button"
+				:title="t('news', 'Refresh list')"
+				variant="tertiary"
+				@click="refreshApp">
+				<template #icon>
+					<RefreshIcon :size="20" />
+				</template>
+			</NcButton>
 		</div>
 		<div class="feed-item-display-container">
 			<VirtualScroll
@@ -42,8 +55,12 @@
 import type { FeedItem } from '../../types/FeedItem.ts'
 
 import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
+import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import { useSwipe } from '@vueuse/core'
 import { defineComponent } from 'vue'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
+import RefreshIcon from 'vue-material-design-icons/Refresh.vue'
 import FeedItemDisplay from './FeedItemDisplay.vue'
 import FeedItemRow from './FeedItemRow.vue'
 import VirtualScroll from './VirtualScroll.vue'
@@ -55,6 +72,9 @@ export default defineComponent({
 		VirtualScroll,
 		FeedItemDisplay,
 		FeedItemRow,
+		NcButton,
+		NcCounterBubble,
+		RefreshIcon,
 	},
 
 	props: {
@@ -73,6 +93,22 @@ export default defineComponent({
 			type: String,
 			required: true,
 		},
+
+		/**
+		 * The name of the list
+		 */
+		listName: {
+			type: String,
+			required: true,
+		},
+
+		/**
+		 * The counter value of the list
+		 */
+		listCount: {
+			type: Number,
+			required: true,
+		},
 	},
 
 	emits: {
@@ -81,10 +117,15 @@ export default defineComponent({
 		'show-details': () => true,
 	},
 
+	setup() {
+		return {
+			isMobile: useIsMobile(),
+		}
+	},
+
 	data() {
 		return {
 			selectedItem: undefined as FeedItem | undefined,
-			debouncedClickItem: null,
 			swiping: {},
 		}
 	},
@@ -265,16 +306,40 @@ export default defineComponent({
 	}
 
 	.header {
-		display: flex;
-		align-items: center;
-		justify-content: right;
 		height: 54px;
 		min-height: 54px;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		min-width: 0;
+		margin-inline-start: 44px;
+		margin-inline-end: 10px;
 	}
 
 	.header-content {
-		flex-grow: 1;
-		padding-inline-start: 52px;
-		font-weight: 700;
+		display: flex;
+		align-items: center;
+		min-width: 0;
+		flex: 1;
+		overflow: hidden;
+		white-space: nowrap;
 	}
+
+	.header-text {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		flex-shrink: 1;
+		margin-inline-end: 6px;
+	}
+
+	.header-counter {
+		flex-shrink: 0;
+	}
+
+	.header-button {
+		flex-shrink: 0;
+	}
+
 </style>

--- a/src/components/feed-display/FeedItemRow.vue
+++ b/src/components/feed-display/FeedItemRow.vue
@@ -170,9 +170,14 @@ export default defineComponent({
 		'show-details': () => true,
 	},
 
-	data: () => {
+	setup: () => {
 		return {
 			isMobile: useIsMobile(),
+		}
+	},
+
+	data: () => {
+		return {
 			showShareMenu: false,
 			shareItem: undefined,
 		}

--- a/src/components/routes/All.vue
+++ b/src/components/routes/All.vue
@@ -2,12 +2,9 @@
 	<ContentTemplate
 		v-if="!loading"
 		:items="allItems"
+		:list-name="t('news', 'All Articles')"
 		fetch-key="all"
-		@load-more="fetchMore()">
-		<template #header>
-			{{ t('news', 'All Articles') }}
-		</template>
-	</ContentTemplate>
+		@load-more="fetchMore()" />
 </template>
 
 <script lang="ts">
@@ -62,11 +59,3 @@ export default defineComponent({
 	},
 })
 </script>
-
-<style scoped>
-	.counter-bubble {
-		display: inline-block;
-		vertical-align: sub;
-		margin-inline-start: 10px;
-	}
-</style>

--- a/src/components/routes/Feed.vue
+++ b/src/components/routes/Feed.vue
@@ -3,14 +3,11 @@
 		v-if="!loading"
 		:key="'feed-' + feedId"
 		:items="items"
+		:list-name="feed ? feed.title : ''"
+		:list-count="feed ? feed.unreadCount : 0"
 		:fetch-key="'feed-' + feedId"
 		@mark-read="markRead()"
-		@load-more="fetchMore()">
-		<template #header>
-			{{ feed ? feed.title : '' }}
-			<NcCounterBubble v-if="feed" class="counter-bubble" :count="feed.unreadCount" />
-		</template>
-	</ContentTemplate>
+		@load-more="fetchMore()" />
 </template>
 
 <script lang="ts">
@@ -19,7 +16,6 @@ import type { FeedItem } from '../../types/FeedItem.ts'
 
 import { defineComponent } from 'vue'
 import { mapState } from 'vuex'
-import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import ContentTemplate from '../ContentTemplate.vue'
 import { ACTIONS, MUTATIONS } from '../../store/index.ts'
 import { getOldestFirst, outOfScopeFilter, sortedFeedItems } from '../../utils/itemFilter.ts'
@@ -29,7 +25,6 @@ export default defineComponent({
 	name: 'RoutesFeed',
 	components: {
 		ContentTemplate,
-		NcCounterBubble,
 	},
 
 	props: {
@@ -144,11 +139,3 @@ export default defineComponent({
 	},
 })
 </script>
-
-<style scoped>
-.counter-bubble {
-	display: inline-block;
-	vertical-align: sub;
-	margin-inline-start: 10px;
-}
-</style>

--- a/src/components/routes/Folder.vue
+++ b/src/components/routes/Folder.vue
@@ -3,14 +3,11 @@
 		v-if="!loading"
 		:key="'folder-' + folderId"
 		:items="items"
+		:list-name="folder ? folder.name : ''"
+		:list-count="folder ? unreadCount : 0"
 		:fetch-key="'folder-' + folderId"
 		@mark-read="markRead()"
-		@load-more="fetchMore()">
-		<template #header>
-			{{ folder ? folder.name : '' }}
-			<NcCounterBubble v-if="folder" class="counter-bubble" :count="unreadCount" />
-		</template>
-	</ContentTemplate>
+		@load-more="fetchMore()" />
 </template>
 
 <script lang="ts">
@@ -20,7 +17,6 @@ import type { Folder } from '../../types/Folder.ts'
 
 import { defineComponent } from 'vue'
 import { mapState } from 'vuex'
-import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import ContentTemplate from '../ContentTemplate.vue'
 import { ACTIONS, MUTATIONS } from '../../store/index.ts'
 import { outOfScopeFilter, sortedFeedItems } from '../../utils/itemFilter.ts'
@@ -30,7 +26,6 @@ export default defineComponent({
 	name: 'RoutesFolder',
 	components: {
 		ContentTemplate,
-		NcCounterBubble,
 	},
 
 	props: {
@@ -161,11 +156,3 @@ export default defineComponent({
 	},
 })
 </script>
-
-<style scoped>
-.counter-bubble {
-	display: inline-block;
-	vertical-align: sub;
-	margin-inline-start: 10px;
-}
-</style>

--- a/src/components/routes/Recent.vue
+++ b/src/components/routes/Recent.vue
@@ -1,11 +1,8 @@
 <template>
 	<ContentTemplate
 		:items="recentItems"
-		fetch-key="recent">
-		<template #header>
-			{{ t('news', 'Recently viewed') }}
-		</template>
-	</ContentTemplate>
+		:list-name="t('news', 'Recently viewed')"
+		fetch-key="recent" />
 </template>
 
 <script lang="ts">

--- a/src/components/routes/Starred.vue
+++ b/src/components/routes/Starred.vue
@@ -2,13 +2,10 @@
 	<ContentTemplate
 		v-if="!loading"
 		:items="starred"
+		:list-name="t('news', 'Starred')"
+		:list-count="items.starredCount"
 		fetch-key="starred"
-		@load-more="fetchMore()">
-		<template #header>
-			{{ t('news', 'Starred') }}
-			<NcCounterBubble class="counter-bubble" :count="items.starredCount" />
-		</template>
-	</ContentTemplate>
+		@load-more="fetchMore()" />
 </template>
 
 <script lang="ts">
@@ -16,7 +13,6 @@ import type { FeedItem } from '../../types/FeedItem.ts'
 
 import { defineComponent } from 'vue'
 import { mapState } from 'vuex'
-import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import ContentTemplate from '../ContentTemplate.vue'
 import { ACTIONS, MUTATIONS } from '../../store/index.ts'
 import { outOfScopeFilter, sortedFeedItems } from '../../utils/itemFilter.ts'
@@ -25,7 +21,6 @@ export default defineComponent({
 	name: 'RoutesStarred',
 	components: {
 		ContentTemplate,
-		NcCounterBubble,
 	},
 
 	computed: {
@@ -67,11 +62,3 @@ export default defineComponent({
 	},
 })
 </script>
-
-<style scoped>
-	.counter-bubble {
-		display: inline-block;
-		vertical-align: sub;
-		margin-inline-start: 10px;
-	}
-</style>

--- a/src/components/routes/Unread.vue
+++ b/src/components/routes/Unread.vue
@@ -2,13 +2,10 @@
 	<ContentTemplate
 		v-if="!loading"
 		:items="unread"
+		:list-name="t('news', 'Unread Articles')"
+		:list-count="items.unreadCount"
 		fetch-key="unread"
-		@load-more="fetchMore()">
-		<template #header>
-			{{ t('news', 'Unread Articles') }}
-			<NcCounterBubble class="counter-bubble" :count="items.unreadCount" />
-		</template>
-	</ContentTemplate>
+		@load-more="fetchMore()" />
 </template>
 
 <script lang="ts">
@@ -16,7 +13,6 @@ import type { FeedItem } from '../../types/FeedItem.ts'
 
 import { defineComponent } from 'vue'
 import { mapState } from 'vuex'
-import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import ContentTemplate from '../ContentTemplate.vue'
 import { ACTIONS, MUTATIONS } from '../../store/index.ts'
 import { outOfScopeFilter, sortedFeedItems } from '../../utils/itemFilter.ts'
@@ -26,7 +22,6 @@ export default defineComponent({
 	name: 'RoutesUnread',
 	components: {
 		ContentTemplate,
-		NcCounterBubble,
 	},
 
 	data() {
@@ -99,11 +94,3 @@ export default defineComponent({
 	},
 })
 </script>
-
-<style scoped>
-	.counter-bubble {
-		display: inline-block;
-		vertical-align: sub;
-		margin-inline-start: 10px;
-	}
-</style>

--- a/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
@@ -56,6 +56,8 @@ describe('FeedItemDisplayList.vue', () => {
 	const mockFeed = {
 		id: 1,
 		folderId: 1,
+		unreadCount: 0,
+		title: 'feed-1',
 	}
 
 	const mockFolder = {
@@ -151,6 +153,8 @@ describe('FeedItemDisplayList.vue', () => {
 			props: {
 				items: [mockItem1, mockItem2, mockItem3, mockItem4],
 				fetchKey: 'unread',
+				listName: 'Unread Articles',
+				listCount: 4,
 			},
 			global: {
 				plugins: [store],


### PR DESCRIPTION
* Resolves: #3252

## Summary
This PR adds a refresh button to the list header

<img width="684" height="287" alt="grafik" src="https://github.com/user-attachments/assets/5e5d4f0a-c7f9-4704-9c79-0c4f25a159c9" />


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
