### PR TITLE
fulltext scraper did not use new user agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - Add option to modify feeds from feed info table
 
 ### Fixed
+- fulltext scraper did not use new user agent
 
 # Releases
 ## [27.0.0-beta.1] - 2025-08-31

--- a/lib/Scraper/Scraper.php
+++ b/lib/Scraper/Scraper.php
@@ -24,10 +24,12 @@ class Scraper implements IScraper
     private $config;
     private $readability;
     private $curl_opts;
+    private $fetcherConfig;
 
-    public function __construct(LoggerInterface $logger)
+    public function __construct(LoggerInterface $logger, FetcherConfig $fetcherConfig)
     {
         $this->logger = $logger;
+        $this->fetcherConfig = $fetcherConfig;
         $this->config = new Configuration([
             'FixRelativeURLs' => true,
             'SummonCthulhu' => true, // Remove <script>
@@ -38,7 +40,7 @@ class Scraper implements IScraper
             CURLOPT_RETURNTRANSFER => true,     // return web page
             CURLOPT_HEADER         => false,    // do not return headers
             CURLOPT_FOLLOWLOCATION => true,     // follow redirects
-            CURLOPT_USERAGENT      => FetcherConfig::DEFAULT_USER_AGENT, // who am i
+            CURLOPT_USERAGENT      => $this->fetcherConfig->getUserAgent(), // who am i
             CURLOPT_AUTOREFERER    => true,     // set referer on redirect
             CURLOPT_CONNECTTIMEOUT => 120,      // timeout on connect
             CURLOPT_TIMEOUT        => 120,      // timeout on response


### PR DESCRIPTION
Related: #3319

## Summary

Seems like we forgot to adjust the scraper to also use the new function.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
