### PR TITLE
feat: Open article from unified search result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 - Add option to enable/disable sync of a feed
 - Add option to modify feeds from feed info table
+- Open article from unified search result
 
 ### Fixed
 - fulltext scraper did not use new user agent

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -17,6 +17,7 @@ return ['routes' => [
 // page
 ['name' => 'page#index', 'url' => '/', 'verb' => 'GET'],
 ['name' => 'page#index', 'url' => '/all', 'verb' => 'GET', 'postfix' => 'view.all'],
+['name' => 'page#index', 'url' => '/item/{itemId}', 'verb' => 'GET', 'postfix' => 'view.itemid'],
 ['name' => 'page#index', 'url' => '/feed/{feedId}', 'verb' => 'GET', 'postfix' => 'view.feedid'],
 ['name' => 'page#index', 'url' => '/folder/{folderId}', 'verb' => 'GET', 'postfix' => 'view.folderid'],
 ['name' => 'page#index', 'url' => '/recent', 'verb' => 'GET', 'postfix' => 'view.recent'],

--- a/lib/Search/ItemSearchProvider.php
+++ b/lib/Search/ItemSearchProvider.php
@@ -100,7 +100,7 @@ class ItemSearchProvider implements IProvider
                 $icon,
                 $item->getTitle(),
                 $this->stripTruncate($item->getBody(), 50),
-                $this->urlGenerator->linkToRoute('news.page.index') . 'feed/' . $item->getFeedId()
+                $this->urlGenerator->linkToRoute('news.page.index') . 'item/' . $item->getId()
             );
         }
 

--- a/src/components/routes/Item.vue
+++ b/src/components/routes/Item.vue
@@ -1,0 +1,63 @@
+<template>
+	<ContentTemplate
+		v-if="!loading"
+		:key="'item-' + itemId"
+		:items="item ? [item] : []"
+		fetch-key="item" />
+</template>
+
+<script lang="ts">
+import type { FeedItem } from '../../types/FeedItem.ts'
+
+import { defineComponent } from 'vue'
+import ContentTemplate from '../ContentTemplate.vue'
+import { ACTIONS } from '../../store/index.ts'
+
+export default defineComponent({
+	name: 'RoutesItem',
+	components: {
+		ContentTemplate,
+	},
+
+	props: {
+		/**
+		 * ID of the item to display
+		 */
+		itemId: {
+			type: String,
+			required: true,
+		},
+	},
+
+	computed: {
+		item(): FeedItem | undefined {
+			const items = this.$store.getters.allItems
+			return items.find((item: FeedItem) => item.id === this.id)
+		},
+
+		id(): number {
+			return Number(this.itemId)
+		},
+
+		loading() {
+			return this.$store.getters.loading
+		},
+
+		oldestFirst() {
+			return this.$store.getters.oldestFirst
+		},
+	},
+
+	created() {
+		this.fetchMore()
+	},
+
+	methods: {
+		async fetchMore() {
+			if (!this.$store.state.items.fetchingItems.all) {
+				this.$store.dispatch(ACTIONS.FETCH_ITEMS, { start: Math.max(1, this.id + (this.oldestFirst ? -1 : 1)), limit: 1 })
+			}
+		},
+	},
+})
+</script>

