### PR TITLE
chore: update transifex link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Features don't belong into the issues section, instead discuss them in [discussi
 
 For translations in other languages than English, we rely on the [Transifex](https://www.transifex.com/) platform.
 
-If you want to help with translating the app, please do not create a pull request. Instead, head over to https://www.transifex.com/nextcloud/nextcloud/news/ and join the team of your native language.
+If you want to help with translating the app, please do not create a pull request. Instead, head over to https://explore.transifex.com/nextcloud/ and join the team of your native language.
 
 If approved, the translation will be automatically ported to the code within 24 hours.
 


### PR DESCRIPTION
## Summary

Broken link. 

It's still possible to link to the resource directly like `https://app.transifex.com/nextcloud/nextcloud/news/`, however guest users are then redirected to a login page, and therefore I've opted for the project overview. 
