### PR TITLE
fix: article body may have incorrect encoding from full text scraping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 
 ### Fixed
+- Special characters may be displayed incorrectly when full text is enabled
 
 # Releases
 ## [28.0.0-beta.1] - 2025-11-13


### PR DESCRIPTION
* Resolves: #3468 

## Summary

To avoid encoding problems when using full text scraping, the downloaded content is converted to utf-8 before parsing and stripping it with the readability library.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
