### PR TITLE
feat: save starred navigation item open state

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -84,7 +84,8 @@ class PageController extends Controller
             'lastViewedFeedType',
             'disableRefresh',
             'displaymode',
-            'splitmode'
+            'splitmode',
+            'starredOpenState'
         ];
 
         foreach ($usersettings as $setting) {

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -18,6 +18,7 @@ export type AppInfoState = {
 	disableRefresh: boolean
 	lastViewedFeedId: string
 	lastViewedFeedType: string
+	starredOpenState: boolean
 }
 
 const state: AppInfoState = reactive({
@@ -31,6 +32,7 @@ const state: AppInfoState = reactive({
 	disableRefresh: loadState('news', 'disableRefresh', null) === '1',
 	lastViewedFeedId: loadState('news', 'lastViewedFeedId', '0'),
 	lastViewedFeedType: loadState('news', 'lastViewedFeedType', '6'),
+	starredOpenState: loadState('news', 'starredOpenState', null) === '1',
 })
 
 const getters = {
@@ -64,6 +66,9 @@ const getters = {
 	},
 	lastViewedFeedType(state: AppInfoState) {
 		return state.lastViewedFeedType
+	},
+	starredOpenState(state: AppInfoState) {
+		return state.starredOpenState
 	},
 }
 
@@ -121,6 +126,12 @@ export const mutations = {
 		{ value }: { value: boolean },
 	) {
 		state.disableRefresh = value
+	},
+	starredOpenState(
+		state: AppInfoState,
+		{ value }: { value: boolean },
+	) {
+		state.starredOpenState = value
 	},
 }
 

--- a/tests/javascript/unit/store/app.spec.ts
+++ b/tests/javascript/unit/store/app.spec.ts
@@ -80,6 +80,11 @@ describe('app.ts', () => {
 			store.state.appInfo.lastViewedFeedType = '6'
 			expect(store.getters.lastViewedFeedType).toBe('6')
 		})
+
+		it('should return starredOpenState state', () => {
+			store.state.appInfo.starredOpenState = true
+			expect(store.getters.starredOpenState).toBe(true)
+		})
 	})
 
 	// describe('actions', () => {
@@ -149,6 +154,13 @@ describe('app.ts', () => {
 
 			mutations.disableRefresh(state, { value: true })
 			expect(state.disableRefresh).toEqual(true)
+		})
+
+		it('starredOpenState should update the value in the state', () => {
+			const state = { starredOpenState: undefined } as AppInfoState
+
+			mutations.starredOpenState(state, { value: true })
+			expect(state.starredOpenState).toEqual(true)
 		})
 	})
 })


### PR DESCRIPTION
## Summary

This PR adds saving the open state to the new starred group feature introduced in  #3148 

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
