### PR TITLE
testing: fix javascript date format test

### DIFF
--- a/tests/javascript/unit/OC.ts
+++ b/tests/javascript/unit/OC.ts
@@ -13,11 +13,11 @@ export class OC {
 	}
 
 	getLanguage() {
-		return 'en-GB'
+		return 'en-US'
 	}
 
 	getLocale() {
-		return 'en_GB'
+		return 'en_US'
 	}
 
 	isUserAdmin() {

--- a/tests/javascript/unit/components/feed-display/FeedItemDisplay.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemDisplay.spec.ts
@@ -58,11 +58,11 @@ describe('FeedItemDisplay.vue', () => {
 		const epoch = Date.now() // Provide an epoch timestamp
 		const formattedDate = (wrapper.vm as any).formatDate(epoch / 1000)
 
-		expect(formattedDate).toEqual(new Date(epoch).toLocaleString(undefined, {
+		expect(formattedDate).toEqual(new Date(epoch).toLocaleString(OC.getLanguage(), {
 			year: "numeric",
 			month: "2-digit",
 			day: "2-digit",
-			hour: "2-digit",
+			hour: "numeric",
 			minute: "2-digit",
 			second: "2-digit",
 		}))

--- a/tests/javascript/unit/components/feed-display/FeedItemRow.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemRow.spec.ts
@@ -57,11 +57,11 @@ describe('FeedItemRow.vue', () => {
 		const epoch = Date.now() // Provide an epoch timestamp
 		const formattedDate = (wrapper.vm as any).formatDate(epoch / 1000)
 
-		expect(formattedDate).toEqual(new Date(epoch).toLocaleString(undefined, {
+		expect(formattedDate).toEqual(new Date(epoch).toLocaleString(OC.getLanguage(), {
 			year: "numeric",
 			month: "2-digit",
 			day: "2-digit",
-			hour: "2-digit",
+			hour: "numeric",
 			minute: "2-digit",
 			second: "2-digit",
 		}))


### PR DESCRIPTION
## Summary

It seems something about the locales changed with the github actions (see failed test #3284).

To fix this use defined locales in test.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
