### PR TITLE
fix: Long articles are cut short

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Fixed
 - Special characters may be displayed incorrectly when full text is enabled
 - Wrong url to feed page
+- Long articles are cut short
 
 # Releases
 ## [28.0.0-beta.1] - 2025-11-13

--- a/lib/Utility/HtmlSanitizer.php
+++ b/lib/Utility/HtmlSanitizer.php
@@ -66,6 +66,8 @@ class HtmlSanitizer
             // Allow relative links and media
             ->allowRelativeLinks(true)
             ->allowRelativeMedias(true)
+            // Disable input length limit
+            ->withMaxInputLength(-1)
             // Add custom iframe src sanitizer to restrict to YouTube, Vimeo, VK
             ->withAttributeSanitizer(new SafeIframeAttributeSanitizer());
 


### PR DESCRIPTION
* Resolves: #3487 

## Summary

This PR disables the input length limit for the html sanitizer.

[Max Input Length](https://symfony.com/doc/current/html_sanitizer.html#max-input-length)
> In order to prevent [DoS attacks](https://en.wikipedia.org/wiki/Denial-of-service_attack), by default the HTML sanitizer limits the input length to 20000 characters (as measured by strlen($input)). All the contents exceeding that length will be truncated. Use this option to increase or decrease this limit.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
