### PR TITLE
fix: update package lists before installing httpie

### DIFF
--- a/.github/workflows/api-integration-tests.yml
+++ b/.github/workflows/api-integration-tests.yml
@@ -57,7 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup BATS & httpie
-        run: sudo apt-get install -y httpie && sudo npm install -g bats@1.11.0
+        run: sudo apt-get update && sudo apt-get install -y httpie && sudo npm install -g bats@1.11.0
 
       ### MySQL specific setup
       - name: Setup mysql

--- a/.github/workflows/updater-test.yml
+++ b/.github/workflows/updater-test.yml
@@ -34,7 +34,7 @@ jobs:
           coverage: none
 
       - name: Setup BATS & httpie
-        run: sudo apt-get install -y httpie && sudo npm install -g bats@1.11.0
+        run: sudo apt-get update && sudo apt-get install -y httpie && sudo npm install -g bats@1.11.0
 
       - name: Set up server
         uses: SMillerDev/nextcloud-actions/setup-nextcloud@main


### PR DESCRIPTION
## Summary

This will fix the problems in the updater-test and api-integration-tests  workflow, that dependencies are not found.

```
 Get:9 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 httpie all 3.2.2-1 [93.9 kB]
Ign:2 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 dpkg-dev all 1.22.6ubuntu6.2
Ign:3 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 libdpkg-perl all 1.22.6ubuntu6.2
Err:2 https://security.ubuntu.com/ubuntu noble-updates/main amd64 dpkg-dev all 1.22.6ubuntu6.2
  404  Not Found [IP: 52.147.219.192 80]
```

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
