### PR TITLE
Release 27.0.0-beta.1

### DIFF
--- a/.github/workflows/api-integration-tests.yml
+++ b/.github/workflows/api-integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.2', '8.3']
-        nextcloud: ['stable30']
+        nextcloud: ['stable31']
         database: ['sqlite', 'pgsql', 'mysql']
         experimental: [false]
         include:

--- a/.github/workflows/api-php-static-code-check.yml
+++ b/.github/workflows/api-php-static-code-check.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.2', '8.3' ]
-        nextcloud: [ 'stable30' ]
+        nextcloud: [ 'stable31' ]
         database: [ 'sqlite' ]
         include:
           - php-versions: 8.3

--- a/.github/workflows/api-php-tests.yml
+++ b/.github/workflows/api-php-tests.yml
@@ -10,12 +10,12 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.3']
-        nextcloud: ['stable30']
+        nextcloud: ['stable31']
         database: ['sqlite']
         experimental: [false]
         include:
           - php-versions: 8.3
-            nextcloud: stable30
+            nextcloud: stable31
             database: sqlite
             experimental: false
     steps:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.3']
-        nextcloud: ['stable30']
+        nextcloud: ['stable31']
         database: ['sqlite']
     steps:
       - name: Checkout

--- a/.github/workflows/frontend-nodejs-tests.yml
+++ b/.github/workflows/frontend-nodejs-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.3']
-        nextcloud: ['stable30']
+        nextcloud: ['stable31']
         database: ['sqlite']
         experimental: [false]
     steps:

--- a/.github/workflows/updater-test.yml
+++ b/.github/workflows/updater-test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.3']
-        nextcloud: ['stable30']
+        nextcloud: ['stable31']
         database: ['sqlite']
         experimental: [false]
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,23 @@ The format is mostly based on [Keep a Changelog](https://keepachangelog.com/en/1
 You can also check [on GitHub](https://github.com/nextcloud/news/releases), the release notes there are generated automatically and include every pull request.
 
 # Unreleased
-## [26.x.x]
+## [27.x.x]
 ### Changed
+
+### Fixed
+
+# Releases
+## [27.0.0-beta.1] - 2025-08-31
+### Changed
+- Drop Support for Nextcloud 30 (#3294)
+- Add Support for Nextcloud 32 (#3294)
 - If feed has no favicon and no logo News will check the linked website of the feed (#3271)
 
 ### Fixed
-- Unread counter displays a huge number of unread posts
-- Nextcloud language setting is not respected for numbers and dates
+- Unread counter displays a huge number of unread posts (#3267)
+- Nextcloud language setting is not respected for numbers and dates (#3278)
 - Handling HTML entities via mbstring is deprecated (#3269)
 
-# Releases
 ## [26.1.0] - 2025-08-02
 ### Changed
 - add refresh button to list header (#3259)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>26.1.0</version>
+    <version>27.0.0-beta.1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>
@@ -55,7 +55,7 @@ Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
         <lib>json</lib>
 
         <owncloud max-version="0" min-version="0"/>
-        <nextcloud min-version="30" max-version="31"/>
+        <nextcloud min-version="31" max-version="32"/>
     </dependencies>
 
     <background-jobs>


### PR DESCRIPTION
## Summary

Changed
- Drop Support for Nextcloud 30 (#3294)
- Add Support for Nextcloud 32 (#3294)
- If feed has no favicon and no logo News will check the linked website of the feed (#3271)

Fixed
- Unread counter displays a huge number of unread posts (#3267)
- Nextcloud language setting is not respected for numbers and dates (#3278)
- Handling HTML entities via mbstring is deprecated (#3269)
## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
