### PR TITLE
translation: re-add translation for recently changed info text

### DIFF
--- a/l10n/ar.js
+++ b/l10n/ar.js
@@ -47,6 +47,7 @@ OC.L10N.register(
     "Article list" : "قائمة المقالات",
     "Article details" : "تفاصيل المقالات",
     "No article selected" : "لم يتم تحديد أي مقالٍ",
+    "Please select an article from the list." : "رجاءً، إختَر مقالاً من القائمة.",
     "Show all articles" : "أظهر جميع المواضيع",
     "Move" : "نقل",
     "User Name" : "اسم المستخدِم",

--- a/l10n/ar.json
+++ b/l10n/ar.json
@@ -45,6 +45,7 @@
     "Article list" : "قائمة المقالات",
     "Article details" : "تفاصيل المقالات",
     "No article selected" : "لم يتم تحديد أي مقالٍ",
+    "Please select an article from the list." : "رجاءً، إختَر مقالاً من القائمة.",
     "Show all articles" : "أظهر جميع المواضيع",
     "Move" : "نقل",
     "User Name" : "اسم المستخدِم",

--- a/l10n/ast.js
+++ b/l10n/ast.js
@@ -27,6 +27,7 @@ OC.L10N.register(
     "Update interval" : "Intervalu d'anovamientu",
     "Use system cron for updates" : "Usar el cron del sistema pa los anovamientos",
     "No article selected" : "Nun se seleicionó nengún artículu",
+    "Please select an article from the list." : "Seleiciona un artículu de la llista.",
     "Show all articles" : "Amosar tolos artículos",
     "Move" : "Mover",
     "Share" : "Compartir",

--- a/l10n/ast.json
+++ b/l10n/ast.json
@@ -25,6 +25,7 @@
     "Update interval" : "Intervalu d'anovamientu",
     "Use system cron for updates" : "Usar el cron del sistema pa los anovamientos",
     "No article selected" : "Nun se seleicionó nengún artículu",
+    "Please select an article from the list." : "Seleiciona un artículu de la llista.",
     "Show all articles" : "Amosar tolos artículos",
     "Move" : "Mover",
     "Share" : "Compartir",

--- a/l10n/ca.js
+++ b/l10n/ca.js
@@ -47,6 +47,7 @@ OC.L10N.register(
     "Article list" : "Llista d'articles",
     "Article details" : "Detalls de l'article",
     "No article selected" : "No s'ha seleccionat cap article",
+    "Please select an article from the list." : "Seleccioneu un article de la llista.",
     "Show all articles" : "Mostra tots els articles",
     "Move" : "Mou",
     "User Name" : "Nom d'usuari",

--- a/l10n/ca.json
+++ b/l10n/ca.json
@@ -45,6 +45,7 @@
     "Article list" : "Llista d'articles",
     "Article details" : "Detalls de l'article",
     "No article selected" : "No s'ha seleccionat cap article",
+    "Please select an article from the list." : "Seleccioneu un article de la llista.",
     "Show all articles" : "Mostra tots els articles",
     "Move" : "Mou",
     "User Name" : "Nom d'usuari",

--- a/l10n/cs.js
+++ b/l10n/cs.js
@@ -50,6 +50,7 @@ OC.L10N.register(
     "Article list" : "Seznam článku",
     "Article details" : "Podrobnosti o článku",
     "No article selected" : "Nevybrán žádný článek",
+    "Please select an article from the list." : "Vyberte jiný článek ze seznamu",
     "Show all articles" : "Zobrazit všechny články",
     "Move" : "Přesunout",
     "User Name" : "Uživatelské jméno",

--- a/l10n/cs.json
+++ b/l10n/cs.json
@@ -48,6 +48,7 @@
     "Article list" : "Seznam článku",
     "Article details" : "Podrobnosti o článku",
     "No article selected" : "Nevybrán žádný článek",
+    "Please select an article from the list." : "Vyberte jiný článek ze seznamu",
     "Show all articles" : "Zobrazit všechny články",
     "Move" : "Přesunout",
     "User Name" : "Uživatelské jméno",

--- a/l10n/da.js
+++ b/l10n/da.js
@@ -45,6 +45,7 @@ OC.L10N.register(
     "Use next update time for feed updates" : "Brug næste opdateringstidspunkt til feedopdateringer",
     "Enable this to use the calculated next update time for feed updates. Disable to update feeds based solely on the update interval." : "Aktiver dette for at bruge det beregnede næste opdateringstidspunkt til feedopdateringer. Deaktiver for at opdatere feeds udelukkende baseret på opdateringsintervallet.",
     "No article selected" : "Der er ikke valgt nogen artikel",
+    "Please select an article from the list." : "Vælg venligst en artikel fra listen.",
     "Show all articles" : "Vis alle artikler",
     "Move" : "Flyt",
     "User Name" : "Brugernavn",

--- a/l10n/da.json
+++ b/l10n/da.json
@@ -43,6 +43,7 @@
     "Use next update time for feed updates" : "Brug næste opdateringstidspunkt til feedopdateringer",
     "Enable this to use the calculated next update time for feed updates. Disable to update feeds based solely on the update interval." : "Aktiver dette for at bruge det beregnede næste opdateringstidspunkt til feedopdateringer. Deaktiver for at opdatere feeds udelukkende baseret på opdateringsintervallet.",
     "No article selected" : "Der er ikke valgt nogen artikel",
+    "Please select an article from the list." : "Vælg venligst en artikel fra listen.",
     "Show all articles" : "Vis alle artikler",
     "Move" : "Flyt",
     "User Name" : "Brugernavn",

--- a/l10n/es.js
+++ b/l10n/es.js
@@ -50,6 +50,7 @@ OC.L10N.register(
     "Article list" : "Lista de artículos",
     "Article details" : "Detalles del artículo",
     "No article selected" : "Ningún artículo seleccionado",
+    "Please select an article from the list." : "Por favor, selecciona un artículo de la lista.",
     "Show all articles" : "Mostrar todos los artículos",
     "Move" : "Mover",
     "User Name" : "Nombre de usuario",

--- a/l10n/es.json
+++ b/l10n/es.json
@@ -48,6 +48,7 @@
     "Article list" : "Lista de artículos",
     "Article details" : "Detalles del artículo",
     "No article selected" : "Ningún artículo seleccionado",
+    "Please select an article from the list." : "Por favor, selecciona un artículo de la lista.",
     "Show all articles" : "Mostrar todos los artículos",
     "Move" : "Mover",
     "User Name" : "Nombre de usuario",

--- a/l10n/es_MX.js
+++ b/l10n/es_MX.js
@@ -39,6 +39,7 @@ OC.L10N.register(
     "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted." : "Tiempo máximo en segundos para esperar a que cargue una fuente RSS o Atom; si tarda más, se abortará la actualización.",
     "Interval in seconds in which the feeds will be updated." : "Intervalo en segundos en el que se actualizarán las fuentes.",
     "No article selected" : "Ningún artículo seleccionado",
+    "Please select an article from the list." : "Por favor, seleccione un artículo de la lista.",
     "Show all articles" : "Mostrar todos los artículos",
     "Move" : "Mover",
     "User Name" : "Nombre de usuario",

--- a/l10n/es_MX.json
+++ b/l10n/es_MX.json
@@ -37,6 +37,7 @@
     "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted." : "Tiempo máximo en segundos para esperar a que cargue una fuente RSS o Atom; si tarda más, se abortará la actualización.",
     "Interval in seconds in which the feeds will be updated." : "Intervalo en segundos en el que se actualizarán las fuentes.",
     "No article selected" : "Ningún artículo seleccionado",
+    "Please select an article from the list." : "Por favor, seleccione un artículo de la lista.",
     "Show all articles" : "Mostrar todos los artículos",
     "Move" : "Mover",
     "User Name" : "Nombre de usuario",

--- a/l10n/et_EE.js
+++ b/l10n/et_EE.js
@@ -50,6 +50,7 @@ OC.L10N.register(
     "Article list" : "Artiklite loend",
     "Article details" : "Artikli üksikasjad",
     "No article selected" : "Ükski artikkel pole valitud",
+    "Please select an article from the list." : "Palun vali loendist artikkel.",
     "Show all articles" : "Näita kõiki artikleid",
     "Move" : "Teisalda",
     "User Name" : "Kasutajanimi",

--- a/l10n/et_EE.json
+++ b/l10n/et_EE.json
@@ -48,6 +48,7 @@
     "Article list" : "Artiklite loend",
     "Article details" : "Artikli üksikasjad",
     "No article selected" : "Ükski artikkel pole valitud",
+    "Please select an article from the list." : "Palun vali loendist artikkel.",
     "Show all articles" : "Näita kõiki artikleid",
     "Move" : "Teisalda",
     "User Name" : "Kasutajanimi",

--- a/l10n/eu.js
+++ b/l10n/eu.js
@@ -42,6 +42,7 @@ OC.L10N.register(
     "Article list" : "Artikuluen zerrenda",
     "Article details" : "Artikuluaren xehetasunak",
     "No article selected" : "Ez da artikulurik hautatu",
+    "Please select an article from the list." : "Mesedez, hautatu zerrendako artikulu bat.",
     "Show all articles" : "Erakutsi artikulu guztiak",
     "Move" : "Mugitu",
     "User Name" : "Erabiltzaile izena",

--- a/l10n/eu.json
+++ b/l10n/eu.json
@@ -40,6 +40,7 @@
     "Article list" : "Artikuluen zerrenda",
     "Article details" : "Artikuluaren xehetasunak",
     "No article selected" : "Ez da artikulurik hautatu",
+    "Please select an article from the list." : "Mesedez, hautatu zerrendako artikulu bat.",
     "Show all articles" : "Erakutsi artikulu guztiak",
     "Move" : "Mugitu",
     "User Name" : "Erabiltzaile izena",

--- a/l10n/fi.js
+++ b/l10n/fi.js
@@ -34,6 +34,7 @@ OC.L10N.register(
     "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted." : "Maksimiaika sekunteina, jonka aikana RSS- tai Atom-syöte odotetaan ladattavaksi. Jos lataus kestää pidempään, se perutaan.",
     "Interval in seconds in which the feeds will be updated." : "Syötteiden päivitysväli sekunteina.",
     "No article selected" : "Artikkelia ei ole valittu",
+    "Please select an article from the list." : "Valitse artikkeli listalta.",
     "Show all articles" : "Näytä kaikki artikkelit",
     "Move" : "Siirrä",
     "User Name" : "Käyttäjänimi",

--- a/l10n/fi.json
+++ b/l10n/fi.json
@@ -32,6 +32,7 @@
     "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted." : "Maksimiaika sekunteina, jonka aikana RSS- tai Atom-syöte odotetaan ladattavaksi. Jos lataus kestää pidempään, se perutaan.",
     "Interval in seconds in which the feeds will be updated." : "Syötteiden päivitysväli sekunteina.",
     "No article selected" : "Artikkelia ei ole valittu",
+    "Please select an article from the list." : "Valitse artikkeli listalta.",
     "Show all articles" : "Näytä kaikki artikkelit",
     "Move" : "Siirrä",
     "User Name" : "Käyttäjänimi",

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -48,6 +48,7 @@ OC.L10N.register(
     "Article list" : "Liste des articles",
     "Article details" : "Détails de l'article",
     "No article selected" : "Aucun article sélectionné",
+    "Please select an article from the list." : "Veuillez sélectionner un article dans la liste.",
     "Show all articles" : "Afficher tous les articles",
     "Move" : "Déplacer",
     "User Name" : "Nom d'utilisateur",

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -46,6 +46,7 @@
     "Article list" : "Liste des articles",
     "Article details" : "Détails de l'article",
     "No article selected" : "Aucun article sélectionné",
+    "Please select an article from the list." : "Veuillez sélectionner un article dans la liste.",
     "Show all articles" : "Afficher tous les articles",
     "Move" : "Déplacer",
     "User Name" : "Nom d'utilisateur",

--- a/l10n/ga.js
+++ b/l10n/ga.js
@@ -50,6 +50,7 @@ OC.L10N.register(
     "Article list" : "Liosta alt",
     "Article details" : "Sonraí alt",
     "No article selected" : "Níor roghnaíodh aon alt",
+    "Please select an article from the list." : "Roghnaigh alt ón liosta le do thoil.",
     "Show all articles" : "Taispeáin gach alt",
     "Move" : "Bog",
     "User Name" : "Ainm Úsáideora",

--- a/l10n/ga.json
+++ b/l10n/ga.json
@@ -48,6 +48,7 @@
     "Article list" : "Liosta alt",
     "Article details" : "Sonraí alt",
     "No article selected" : "Níor roghnaíodh aon alt",
+    "Please select an article from the list." : "Roghnaigh alt ón liosta le do thoil.",
     "Show all articles" : "Taispeáin gach alt",
     "Move" : "Bog",
     "User Name" : "Ainm Úsáideora",

--- a/l10n/gl.js
+++ b/l10n/gl.js
@@ -47,6 +47,7 @@ OC.L10N.register(
     "Article list" : "Lista de artigos",
     "Article details" : "Detalles do artigo",
     "No article selected" : "Non seleccionou ningún artigo",
+    "Please select an article from the list." : "Seleccione un artigo da lista.",
     "Show all articles" : "Amosar todos os artigos",
     "Move" : "Mover",
     "User Name" : "Nome de usuario",

--- a/l10n/gl.json
+++ b/l10n/gl.json
@@ -45,6 +45,7 @@
     "Article list" : "Lista de artigos",
     "Article details" : "Detalles do artigo",
     "No article selected" : "Non seleccionou ningún artigo",
+    "Please select an article from the list." : "Seleccione un artigo da lista.",
     "Show all articles" : "Amosar todos os artigos",
     "Move" : "Mover",
     "User Name" : "Nome de usuario",

--- a/l10n/it.js
+++ b/l10n/it.js
@@ -36,6 +36,7 @@ OC.L10N.register(
     "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted." : "Numero massimo di secondi di attesa per il caricamento di una fonte RSS o Atom; se richiede troppo tempo l'aggiornamento sarà interrotto.",
     "Interval in seconds in which the feeds will be updated." : "Intervallo in secondi nel quale le fonti saranno aggiornate.",
     "No article selected" : "Nessun articolo selezionato",
+    "Please select an article from the list." : "Seleziona un articolo dalla lista.",
     "Show all articles" : "Mostra tutti gli articoli",
     "Move" : "Sposta",
     "User Name" : "Nome utente",

--- a/l10n/it.json
+++ b/l10n/it.json
@@ -34,6 +34,7 @@
     "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted." : "Numero massimo di secondi di attesa per il caricamento di una fonte RSS o Atom; se richiede troppo tempo l'aggiornamento sarà interrotto.",
     "Interval in seconds in which the feeds will be updated." : "Intervallo in secondi nel quale le fonti saranno aggiornate.",
     "No article selected" : "Nessun articolo selezionato",
+    "Please select an article from the list." : "Seleziona un articolo dalla lista.",
     "Show all articles" : "Mostra tutti gli articoli",
     "Move" : "Sposta",
     "User Name" : "Nome utente",

--- a/l10n/ja.js
+++ b/l10n/ja.js
@@ -42,6 +42,7 @@ OC.L10N.register(
     "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted." : "RSS / Atom フィードの読み込み待機秒数の制限;設定時間より長くかかる場合はアップデートが中止されます。",
     "Interval in seconds in which the feeds will be updated." : "フィードを更新するまでの間隔を秒数で指定してください。",
     "No article selected" : "記事が選択されていません",
+    "Please select an article from the list." : "リストから記事を選択してください.",
     "Show all articles" : "すべての記事を表示",
     "Move" : "移動",
     "User Name" : "ユーザーネーム",

--- a/l10n/ja.json
+++ b/l10n/ja.json
@@ -40,6 +40,7 @@
     "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted." : "RSS / Atom フィードの読み込み待機秒数の制限;設定時間より長くかかる場合はアップデートが中止されます。",
     "Interval in seconds in which the feeds will be updated." : "フィードを更新するまでの間隔を秒数で指定してください。",
     "No article selected" : "記事が選択されていません",
+    "Please select an article from the list." : "リストから記事を選択してください.",
     "Show all articles" : "すべての記事を表示",
     "Move" : "移動",
     "User Name" : "ユーザーネーム",

--- a/l10n/ka.js
+++ b/l10n/ka.js
@@ -40,6 +40,7 @@ OC.L10N.register(
     "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted." : "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted.",
     "Interval in seconds in which the feeds will be updated." : "Interval in seconds in which the feeds will be updated.",
     "No article selected" : "No article selected",
+    "Please select an article from the list." : "Please select an article from the list.",
     "Show all articles" : "Show all articles",
     "Move" : "Move",
     "User Name" : "User Name",

--- a/l10n/ka.json
+++ b/l10n/ka.json
@@ -38,6 +38,7 @@
     "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted." : "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted.",
     "Interval in seconds in which the feeds will be updated." : "Interval in seconds in which the feeds will be updated.",
     "No article selected" : "No article selected",
+    "Please select an article from the list." : "Please select an article from the list.",
     "Show all articles" : "Show all articles",
     "Move" : "Move",
     "User Name" : "User Name",

--- a/l10n/ko.js
+++ b/l10n/ko.js
@@ -34,6 +34,7 @@ OC.L10N.register(
     "Delete unread articles automatically" : "읽지 않은 글 자동으로 삭제",
     "Enable this if you also want to delete unread articles." : "읽지 않은 글을 자동으로 삭제하고자 할 경우 이 옵션을 활성화하십시오.",
     "No article selected" : "선택한 글 없음",
+    "Please select an article from the list." : "목록에서 글을 선택하십시오.",
     "Show all articles" : "모든 글 보기",
     "Move" : "이동",
     "User Name" : "사용자 이름",

--- a/l10n/ko.json
+++ b/l10n/ko.json
@@ -32,6 +32,7 @@
     "Delete unread articles automatically" : "읽지 않은 글 자동으로 삭제",
     "Enable this if you also want to delete unread articles." : "읽지 않은 글을 자동으로 삭제하고자 할 경우 이 옵션을 활성화하십시오.",
     "No article selected" : "선택한 글 없음",
+    "Please select an article from the list." : "목록에서 글을 선택하십시오.",
     "Show all articles" : "모든 글 보기",
     "Move" : "이동",
     "User Name" : "사용자 이름",

--- a/l10n/lt_LT.js
+++ b/l10n/lt_LT.js
@@ -35,6 +35,7 @@ OC.L10N.register(
     "How many redirects the feed fetcher should follow." : "Kiek kartų kanalų gaviklis turėtų sekti paskui peradresavimus.",
     "Article list" : "Straipsnių sąrašas",
     "Article details" : "Išsamiau apie straipsnį",
+    "Please select an article from the list." : "Pasirinkite straipsnį iš sąrašo.",
     "Show all articles" : "Rodyti visus straipsnius",
     "Move" : "Perkelti",
     "User Name" : "Naudotojo vardas",

--- a/l10n/lt_LT.json
+++ b/l10n/lt_LT.json
@@ -33,6 +33,7 @@
     "How many redirects the feed fetcher should follow." : "Kiek kartų kanalų gaviklis turėtų sekti paskui peradresavimus.",
     "Article list" : "Straipsnių sąrašas",
     "Article details" : "Išsamiau apie straipsnį",
+    "Please select an article from the list." : "Pasirinkite straipsnį iš sąrašo.",
     "Show all articles" : "Rodyti visus straipsnius",
     "Move" : "Perkelti",
     "User Name" : "Naudotojo vardas",

--- a/l10n/nb.js
+++ b/l10n/nb.js
@@ -40,6 +40,7 @@ OC.L10N.register(
     "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted." : "Maksimalt antall sekunder å vente på at en RSS- eller Atom-strøm skal lastes; hvis det tar lengre tid vil oppdateringen bli avbrutt.",
     "Interval in seconds in which the feeds will be updated." : "Intervall i sekunder som strømmene vil bli oppdatert.",
     "No article selected" : "Ingen artikkel valgt",
+    "Please select an article from the list." : "Vennligst velg en artikkel fra lasten.",
     "Show all articles" : "Vis alle artikler",
     "Move" : "Flytt",
     "User Name" : "Brukernavn",

--- a/l10n/nb.json
+++ b/l10n/nb.json
@@ -38,6 +38,7 @@
     "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted." : "Maksimalt antall sekunder å vente på at en RSS- eller Atom-strøm skal lastes; hvis det tar lengre tid vil oppdateringen bli avbrutt.",
     "Interval in seconds in which the feeds will be updated." : "Intervall i sekunder som strømmene vil bli oppdatert.",
     "No article selected" : "Ingen artikkel valgt",
+    "Please select an article from the list." : "Vennligst velg en artikkel fra lasten.",
     "Show all articles" : "Vis alle artikler",
     "Move" : "Flytt",
     "User Name" : "Brukernavn",

--- a/l10n/pl.js
+++ b/l10n/pl.js
@@ -40,6 +40,7 @@ OC.L10N.register(
     "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted." : "Maksymalna liczba sekund oczekiwania na wczytanie kanału RSS lub Atom; jeśli potrwa to zbyt długo, aktualizacja zostanie przerwana.",
     "Interval in seconds in which the feeds will be updated." : "Przedział czasu w sekundach, w którym kanały będą zaktualizowane.",
     "No article selected" : "Nie wybrano artykułu",
+    "Please select an article from the list." : "Proszę wybrać artykuł z listy.",
     "Show all articles" : "Pokaż wszystkie artykuły",
     "Move" : "Przenieś",
     "User Name" : "Nazwa użytkownika",

--- a/l10n/pl.json
+++ b/l10n/pl.json
@@ -38,6 +38,7 @@
     "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted." : "Maksymalna liczba sekund oczekiwania na wczytanie kanału RSS lub Atom; jeśli potrwa to zbyt długo, aktualizacja zostanie przerwana.",
     "Interval in seconds in which the feeds will be updated." : "Przedział czasu w sekundach, w którym kanały będą zaktualizowane.",
     "No article selected" : "Nie wybrano artykułu",
+    "Please select an article from the list." : "Proszę wybrać artykuł z listy.",
     "Show all articles" : "Pokaż wszystkie artykuły",
     "Move" : "Przenieś",
     "User Name" : "Nazwa użytkownika",

--- a/l10n/pt_BR.js
+++ b/l10n/pt_BR.js
@@ -50,6 +50,7 @@ OC.L10N.register(
     "Article list" : "Lista de artigos",
     "Article details" : "Detalhes do artigo",
     "No article selected" : "Nenhum artigo selecionado",
+    "Please select an article from the list." : "Selecione um artigo da lista.",
     "Show all articles" : "Exibir todos os artigos",
     "Move" : "Mover",
     "User Name" : "Nome de usuário",

--- a/l10n/pt_BR.json
+++ b/l10n/pt_BR.json
@@ -48,6 +48,7 @@
     "Article list" : "Lista de artigos",
     "Article details" : "Detalhes do artigo",
     "No article selected" : "Nenhum artigo selecionado",
+    "Please select an article from the list." : "Selecione um artigo da lista.",
     "Show all articles" : "Exibir todos os artigos",
     "Move" : "Mover",
     "User Name" : "Nome de usuário",

--- a/l10n/ru.js
+++ b/l10n/ru.js
@@ -44,6 +44,7 @@ OC.L10N.register(
     "Interval in seconds in which the feeds will be updated." : "Интервал обновления лент в секундах",
     "Use next update time for feed updates" : "Использовать следующее время обновления для обновлений ленты",
     "No article selected" : "Статья не выбрана",
+    "Please select an article from the list." : "Пожалуйста, выберите статью из списка.",
     "Show all articles" : "Показать все статьи",
     "Move" : "Переместить",
     "User Name" : "Имя пользователя",

--- a/l10n/ru.json
+++ b/l10n/ru.json
@@ -42,6 +42,7 @@
     "Interval in seconds in which the feeds will be updated." : "Интервал обновления лент в секундах",
     "Use next update time for feed updates" : "Использовать следующее время обновления для обновлений ленты",
     "No article selected" : "Статья не выбрана",
+    "Please select an article from the list." : "Пожалуйста, выберите статью из списка.",
     "Show all articles" : "Показать все статьи",
     "Move" : "Переместить",
     "User Name" : "Имя пользователя",

--- a/l10n/sk.js
+++ b/l10n/sk.js
@@ -47,6 +47,7 @@ OC.L10N.register(
     "Article list" : "Zoznam článkov",
     "Article details" : "Detail článku",
     "No article selected" : "Žiadny článok nebol vybraný.",
+    "Please select an article from the list." : "Vyberte prosím článok zo zoznamu.",
     "Show all articles" : "Zobraziť všetky články",
     "Move" : "Presunúť",
     "User Name" : "Úžívateľské meno",

--- a/l10n/sk.json
+++ b/l10n/sk.json
@@ -45,6 +45,7 @@
     "Article list" : "Zoznam článkov",
     "Article details" : "Detail článku",
     "No article selected" : "Žiadny článok nebol vybraný.",
+    "Please select an article from the list." : "Vyberte prosím článok zo zoznamu.",
     "Show all articles" : "Zobraziť všetky články",
     "Move" : "Presunúť",
     "User Name" : "Úžívateľské meno",

--- a/l10n/sl.js
+++ b/l10n/sl.js
@@ -40,6 +40,7 @@ OC.L10N.register(
     "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted." : "Čas, namenjen nalaganju virov RSS in Atom. Če traja dlje je nalaganje virov prekinjeno.",
     "Interval in seconds in which the feeds will be updated." : "Časovni zamik v sekundah za posodabljanje spletnih virov.",
     "No article selected" : "Ni izbranega prispevka",
+    "Please select an article from the list." : "Izberite prispevek s seznama.",
     "Show all articles" : "Pokaži vse prispevke",
     "Move" : "Premakni",
     "User Name" : "Uporabniško ime",

--- a/l10n/sl.json
+++ b/l10n/sl.json
@@ -38,6 +38,7 @@
     "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted." : "Čas, namenjen nalaganju virov RSS in Atom. Če traja dlje je nalaganje virov prekinjeno.",
     "Interval in seconds in which the feeds will be updated." : "Časovni zamik v sekundah za posodabljanje spletnih virov.",
     "No article selected" : "Ni izbranega prispevka",
+    "Please select an article from the list." : "Izberite prispevek s seznama.",
     "Show all articles" : "Pokaži vse prispevke",
     "Move" : "Premakni",
     "User Name" : "Uporabniško ime",

--- a/l10n/sr.js
+++ b/l10n/sr.js
@@ -48,6 +48,7 @@ OC.L10N.register(
     "Article list" : "Листа чланака",
     "Article details" : "Детаљи чланка",
     "No article selected" : "Није изабран ниједан чланак",
+    "Please select an article from the list." : "Молимо вас да изаберете чланак из листе.",
     "Show all articles" : "Прикажи све чланке",
     "Move" : "Помери",
     "User Name" : "Име корисника",

--- a/l10n/sr.json
+++ b/l10n/sr.json
@@ -46,6 +46,7 @@
     "Article list" : "Листа чланака",
     "Article details" : "Детаљи чланка",
     "No article selected" : "Није изабран ниједан чланак",
+    "Please select an article from the list." : "Молимо вас да изаберете чланак из листе.",
     "Show all articles" : "Прикажи све чланке",
     "Move" : "Помери",
     "User Name" : "Име корисника",

--- a/l10n/sv.js
+++ b/l10n/sv.js
@@ -49,6 +49,7 @@ OC.L10N.register(
     "Article list" : "Artikellista",
     "Article details" : "Artikeldetaljer",
     "No article selected" : "Ingen artikel har valts",
+    "Please select an article from the list." : "Välj en artikel från listan.",
     "Show all articles" : "Visa alla artiklar",
     "Move" : "Flytta",
     "User Name" : "Användarnamn",

--- a/l10n/sv.json
+++ b/l10n/sv.json
@@ -47,6 +47,7 @@
     "Article list" : "Artikellista",
     "Article details" : "Artikeldetaljer",
     "No article selected" : "Ingen artikel har valts",
+    "Please select an article from the list." : "Välj en artikel från listan.",
     "Show all articles" : "Visa alla artiklar",
     "Move" : "Flytta",
     "User Name" : "Användarnamn",

--- a/l10n/tr.js
+++ b/l10n/tr.js
@@ -50,6 +50,7 @@ OC.L10N.register(
     "Article list" : "Yazı listesi",
     "Article details" : "Yazı ayrıntıları",
     "No article selected" : "Herhangi bir yazı seçilmemiş",
+    "Please select an article from the list." : "Lütfen listeden bir yazı seçin.",
     "Show all articles" : "Tüm yazıları görüntüle",
     "Move" : "Taşı",
     "User Name" : "Kullanıcı adı",

--- a/l10n/tr.json
+++ b/l10n/tr.json
@@ -48,6 +48,7 @@
     "Article list" : "Yazı listesi",
     "Article details" : "Yazı ayrıntıları",
     "No article selected" : "Herhangi bir yazı seçilmemiş",
+    "Please select an article from the list." : "Lütfen listeden bir yazı seçin.",
     "Show all articles" : "Tüm yazıları görüntüle",
     "Move" : "Taşı",
     "User Name" : "Kullanıcı adı",

--- a/l10n/ug.js
+++ b/l10n/ug.js
@@ -40,6 +40,7 @@ OC.L10N.register(
     "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted." : "RSS ياكى ئاتوم يەملىرىنىڭ يۈكلىنىشىنى ساقلاش ئۈچۈن ئەڭ كۆپ سېكۇنت. ئۇزۇنراق ۋاقىت كەتسە يېڭىلاش ئەمەلدىن قالدۇرۇلىدۇ.",
     "Interval in seconds in which the feeds will be updated." : "يەم-خەشەكلەر يېڭىلىنىدىغان سېكۇنتتا ئارىلىق.",
     "No article selected" : "ھېچقانداق ماقالە تاللانمىدى",
+    "Please select an article from the list." : "تىزىملىكتىن ماقالە تاللاڭ.",
     "Show all articles" : "بارلىق ماقالىلەرنى كۆرسەت",
     "Move" : "Move",
     "User Name" : "ئىشلەتكۈچى ئىسمى",

--- a/l10n/ug.json
+++ b/l10n/ug.json
@@ -38,6 +38,7 @@
     "Maximum number of seconds to wait for an RSS or Atom feed to load; if it takes longer the update will be aborted." : "RSS ياكى ئاتوم يەملىرىنىڭ يۈكلىنىشىنى ساقلاش ئۈچۈن ئەڭ كۆپ سېكۇنت. ئۇزۇنراق ۋاقىت كەتسە يېڭىلاش ئەمەلدىن قالدۇرۇلىدۇ.",
     "Interval in seconds in which the feeds will be updated." : "يەم-خەشەكلەر يېڭىلىنىدىغان سېكۇنتتا ئارىلىق.",
     "No article selected" : "ھېچقانداق ماقالە تاللانمىدى",
+    "Please select an article from the list." : "تىزىملىكتىن ماقالە تاللاڭ.",
     "Show all articles" : "بارلىق ماقالىلەرنى كۆرسەت",
     "Move" : "Move",
     "User Name" : "ئىشلەتكۈچى ئىسمى",

--- a/l10n/zh_CN.js
+++ b/l10n/zh_CN.js
@@ -50,6 +50,7 @@ OC.L10N.register(
     "Article list" : "文章列表",
     "Article details" : "文章详情",
     "No article selected" : "未选择文章",
+    "Please select an article from the list." : "请从列表选择文章.",
     "Show all articles" : "显示全部文章",
     "Move" : "移动",
     "User Name" : "用户名称",

--- a/l10n/zh_CN.json
+++ b/l10n/zh_CN.json
@@ -48,6 +48,7 @@
     "Article list" : "文章列表",
     "Article details" : "文章详情",
     "No article selected" : "未选择文章",
+    "Please select an article from the list." : "请从列表选择文章.",
     "Show all articles" : "显示全部文章",
     "Move" : "移动",
     "User Name" : "用户名称",


### PR DESCRIPTION
## Summary
The simple linter fix in 1ac49fa2da0b84df41274d24177fd299b770faf6, caused a  complete translation change 356b97bc2cf81bf87f5807a25ec19c96c6b60187, where a one-liner  can save some translation work from transifex.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
