### PR TITLE
Release 27.2.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,19 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [27.x.x]
 ### Changed
-- Replaced HTMLPurifier with Symfony HTML Sanitizer for improved performance and maintainability
 
 
 ### Fixed
-- `favicon` links not updated for existing feeds
 
 
 # Releases
+## [27.2.0-beta.1] - 2025-11-02
+### Changed
+- Replaced HTMLPurifier with Symfony HTML Sanitizer for improved performance and maintainability (#3393)
+
+### Fixed
+- `favicon` links not updated for existing feeds (#3391)
+
 ## [27.1.0] - 2025-10-26
 ### Changed
 - Display categories at the end of an article (#3380)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>27.1.0</version>
+    <version>27.2.0-beta.1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
## Summary

### Changed
- Replaced HTMLPurifier with Symfony HTML Sanitizer for improved performance and maintainability (#3393)

### Fixed
- `favicon` links not updated for existing feeds (#3391)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
