### PR TITLE
Release 26.2.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,19 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [26.x.x]
 ### Changed
+
+### Fixed
+
+# Releases
+## [26.2.0-beta.1] - 2025-08-31
+### Changed
 - If feed has no favicon and no logo News will check the linked website of the feed (#3271)
 
 ### Fixed
-- Unread counter displays a huge number of unread posts
-- Nextcloud language setting is not respected for numbers and dates
+- Unread counter displays a huge number of unread posts (#3267)
+- Nextcloud language setting is not respected for numbers and dates (#3278)
 - Handling HTML entities via mbstring is deprecated (#3269)
 
-# Releases
 ## [26.1.0] - 2025-08-02
 ### Changed
 - add refresh button to list header (#3259)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>26.1.0</version>
+    <version>26.2.0-beta.1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
## Summary

### Changed
- If feed has no favicon and no logo News will check the linked website of the feed (#3271)

### Fixed
- Unread counter displays a huge number of unread posts (#3267)
- Nextcloud language setting is not respected for numbers and dates (#3278)
- Handling HTML entities via mbstring is deprecated (#3269)


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