--- a/src/dataservices/item.service.ts
+++ b/src/dataservices/item.service.ts
@@ -19,7 +19,7 @@ export class ItemService {
 	/**
 	 * Makes backend call to retrieve all items
 	 *
-	 * @param start (id of last starred item loaded)
+	 * @param start (id of last item loaded)
 	 * @return response object containing backend request response
 	 */
 	static async fetchAll(start: number): Promise<AxiosResponse> {
@@ -77,7 +77,7 @@ export class ItemService {
 	 * Makes backend call to retrieve items from a specific feed
 	 *
 	 * @param feedId id number of feed to retrieve items for
-	 * @param start (id of last unread item loaded)
+	 * @param start (id of last feed item loaded)
 	 * @return response object containing backend request response
 	 */
 	static async fetchFeedItems(feedId: number, start?: number): Promise<AxiosResponse> {
@@ -111,7 +111,7 @@ export class ItemService {
 	 * Makes backend call to retrieve items from a specific folder
 	 *
 	 * @param folderId id number of folder to retrieve items for
-	 * @param start (id of last unread item loaded)
+	 * @param start (id of last folder item loaded)
 	 * @return response object containing backend request response
 	 */
 	static async fetchFolderItems(folderId: number, start: number): Promise<AxiosResponse> {

--- a/src/dataservices/item.service.ts
+++ b/src/dataservices/item.service.ts
@@ -20,12 +20,13 @@ export class ItemService {
 	 * Makes backend call to retrieve all items
 	 *
 	 * @param start (id of last item loaded)
+	 * @param limit (number of items loaded)
 	 * @return response object containing backend request response
 	 */
-	static async fetchAll(start: number): Promise<AxiosResponse> {
+	static async fetchAll(start: number, limit: number): Promise<AxiosResponse> {
 		return await axios.get(API_ROUTES.ITEMS, {
 			params: {
-				limit: 40,
+				limit,
 				oldestFirst: store.state.oldestFirst,
 				search: '',
 				showAll: true,

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,6 +4,7 @@ import AllPanel from '../components/routes/All.vue'
 import ExplorePanel from '../components/routes/Explore.vue'
 import FeedPanel from '../components/routes/Feed.vue'
 import FolderPanel from '../components/routes/Folder.vue'
+import ItemPanel from '../components/routes/Item.vue'
 import RecentPanel from '../components/routes/Recent.vue'
 import StarredPanel from '../components/routes/Starred.vue'
 import UnreadPanel from '../components/routes/Unread.vue'
@@ -17,6 +18,7 @@ export const ROUTES = {
 	UNREAD: 'unread',
 	FEED: 'feed',
 	FOLDER: 'folder',
+	ITEM: 'item',
 	ALL: 'all',
 	RECENT: 'recent',
 }
@@ -81,6 +83,12 @@ const routes = [
 		name: ROUTES.FOLDER,
 		path: '/folder/:folderId',
 		component: FolderPanel,
+		props: true,
+	},
+	{
+		name: ROUTES.ITEM,
+		path: '/item/:itemId',
+		component: ItemPanel,
 		props: true,
 	},
 	{

--- a/src/store/item.ts
+++ b/src/store/item.ts
@@ -128,17 +128,18 @@ export const actions = {
 	 * @param param0.commit Commit param
 	 * @param param1 ActionArgs
 	 * @param param1.start Start data
+	 * @param param1.limit Number of items
 	 */
 	async [FEED_ITEM_ACTION_TYPES.FETCH_ITEMS](
 		{ commit }: ActionParams<ItemState>,
-		{ start }: { start: number } = { start: 0 },
+		{ start, limit }: { start: number, limit: number } = { start: 0, limit: 40 },
 	) {
 		const requestId = Date.now()
 		latestFetchRequest = requestId
 
 		commit(FEED_ITEM_MUTATION_TYPES.SET_FETCHING, { key: 'all', fetching: true })
 
-		const response = await ItemService.fetchAll(start || state.lastItemLoaded.all)
+		const response = await ItemService.fetchAll(start || state.lastItemLoaded.all, limit)
 
 		// skip response if outdated
 		if (latestFetchRequest !== requestId) {

--- a/tests/Unit/Search/ItemSearchProviderTest.php
+++ b/tests/Unit/Search/ItemSearchProviderTest.php
@@ -152,6 +152,6 @@ class ItemSearchProviderTest extends TestCase
         $this->assertSame('some_tErm', $entry['title']);
         $this->assertSame('folderpath.svg', $entry['thumbnailUrl']);
         $this->assertSame('some text', $entry['subline']);
-        $this->assertSame('/news/feed/1', $entry['resourceUrl']);
+        $this->assertSame('/news/item/1', $entry['resourceUrl']);
     }
 }


### PR DESCRIPTION
## Summary

This PR adds a new route (/item/:id) to open an article directly and changed the item search to use the new route.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
