### PR TITLE
feat: display categories at the end of an article

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [27.x.x]
 ### Changed
+- Display categories at the end of an article
 
 ### Fixed
 

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -157,6 +157,15 @@
 
 			<div class="body" :dir="item.rtl && 'rtl'" v-html="item.body" />
 			<!--eslint-enable-->
+
+			<div v-if="item.categories?.length > 0" class="feed-item-categories">
+				<NcChip
+					v-for="category in item.categories"
+					:key="category"
+					:text="category"
+					no-close
+					variant="secondary" />
+			</div>
 		</div>
 	</div>
 </template>
@@ -171,6 +180,7 @@ import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import { defineComponent } from 'vue'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActions from '@nextcloud/vue/components/NcActions'
+import NcChip from '@nextcloud/vue/components/NcChip'
 import ChevronLeftIcon from 'vue-material-design-icons/ChevronLeft.vue'
 import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
 import CloseIcon from 'vue-material-design-icons/Close.vue'
@@ -193,6 +203,7 @@ export default defineComponent({
 		ShareVariant,
 		NcActions,
 		NcActionButton,
+		NcChip,
 		ShareItem,
 		ChevronLeftIcon,
 		ChevronRightIcon,
@@ -516,6 +527,13 @@ export default defineComponent({
 		min-width: 30px;
 		min-height: 30px;
 		height: 30px;
+	}
+
+	.feed-item-categories {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--default-grid-baseline);
+		margin-top: var(--default-grid-baseline);
 	}
 
 </style>

--- a/tests/javascript/unit/components/feed-display/FeedItemDisplay.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemDisplay.spec.ts
@@ -38,6 +38,14 @@ describe('FeedItemDisplay.vue', () => {
 						commit: commitStub,
 					},
 				},
+				stubs: {
+					NcChip: {
+						name: 'NcChip',
+						props: ['text', 'variant', 'noClose'],
+						template: '<span class="nc-chip">{{ text }}</span>',
+					},
+
+				},
 			},
 		})
 	})
@@ -103,5 +111,32 @@ describe('FeedItemDisplay.vue', () => {
 		wrapper.vm.stopAudio()
 
 		expect(pauseStub).toBeCalled()
+	})
+
+	it('should show no chips when item has no categories', () => {
+		const chips = wrapper.findAllComponents({ name: 'NcChip' })
+
+		expect(chips.length).toBe(0)
+	})
+
+	it('should show no chips when item.categories is empty', async () => {
+		await wrapper.setProps({
+			item: { ...mockItem, categories: [] },
+		})
+		const chips = wrapper.findAllComponents({ name: 'NcChip' })
+
+		expect(chips.length).toBe(0)
+	})
+
+	it('should show three chips with text from item.categories', async () => {
+		await wrapper.setProps({
+			item: { ...mockItem, categories: ['Nextcloud', 'News', 'Reader'] },
+		})
+		const chips = wrapper.findAllComponents({ name: 'NcChip' })
+		expect(chips.length).toBe(3)
+
+		expect(chips[0].text()).toBe('Nextcloud')
+		expect(chips[1].text()).toBe('News')
+		expect(chips[2].text()).toBe('Reader')
 	})
 })


### PR DESCRIPTION
* Resolves: #3368

## Summary
This PR adds showing existing item categories of an article. The backend support for this was introduced with #1248.

As they are not standardised and sometimes not useful, they are displayed at the end of an article to avoid clutter.

This is an example from the nextcloud blog.

<img width="990" height="340" alt="grafik" src="https://github.com/user-attachments/assets/93f2043f-001e-4788-a8c8-3daabb1e69a0" />


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
