### PR TITLE
Release 27.2.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,18 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [27.x.x]
 ### Changed
-- Download and store feed logos in the `appdata` directory
-- Add API Endpoint to serve feed logos from backend
-- Web-Frontend now uses feed logos fetched from backend
 
 
 ### Fixed
 
 
 # Releases
+## [27.2.0-beta.2] - 2025-11-09
+### Changed
+- Download and store feed logos in the `appdata` directory (#3392)
+- Add API Endpoint to serve feed logos from backend (#3392)
+- Web-Frontend now uses feed logos fetched from backend (#3392)
+
 ## [27.2.0-beta.1] - 2025-11-02
 ### Changed
 - Replaced HTMLPurifier with Symfony HTML Sanitizer for improved performance and maintainability (#3393)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>27.2.0-beta.1</version>
+    <version>27.2.0-beta.2</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
## Summary
### Changed
- Download and store feed logos in the `appdata` directory (#3392)
- Add API Endpoint to serve feed logos from backend (#3392)
- Web-Frontend now uses feed logos fetched from backend (#3392)


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
