### PR TITLE
feat: show time of the last feed logo purge in admin settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [27.x.x]
 ### Changed
+- Show time of the last feed logo purge in admin settings
 
 
 ### Fixed

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -67,7 +67,6 @@ class Application extends App implements IBootstrap
         'exploreUrl'               => '',
         'updateInterval'           => 3600,
         'useNextUpdateTime'        => false,
-        'lastLogoPurge'            => 0,
     ];
 
     public function __construct(array $urlParams = [])

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -37,6 +37,13 @@ class AdminSettings implements ISettings
 
         $this->initialState->provideInitialState("lastCron", $lastUpdate);
 
+        $lastLogoPurge = $this->config->getValueInt(
+            Application::NAME,
+            'lastLogoPurge',
+            0
+        );
+        $this->initialState->provideInitialState("lastLogoPurge", $lastLogoPurge);
+
         return new TemplateResponse(Application::NAME, 'admin', []);
     }
 

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -9,6 +9,20 @@ SPDX-Licence-Identifier: AGPL-3.0-or-later
 		class="news-settings"
 		doc-url="https://nextcloud.github.io/news/admin/">
 		<div class="field">
+			<NcNoteCard v-if="lastLogoPurge === 0" type="warning">
+				{{ t('news', 'Logo purge has never been run.') }}
+			</NcNoteCard>
+
+			<NcNoteCard v-else-if="oldLastLogoPurge" type="error">
+				{{ t('news', 'Last logo purge ran {relativeLastLogoPurge}. Something is wrong.', { relativeLastLogoPurge }) }}
+			</NcNoteCard>
+
+			<NcNoteCard v-else type="success">
+				{{ t('news', 'Last logo purge job ran {relativeLastLogoPurge}.', { relativeLastLogoPurge }) }}
+			</NcNoteCard>
+		</div>
+
+		<div class="field">
 			<NcNoteCard v-if="lastCron === 0" type="warning">
 				{{ t('news', 'No job execution data available. The cron job may not be running properly.') }}
 			</NcNoteCard>
@@ -146,6 +160,7 @@ function debounce(func, wait) {
 
 const successMessage = debounce(() => showSuccess(t('news', 'Successfully updated news configuration')), 500)
 const lastCron = loadState('news', 'lastCron')
+const lastLogoPurge = loadState('news', 'lastLogoPurge')
 
 export default {
 	name: 'AdminSettings',
@@ -168,12 +183,18 @@ export default {
 			useNextUpdateTime: loadState('news', 'useNextUpdateTime') === '1',
 			relativeTime: formatDateRelative(lastCron),
 			lastCron,
+			relativeLastLogoPurge: formatDateRelative(lastLogoPurge),
+			lastLogoPurge,
 		}
 	},
 
 	computed: {
 		oldExecution() {
 			return Date.now() / 1000 - this.lastCron > (parseInt(this.updateInterval) * 2) + 900
+		},
+
+		oldLastLogoPurge() {
+			return Date.now() / 1000 - this.lastLogoPurge > 604800
 		},
 	},
 

--- a/tests/javascript/unit/components/AdminSettings.spec.ts
+++ b/tests/javascript/unit/components/AdminSettings.spec.ts
@@ -25,7 +25,13 @@ describe('AdminSettings.vue', () => {
 
 	beforeAll(() => {
 		loadState.mockReturnValue('')
-		wrapper = shallowMount(AdminSettings, { })
+		wrapper = shallowMount(AdminSettings, {
+			data() {
+				return {
+					updateInterval: 3600,
+				}
+			},
+		})
 	})
 
 	beforeEach(() => {
@@ -33,7 +39,39 @@ describe('AdminSettings.vue', () => {
 	})
 
 	it('should initialize and fetch settings from state', () => {
-		expect(loadState).toBeCalledTimes(9)
+		expect(loadState).toBeCalledTimes(10)
+	})
+
+	it('returns true when lastCron is too old', async () => {
+		const now = 1000000000
+		vi.setSystemTime(now * 1000)
+		wrapper.vm.lastCron = now - 8200
+
+		expect(wrapper.vm.oldExecution).toBe(true)
+	})
+
+	it('returns false when lastCron within range', async () => {
+		const now = 1000000000
+		vi.setSystemTime(now * 1000)
+		wrapper.vm.lastCron = now - 8000
+
+		expect(wrapper.vm.oldExecution).toBe(false)
+	})
+
+	it('returns true when lastLogoPurge is more than 7 days ago', () => {
+		const now = 1000000000
+		vi.setSystemTime(now * 1000)
+		wrapper.vm.lastLogoPurge = now - 605800
+
+		expect(wrapper.vm.oldLastLogoPurge).toBe(true)
+	})
+
+	it('returns false when lastLogoPurge is less than 7 days ago', () => {
+		const now = 1000000000
+		vi.setSystemTime(now * 1000)
+		wrapper.vm.lastLogoPurge = now - 604800
+
+		expect(wrapper.vm.oldLastLogoPurge).toBe(false)
 	})
 
 	it('should send post with updated settings', async () => {


### PR DESCRIPTION
## Summary

This PR adds a info about the last run time for the logo purge job.
It also fixes that the admin page can't be accessed in the current beta because of having   ` 'lastLogoPurge'            => 0,` in DEFAULT_SETTINGS, which is not a setting and set as integer. The admin settings class expect only string values for the default setting values.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
