### PR TITLE
Refactor favicon fetching to also check feed link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [26.x.x]
 ### Changed
+- If feed has no favicon and no logo News will check the linked website of the feed (#3271)
 
 ### Fixed
 - Unread counter displays a huge number of unread posts


### PR DESCRIPTION
* Resolves: #2378

## Summary

So I (and Copilot) refactored this part of the code to also include a check of the feeds link that was one suggestion in #2378 I also tested the bbc feed logo again and what happens if we allow non square images and it results in the image being repeated twice I assume to fill the square space so you cant identify anything anyway.

But this change will add favicons to a lot of more feeds that use some cdn to serve their feed, of course we still have the issue that some websites will block News but well ... at least the few reported that I tested except one got an image now.

<img width="236" height="185" alt="grafik" src="https://github.com/user-attachments/assets/9f3da958-e065-4ccc-8f92-3f092f0c2120" />

You can almost not see the NYT but that is because they have a black icon without background. That BBC got the three back dots surprised me I always thought red was their color but turns out the website logo is also like this just with B B C in the black squares.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
