### PR TITLE
fix: Latvian accented characters messed up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 
 ### Fixed
+- Latvian accented characters messed up
 
 
 # Releases

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -376,18 +376,20 @@ class FeedFetcher implements IFeedFetcher
                 libxml_clear_errors();
             }
             
-            // Convert to UTF-8 if needed with comprehensive encoding detection
-            $encodingList = ['UTF-8', 'ISO-8859-1', 'Windows-1252', 'ASCII', 'UTF-16', 'UTF-16BE', 'UTF-16LE'];
-            $detectedEncoding = mb_detect_encoding($body, $encodingList, true);
-            if ($detectedEncoding !== false && $detectedEncoding !== 'UTF-8') {
-                $convertedBody = mb_convert_encoding($body, 'UTF-8', $detectedEncoding);
-                if ($convertedBody !== false) {
-                    $body = $convertedBody;
-                } else {
-                    $this->logger->warning(
-                        'Failed to convert encoding from {from} to UTF-8 for feed item',
-                        ['from' => $detectedEncoding]
-                    );
+            if (!mb_check_encoding($body, 'UTF-8')) {
+                // Convert to UTF-8 if needed with comprehensive encoding detection
+                $encodingList = ['ISO-8859-1', 'Windows-1252', 'ASCII', 'UTF-16', 'UTF-16BE', 'UTF-16LE'];
+                $detectedEncoding = mb_detect_encoding($body, $encodingList, true);
+                if ($detectedEncoding !== false) {
+                    $convertedBody = mb_convert_encoding($body, 'UTF-8', $detectedEncoding);
+                    if ($convertedBody !== false) {
+                        $body = $convertedBody;
+                    } else {
+                        $this->logger->warning(
+                            'Failed to convert encoding from {from} to UTF-8 for feed item',
+                            ['from' => $detectedEncoding]
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
* Resolves: #3362

## Summary
This PR adds mb_check_encoding to ensure the body text is not already UTF-8, because mb_detect_encoding is not always accurate with its heuristic.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
