### PR TITLE
fix: Wrong url to feed page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 ### Fixed
 - Special characters may be displayed incorrectly when full text is enabled
+- Wrong url to feed page
 
 # Releases
 ## [28.0.0-beta.1] - 2025-11-13

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -95,7 +95,7 @@
 
 			<div class="subtitle" :dir="item.rtl && 'rtl'">
 				<span v-if="!item.sharedBy" class="source">
-					<a :href="feedUrl + '/' + feed.id">
+					<a :href="feedUrl">
 						{{ feed.title }}
 						<img
 							:src="feedIcon"
@@ -173,6 +173,7 @@
 import type { Feed } from '../../types/Feed.ts'
 import type { FeedItem } from '../../types/FeedItem.ts'
 
+import { generateUrl } from '@nextcloud/router'
 import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import { defineComponent } from 'vue'
@@ -256,7 +257,6 @@ export default defineComponent({
 			isMobile: useIsMobile(),
 			keepUnread: false,
 			showShareMenu: false,
-			feedUrl: API_ROUTES.FEED,
 		}
 	},
 
@@ -267,6 +267,10 @@ export default defineComponent({
 
 		feedIcon() {
 			return API_ROUTES.FAVICON + '/' + this.feed.urlHash
+		},
+
+		feedUrl() {
+			return generateUrl('/apps/news/feed/' + this.feed.id)
 		},
 
 		screenReaderMode() {


### PR DESCRIPTION
* Resolves: #3483

## Summary

This PR fixes the feed url link in item details view.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
