### PR TITLE
deps: update vite to 7.1.5 and @nextcloud/vite-config to 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@nextcloud/browserslist-config": "^3.0.1",
         "@nextcloud/eslint-config": "^9.0.0-rc.5",
         "@nextcloud/stylelint-config": "^3.1.0",
-        "@nextcloud/vite-config": "^2.4.0",
+        "@nextcloud/vite-config": "^2.5.0",
         "@types/lodash": "^4.17.20",
         "@types/node": "^24.3.1",
         "@vitest/coverage-istanbul": "^3.2.4",
@@ -36,7 +36,7 @@
         "@vue/tsconfig": "^0.8.1",
         "jsdom": "^26.1.0",
         "regenerator-runtime": "^0.14.1",
-        "vite": "^6.3.6",
+        "vite": "^7.1.5",
         "vitest": "^3.2.4"
       },
       "engines": {
@@ -1601,21 +1601,6 @@
         "npm": "^10.0.0"
       }
     },
-    "node_modules/@nextcloud/dialogs/node_modules/vite-plugin-node-polyfills": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.24.0.tgz",
-      "integrity": "sha512-GA9QKLH+vIM8NPaGA+o2t8PDfFUl32J8rUp1zQfMKVJQiNkOX4unE51tR6ppl6iKw5yOrDAdSH7r/UIFLCVhLw==",
-      "dependencies": {
-        "@rollup/plugin-inject": "^5.0.5",
-        "node-stdlib-browser": "^1.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/davidmyersdev"
-      },
-      "peerDependencies": {
-        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
-      }
-    },
     "node_modules/@nextcloud/eslint-config": {
       "version": "9.0.0-rc.5",
       "resolved": "https://registry.npmjs.org/@nextcloud/eslint-config/-/eslint-config-9.0.0-rc.5.tgz",
@@ -1839,24 +1824,24 @@
       }
     },
     "node_modules/@nextcloud/vite-config": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vite-config/-/vite-config-2.4.0.tgz",
-      "integrity": "sha512-f1YH16eiQAyxRynm5hgJIRH4hAwaBzRt+YD1ySKf/5ri/y7a/ZpkdWAxS5WgYVn1mSxl0ZVzQX04O3oKz8dIkQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vite-config/-/vite-config-2.5.0.tgz",
+      "integrity": "sha512-i9Cjo9ITgEWJ5ws/I7f5d5S+GSy9zM8DqjFMvwvserrfSHXmJvPhF9XVRT89CbSMYtGoCYzJMNxe6jNp9FF3nw==",
       "dev": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@rollup/plugin-replace": "^6.0.2",
-        "@vitejs/plugin-vue": "^6.0.0",
+        "@vitejs/plugin-vue": "^6.0.1",
         "browserslist-to-esbuild": "^2.1.1",
-        "magic-string": "^0.30.17",
+        "magic-string": "^0.30.18",
         "rollup-plugin-corejs": "^1.0.1",
         "rollup-plugin-esbuild-minify": "^1.3.0",
         "rollup-plugin-license": "^3.6.0",
-        "rollup-plugin-node-externals": "^8.0.1",
+        "rollup-plugin-node-externals": "^8.1.0",
         "spdx-expression-parse": "^4.0.0",
         "vite-plugin-css-injected-by-js": "^3.5.2",
         "vite-plugin-dts": "^4.5.4",
-        "vite-plugin-node-polyfills": "^0.23.0"
+        "vite-plugin-node-polyfills": "^0.24.0"
       },
       "engines": {
         "node": "^20 || ^22 || ^24"
@@ -1864,7 +1849,7 @@
       "peerDependencies": {
         "browserslist": ">=4.0",
         "sass": ">=1.60",
-        "vite": "^5 || ^6 || ^7"
+        "vite": "^7.1.4"
       }
     },
     "node_modules/@nextcloud/vue": {
@@ -5943,10 +5928,13 @@
       }
     },
     "node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -9763,9 +9751,9 @@
       }
     },
     "node_modules/rollup-plugin-node-externals": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-externals/-/rollup-plugin-node-externals-8.0.1.tgz",
-      "integrity": "sha512-j6uve/BPEyHCmQuXpu5/LT5qXw69QLIi6YnFrs6F7tmGFXjkFDT0zqZMt0KaMuWSvkcxJFBklsKfYYoKKEPwyw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-externals/-/rollup-plugin-node-externals-8.1.1.tgz",
+      "integrity": "sha512-MEWJmXMGjo5E7o9hgAmma6XLCdU9gTVRcaaCubugTJdoJD3A91qxtxiukT9k2PeUdogtCaNehV3pvJUWrRNtwg==",
       "dev": true,
       "funding": [
         {
@@ -11152,13 +11140,13 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -11658,22 +11646,23 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
-      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
+      "integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
-        "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -11682,14 +11671,14 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@types/node": "^20.19.0 || >=22.12.0",
         "jiti": ">=1.21.0",
-        "less": "*",
+        "less": "^4.0.0",
         "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"
@@ -11791,10 +11780,9 @@
       }
     },
     "node_modules/vite-plugin-node-polyfills": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.23.0.tgz",
-      "integrity": "sha512-4n+Ys+2bKHQohPBKigFlndwWQ5fFKwaGY6muNDMTb0fSQLyBzS+jjUNRZG9sKF0S/Go4ApG6LFnUGopjkILg3w==",
-      "dev": true,
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.24.0.tgz",
+      "integrity": "sha512-GA9QKLH+vIM8NPaGA+o2t8PDfFUl32J8rUp1zQfMKVJQiNkOX4unE51tR6ppl6iKw5yOrDAdSH7r/UIFLCVhLw==",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-inject": "^5.0.5",
@@ -11804,7 +11792,7 @@
         "url": "https://github.com/sponsors/davidmyersdev"
       },
       "peerDependencies": {
-        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@nextcloud/browserslist-config": "^3.0.1",
     "@nextcloud/eslint-config": "^9.0.0-rc.5",
     "@nextcloud/stylelint-config": "^3.1.0",
-    "@nextcloud/vite-config": "^2.4.0",
+    "@nextcloud/vite-config": "^2.5.0",
     "@types/lodash": "^4.17.20",
     "@types/node": "^24.3.1",
     "@vitest/coverage-istanbul": "^3.2.4",
@@ -74,7 +74,7 @@
     "@vue/tsconfig": "^0.8.1",
     "jsdom": "^26.1.0",
     "regenerator-runtime": "^0.14.1",
-    "vite": "^6.3.6",
+    "vite": "^7.1.5",
     "vitest": "^3.2.4"
   }
 }


### PR DESCRIPTION
## Summary

nextcloud vite-config 2.4.0 adds support for vite 7, but doesn't compile with it.
2.5.0 needs minimum vite version 7.1.4, so update both to be up to date again.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
