### PR TITLE
testing: add additional unit tests for feed display components

### DIFF
--- a/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemDisplayList.spec.ts
@@ -311,6 +311,27 @@ describe('FeedItemDisplayList.vue', () => {
 		expect((wrapper.findComponent(VirtualScroll)).findAllComponents(FeedItemRow).length).toEqual(4)
 	})
 
+	it('should emit "load-more" when calling fetchMore', () => {
+		wrapper.vm.fetchMore()
+
+		expect(wrapper.emitted()).toHaveProperty('load-more')
+		expect(wrapper.emitted('load-more')!.length).toBe(2)
+	})
+
+	it('should emit "mark-read" when calling markRead', () => {
+		wrapper.vm.markRead()
+
+		expect(wrapper.emitted()).toHaveProperty('mark-read')
+		expect(wrapper.emitted('mark-read')!.length).toBe(1)
+	})
+
+	it('should emit "show-details" when calling showDetails', () => {
+		wrapper.vm.showDetails()
+
+		expect(wrapper.emitted()).toHaveProperty('show-details')
+		expect(wrapper.emitted('show-details')!.length).toBe(1)
+	})
+
 	it('should dispatch STAR_ITEM / UNSTAR_ITEM to toggle starred flag', async () => {
 		wrapper.vm.selectedItem = mockItem1
 		wrapper.vm.toggleStarred()

--- a/tests/javascript/unit/components/feed-display/FeedItemRow.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemRow.spec.ts
@@ -151,4 +151,11 @@ describe('FeedItemRow.vue', () => {
 		expect(markReadSpy).toHaveBeenCalledWith(mockItem)
 		expect(wrapper.emitted()).toHaveProperty('show-details')
 	})
+
+	it('should set showShareMenu to false', () => {
+		wrapper.vm.showShareMenu = true
+
+		wrapper.vm.closeShareMenu()
+		expect(wrapper.vm.showShareMenu).toEqual(false)
+	})
 })


### PR DESCRIPTION
## Summary

This PR adds additional unit tests for the feed display components.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
