### PR TITLE
Release 27.2.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ## [27.x.x]
 ### Changed
-- Show time of the last feed logo purge in admin settings
 
 
 ### Fixed
 
 
 # Releases
+## [27.2.0-beta.3] - 2025-11-10
+### Changed
+- Show time of the last feed logo purge in admin settings (#3414)
+
 ## [27.2.0-beta.2] - 2025-11-09
 ### Changed
 - Download and store feed logos in the `appdata` directory (#3392)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>27.2.0-beta.2</version>
+    <version>27.2.0-beta.3</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
## Summary

### Changed
- Show time of the last feed logo purge in admin settings (#3414)


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
