### PR TITLE
Fix Handling HTML entities via mbstring is deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Fixed
 - Unread counter displays a huge number of unread posts
 - Nextcloud language setting is not respected for numbers and dates
+- Handling HTML entities via mbstring is deprecated (#3269)
 
 # Releases
 ## [26.1.0] - 2025-08-02

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -379,7 +379,7 @@ class FeedFetcher implements IFeedFetcher
             // Convert to UTF-8 if needed with comprehensive encoding detection
             $encodingList = ['UTF-8', 'ISO-8859-1', 'Windows-1252', 'ASCII', 'UTF-16', 'UTF-16BE', 'UTF-16LE'];
             $detectedEncoding = mb_detect_encoding($body, $encodingList, true);
-            if ($detectedEncoding && $detectedEncoding !== 'UTF-8') {
+            if ($detectedEncoding !== false && $detectedEncoding !== 'UTF-8') {
                 $convertedBody = mb_convert_encoding($body, 'UTF-8', $detectedEncoding);
                 if ($convertedBody !== false) {
                     $body = $convertedBody;

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -362,11 +362,7 @@ class FeedFetcher implements IFeedFetcher
 
         // purification is done in the service layer
         if (!is_null($body)) {
-            $body = mb_convert_encoding(
-                $body,
-                'HTML-ENTITIES',
-                mb_detect_encoding($body)
-            );
+            // First, handle CDATA sections if present
             if (strpos($body, 'CDATA') !== false) {
                 libxml_use_internal_errors(true);
                 $data = simplexml_load_string(
@@ -378,6 +374,21 @@ class FeedFetcher implements IFeedFetcher
                     $body = (string) $data;
                 }
                 libxml_clear_errors();
+            }
+            
+            // Convert to UTF-8 if needed with comprehensive encoding detection
+            $encodingList = ['UTF-8', 'ISO-8859-1', 'Windows-1252', 'ASCII', 'UTF-16', 'UTF-16BE', 'UTF-16LE'];
+            $detectedEncoding = mb_detect_encoding($body, $encodingList, true);
+            if ($detectedEncoding && $detectedEncoding !== 'UTF-8') {
+                $convertedBody = mb_convert_encoding($body, 'UTF-8', $detectedEncoding);
+                if ($convertedBody !== false) {
+                    $body = $convertedBody;
+                } else {
+                    $this->logger->warning(
+                        'Failed to convert encoding from {from} to UTF-8 for feed item',
+                        ['from' => $detectedEncoding]
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
* Resolves: #2609

## Summary

Hopefully this will have the same effect on the content

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
