### PR TITLE
fix: changing starred routes does not deselect current item

### DIFF
--- a/src/components/routes/Starred.vue
+++ b/src/components/routes/Starred.vue
@@ -1,6 +1,7 @@
 <template>
 	<ContentTemplate
 		v-if="!loading"
+		:key="fetchKey"
 		:list-name="starredFeed ? starredFeed.title : t('news', 'Starred')"
 		:list-count="starredFeed ? starredFeed.starredCount : items.starredCount"
 		:items="starred"


### PR DESCRIPTION
## Summary
This PR contains a small bug fix for the starred route feature #3148

Since the starred route now has multiple routes it needs a unique key otherwise things like deselecting the current viewed article from the last selected route wont work.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
