### PR TITLE
fix: favicon links not updated for existing feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 
 ### Fixed
+- `favicon` links not updated for existing feeds
 
 
 # Releases

--- a/lib/Service/FeedServiceV2.php
+++ b/lib/Service/FeedServiceV2.php
@@ -370,6 +370,12 @@ class FeedServiceV2 extends Service
             $feed->setNextUpdateTime(null);
         }
 
+        // update favicon link
+        $fetchedFavicon = $fetchedFeed->getFaviconLink();
+        if ($fetchedFavicon) {
+            $feed->setFaviconLink($fetchedFavicon);
+        }
+
         foreach (array_reverse($items) as &$item) {
             $item->setFeedId($feed->getId())
                 ->setBody($this->purifier->purify($item->getBody()));


### PR DESCRIPTION
## Summary

The feed fetcher checks the feed logo with every fetch, but does not update it in the database.

In addition, the original link is now used in case of a `304 - Not Modified`.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
