### PR TITLE
fix feed url in global search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 ### Fixed
 - fulltext scraper did not use new user agent
+- fix feed `url` in search results
 
 # Releases
 ## [27.0.0-beta.1] - 2025-08-31

--- a/lib/Search/FeedSearchProvider.php
+++ b/lib/Search/FeedSearchProvider.php
@@ -55,7 +55,7 @@ class FeedSearchProvider implements IProvider
         $term = strtolower($term);
 
         $imageurl  = $this->urlGenerator->imagePath('core', 'rss.svg');
-        $feeduiurl = $this->urlGenerator->linkToRoute('news.page.index') . '#/feed/';
+        $feeduiurl = $this->urlGenerator->linkToRoute('news.page.index') . 'feed/';
         foreach ($this->service->findAllForUser($user->getUID()) as $feed) {
             if (strpos(strtolower($feed->getTitle()), $term) === false) {
                 continue;

--- a/lib/Search/FolderSearchProvider.php
+++ b/lib/Search/FolderSearchProvider.php
@@ -73,7 +73,7 @@ class FolderSearchProvider implements IProvider
                 $imageurl,
                 $folder->getName(),
                 '',
-                $this->urlGenerator->linkToRoute('news.page.index') . '#/folder/' . $folder->getId()
+                $this->urlGenerator->linkToRoute('news.page.index') . 'folder/' . $folder->getId()
             );
         }
 

--- a/lib/Search/ItemSearchProvider.php
+++ b/lib/Search/ItemSearchProvider.php
@@ -100,7 +100,7 @@ class ItemSearchProvider implements IProvider
                 $icon,
                 $item->getTitle(),
                 $this->stripTruncate($item->getBody(), 50),
-                $this->urlGenerator->linkToRoute('news.page.index') . '#/feed/' . $item->getFeedId()
+                $this->urlGenerator->linkToRoute('news.page.index') . 'feed/' . $item->getFeedId()
             );
         }
 

--- a/tests/Unit/Search/FeedSearchProviderTest.php
+++ b/tests/Unit/Search/FeedSearchProviderTest.php
@@ -124,7 +124,7 @@ class FeedSearchProviderTest extends TestCase
         $this->generator->expects($this->once())
                         ->method('linkToRoute')
                         ->with('news.page.index')
-                        ->willReturn('/news');
+                        ->willReturn('/news/');
 
 
         $result = $this->class->search($user, $query)->jsonSerialize();
@@ -133,6 +133,6 @@ class FeedSearchProviderTest extends TestCase
         $this->assertSame('some_tErm', $entry['title']);
         $this->assertSame('folderpath.svg', $entry['thumbnailUrl']);
         $this->assertSame('Unread articles: 1', $entry['subline']);
-        $this->assertSame('/news#/feed/1', $entry['resourceUrl']);
+        $this->assertSame('/news/feed/1', $entry['resourceUrl']);
     }
 }

--- a/tests/Unit/Search/FolderSearchProviderTest.php
+++ b/tests/Unit/Search/FolderSearchProviderTest.php
@@ -127,7 +127,7 @@ class FolderSearchProviderTest extends TestCase
         $this->generator->expects($this->once())
                         ->method('linkToRoute')
                         ->with('news.page.index')
-                        ->willReturn('/news');
+                        ->willReturn('/news/');
 
 
         $result = $this->class->search($user, $query)->jsonSerialize();
@@ -136,6 +136,6 @@ class FolderSearchProviderTest extends TestCase
         $this->assertSame('some_tErm', $entry['title']);
         $this->assertSame('folderpath.svg', $entry['thumbnailUrl']);
         $this->assertSame('', $entry['subline']);
-        $this->assertSame('/news#/folder/1', $entry['resourceUrl']);
+        $this->assertSame('/news/folder/1', $entry['resourceUrl']);
     }
 }

--- a/tests/Unit/Search/ItemSearchProviderTest.php
+++ b/tests/Unit/Search/ItemSearchProviderTest.php
@@ -143,7 +143,7 @@ class ItemSearchProviderTest extends TestCase
         $this->generator->expects($this->exactly(2))
                         ->method('linkToRoute')
                         ->with('news.page.index')
-                        ->willReturn('/news');
+                        ->willReturn('/news/');
 
 
         $result = $this->class->search($user, $query)->jsonSerialize();
@@ -152,6 +152,6 @@ class ItemSearchProviderTest extends TestCase
         $this->assertSame('some_tErm', $entry['title']);
         $this->assertSame('folderpath.svg', $entry['thumbnailUrl']);
         $this->assertSame('some text', $entry['subline']);
-        $this->assertSame('/news#/feed/1', $entry['resourceUrl']);
+        $this->assertSame('/news/feed/1', $entry['resourceUrl']);
     }
 }


### PR DESCRIPTION
## Summary

Remove hash from feed url in search results (#3159)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
