### PR TITLE
fix: Unread counter displays a huge number of unread posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 
 ### Fixed
+- Unread counter displays a huge number of unread posts
 
 # Releases
 ## [26.1.0] - 2025-08-02

--- a/src/store/feed.ts
+++ b/src/store/feed.ts
@@ -55,7 +55,7 @@ export const actions = {
 
 		commit(FEED_MUTATION_TYPES.SET_FEEDS, response.data.feeds)
 		commit(FEED_ITEM_MUTATION_TYPES.SET_UNREAD_COUNT, (response.data.feeds.reduce((total: number, feed: Feed) => {
-			return total + feed.unreadCount
+			return total + Number(feed.unreadCount || 0)
 		}, 0)))
 
 		if (response?.data.starred) {
@@ -236,6 +236,11 @@ export const mutations = {
 			if (typeof it?.ordering === 'number') {
 				state.ordering['feed-' + it.id] = it.ordering
 			}
+
+			if (typeof it.unreadCount !== 'number') {
+				it.unreadCount = Number(it.unreadCount || 0)
+			}
+
 			return it
 		})
 	},


### PR DESCRIPTION
* Resolves: #3255 (hopefully)

## Summary

I don't know how it can happen, but in case of #3255, when the counter initially shows this huge values, the only explanation is that it gets at least one feed unread counter as string.
So I have added checks that make sure it is treated as number.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
