### PR TITLE
feat: add option to enable/disable sync of a feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [27.x.x]
 ### Changed
+- Add option to enable/disable sync of a feed
 
 ### Fixed
 

--- a/lib/Controller/FeedController.php
+++ b/lib/Controller/FeedController.php
@@ -291,6 +291,7 @@ class FeedController extends Controller
      * @param int|null    $ordering
      * @param int|null    $folderId
      * @param string|null $title
+     * @param bool        $preventUpdate
      *
      * @return array|JSONResponse
      */
@@ -302,7 +303,8 @@ class FeedController extends Controller
         ?int $updateMode = null,
         ?int $ordering = null,
         ?int $folderId = -1,
-        ?string $title = null
+        ?string $title = null,
+        ?bool $preventUpdate = null
     ) {
         try {
             $feed = $this->feedService->find($this->getUserId(), $feedId);
@@ -328,6 +330,9 @@ class FeedController extends Controller
         }
         if ($title !== null) {
             $feed->setTitle($title);
+        }
+        if ($preventUpdate !== null) {
+            $feed->setPreventUpdate($preventUpdate);
         }
 
         try {

--- a/src/components/SidebarFeedLinkActions.vue
+++ b/src/components/SidebarFeedLinkActions.vue
@@ -102,6 +102,24 @@
 			@click="deleteFeed()">
 			{{ t("news", "Delete") }}
 		</NcActionButton>
+		<NcActionButton
+			v-if="feed.preventUpdate"
+			:close-after-click="true"
+			@click="setPreventUpdate(false)">
+			<template #icon>
+				<SyncOff />
+			</template>
+			{{ t("news", "Sync disabled") }}
+		</NcActionButton>
+		<NcActionButton
+			v-if="!feed.preventUpdate"
+			:close-after-click="true"
+			@click="setPreventUpdate(true)">
+			<template #icon>
+				<Sync />
+			</template>
+			{{ t("news", "Sync enabled") }}
+		</NcActionButton>
 		<NcAppNavigationItem
 			:name="t('news', 'Open Feed URL')"
 			:href="feed.location">
@@ -125,6 +143,8 @@ import FileDocumentRefresh from 'vue-material-design-icons/FileDocumentRefresh.v
 import PinIcon from 'vue-material-design-icons/Pin.vue'
 import PinOffIcon from 'vue-material-design-icons/PinOff.vue'
 import RssIcon from 'vue-material-design-icons/Rss.vue'
+import Sync from 'vue-material-design-icons/Sync.vue'
+import SyncOff from 'vue-material-design-icons/SyncOff.vue'
 import TextLongIcon from 'vue-material-design-icons/TextLong.vue'
 import TextShortIcon from 'vue-material-design-icons/TextShort.vue'
 import { FEED_ORDER, FEED_UPDATE_MODE } from '../enums/index.ts'
@@ -144,6 +164,8 @@ export default defineComponent({
 		RssIcon,
 		PinIcon,
 		PinOffIcon,
+		Sync,
+		SyncOff,
 		TextShortIcon,
 		TextLongIcon,
 		ArrowRightIcon,
@@ -183,6 +205,10 @@ export default defineComponent({
 	methods: {
 		markRead() {
 			this.$store.dispatch(ACTIONS.FEED_MARK_READ, { feed: this.feed })
+		},
+
+		setPreventUpdate(preventUpdate: boolean) {
+			this.$store.dispatch(ACTIONS.FEED_SET_PREVENT_UPDATE, { feed: this.feed, preventUpdate })
 		},
 
 		setPinned(pinned: boolean) {

--- a/src/components/modals/FeedInfoTable.vue
+++ b/src/components/modals/FeedInfoTable.vue
@@ -123,10 +123,10 @@
 							{{ feed.title }}
 						</td>
 						<td class="date">
-							{{ formatDate(feed.lastModified / 1000000) }}
+							{{ feed.preventUpdate ? t('news', 'Sync disabled') : formatDate(feed.lastModified / 1000000) }}
 						</td>
 						<td class="date">
-							{{ feed.nextUpdateTime ? formatDate(feed.nextUpdateTime) : t('news', 'Not available') }}
+							{{ feed.nextUpdateTime && !feed.preventUpdate ? formatDate(feed.nextUpdateTime) : t('news', 'Not available') }}
 						</td>
 						<td class="number">
 							{{ feed.articlesPerUpdate }}

--- a/src/dataservices/feed.service.ts
+++ b/src/dataservices/feed.service.ts
@@ -60,15 +60,17 @@ export class FeedService {
 	 * @param param0.ordering {FEED_ORDER} sets feed order (0 = NEWEST, 1 = OLDEST, 2 = DEFAULT)
 	 * @param param0.fullTextEnabled {Boolean} should be full text be enabled (true) or not (flse)
 	 * @param param0.updateMode {FEED_UPDATE_MODE} sets updateMode (0 = UNREAD, 1 = IGNORE)
+	 * @param param0.preventUpdate {boolean} enable/disable feed sync
 	 * @param param0.title {String} title of feed to display
 	 * @return Null value is returned on success
 	 */
-	static updateFeed({ feedId, pinned, ordering, fullTextEnabled, updateMode, title }: { feedId: number, pinned?: boolean, ordering?: FEED_ORDER, fullTextEnabled?: boolean, updateMode?: FEED_UPDATE_MODE, title?: string }): Promise<AxiosResponse> {
+	static updateFeed({ feedId, pinned, ordering, fullTextEnabled, updateMode, preventUpdate, title }: { feedId: number, pinned?: boolean, ordering?: FEED_ORDER, fullTextEnabled?: boolean, updateMode?: FEED_UPDATE_MODE, preventUpdate?: boolean, title?: string }): Promise<AxiosResponse> {
 		return axios.patch(API_ROUTES.FEED + `/${feedId}`, {
 			pinned,
 			ordering,
 			fullTextEnabled,
 			updateMode,
+			preventUpdate,
 			title,
 		})
 	}

--- a/src/store/feed.ts
+++ b/src/store/feed.ts
@@ -15,6 +15,7 @@ export const FEED_ACTION_TYPES = {
 	FEED_MARK_READ: 'FEED_MARK_READ',
 
 	FEED_SET_PINNED: 'FEED_SET_PINNED',
+	FEED_SET_PREVENT_UPDATE: 'FEED_SET_PREVENT_UPDATE',
 	FEED_SET_ORDERING: 'FEED_SET_ORDERING',
 	FEED_SET_FULL_TEXT: 'FEED_SET_FULL_TEXT',
 	FEED_SET_UPDATE_MODE: 'FEED_SET_UPDATE_MODE',
@@ -149,6 +150,15 @@ export const actions = {
 		await FeedService.updateFeed({ feedId: feed.id as number, pinned })
 
 		commit(FEED_MUTATION_TYPES.UPDATE_FEED, { id: feed.id, pinned })
+	},
+
+	async [FEED_ACTION_TYPES.FEED_SET_PREVENT_UPDATE](
+		{ commit }: ActionParams<FeedState>,
+		{ feed, preventUpdate }: { feed: Feed, preventUpdate: boolean },
+	) {
+		await FeedService.updateFeed({ feedId: feed.id as number, preventUpdate })
+
+		commit(FEED_MUTATION_TYPES.UPDATE_FEED, { id: feed.id, preventUpdate })
 	},
 
 	async [FEED_ACTION_TYPES.FEED_SET_ORDERING](

--- a/src/types/Feed.ts
+++ b/src/types/Feed.ts
@@ -9,6 +9,7 @@ export type Feed = {
 	faviconLink?: string
 	id?: number
 	pinned: boolean
+	preventUpdate: boolean
 	ordering: FEED_ORDER
 	fullTextEnabled: boolean
 	updateMode: FEED_UPDATE_MODE

--- a/tests/Unit/Controller/FeedControllerTest.php
+++ b/tests/Unit/Controller/FeedControllerTest.php
@@ -668,6 +668,10 @@ class FeedControllerTest extends TestCase
              ->method('setTitle')
              ->with(true);
 
+        $feed->expects($this->never())
+             ->method('setPreventUpdate')
+             ->with(true);
+
         $this->feedService->expects($this->once())
             ->method('find')
             ->with($this->uid, 4)
@@ -710,6 +714,10 @@ class FeedControllerTest extends TestCase
 
         $feed->expects($this->never())
              ->method('setTitle')
+             ->with(true);
+
+        $feed->expects($this->never())
+             ->method('setPreventUpdate')
              ->with(true);
 
         $this->feedService->expects($this->once())
@@ -772,6 +780,10 @@ class FeedControllerTest extends TestCase
             ->method('setTitle')
             ->with('title');
 
+        $feed->expects($this->once())
+            ->method('setPreventUpdate')
+            ->with(1);
+
         $this->feedService->expects($this->once())
             ->method('find')
             ->with($this->uid, 4)
@@ -782,7 +794,7 @@ class FeedControllerTest extends TestCase
             ->with($this->uid, $feed)
             ->will($this->throwException(new ServiceNotFoundException('test')));
 
-        $response = $this->class->patch(4, 2, false, 1, 1, 1, 'title');
+        $response = $this->class->patch(4, 2, false, 1, 1, 1, 'title', 1);
         $params = json_decode($response->render(), true);
 
         $this->assertEquals('test', $params['message']);


### PR DESCRIPTION
* Resolves: #1625 

## Summary

This PR adds an option to the feed action menu, to enable/disable sync of the selected feed. The sync is controlled by feed.preventUpdate which exist already on the backend.
The feed info table will show "Sync disabled" as last update time to keep an overview of which feeds are deactivated.

<img width="414" height="399" alt="grafik" src="https://github.com/user-attachments/assets/77777dc1-77e6-4b5c-9efe-7f122d0b3a6f" />


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
