### PR TITLE
testing: set global.appVersion needed since @nextcloud/vue 9.3.0

### DIFF
--- a/tests/javascript/unit/setup.ts
+++ b/tests/javascript/unit/setup.ts
@@ -2,6 +2,7 @@ import { config } from '@vue/test-utils'
 import { vi } from 'vitest'
 
 global.appName = 'news'
+global.appVersion = '1.0.0'
 
 global.OC = {
 	getLanguage() {


### PR DESCRIPTION
## Summary

Set global.appVersion in setup.ts to prevent error message:

`[ERROR] @nextcloud/vue: The `@nextcloud/vue` library was used without setting / replacing the `appVersion`. { app: '@nextcloud/vue', level: 2 }`

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
