### PR TITLE
order items by pubdate when querying through /items endpoint

### DIFF
--- a/lib/Controller/ItemApiController.php
+++ b/lib/Controller/ItemApiController.php
@@ -65,8 +65,10 @@ class ItemApiController extends ApiController
         bool $getRead = true,
         int $batchSize = -1,
         int $offset = 0,
-        bool $oldestFirst = false
+        $oldestFirst = false
     ): array {
+        $oldestFirst = filter_var($oldestFirst, FILTER_VALIDATE_BOOLEAN);
+
         switch ($type) {
             case ListType::FEED:
                 $items = $this->itemService->findAllInFeedWithFilters(


### PR DESCRIPTION
## Summary

This commit allows /items API to return Items in the order of their pubDates, depending on oldestFirst boolean value.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
