### PR TITLE
feat: use lastViewedFeedId when loading starred as initial route

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -26,8 +26,8 @@ export const ROUTES = {
 /**
  *
  */
-function getInitialRoute() {
-	const params: { feedId?: string, folderId?: string } = {}
+export function getInitialRoute() {
+	const params: { feedId?: string, folderId?: string, starredFeedId?: string } = {}
 
 	switch (store.state.lastViewedFeedType) {
 		case '0':
@@ -43,7 +43,13 @@ function getInitialRoute() {
 				params,
 			}
 		case '2':
-			return { name: ROUTES.STARRED }
+			if (store.state.lastViewedFeedId > 0) {
+				params.starredFeedId = store.state.lastViewedFeedId
+			}
+			return {
+				name: ROUTES.STARRED,
+				params,
+			}
 		case '3':
 			return { name: ROUTES.ALL }
 		case '5':

--- a/tests/javascript/unit/routes/index.spec.ts
+++ b/tests/javascript/unit/routes/index.spec.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getInitialRoute, ROUTES } from '../../../../src/routes/index.ts'
+import app from '../../../../src/store/app.ts'
+
+describe('getInitialRoute', () => {
+	beforeEach(() => {
+		app.state.lastViewedFeedType = ''
+		app.state.lastViewedFeedId = 0
+	})
+
+	it('should return FEED route with feedId if lastViewedFeedType is 0', () => {
+		app.state.lastViewedFeedType = '0'
+		app.state.lastViewedFeedId = 123
+
+		const result = getInitialRoute()
+		expect(result).toEqual({
+			name: ROUTES.FEED,
+			params: { feedId: 123 },
+		})
+	})
+
+	it('should return FOLDER route with folderId if lastViewedFeedType is 1', () => {
+		app.state.lastViewedFeedType = '1'
+		app.state.lastViewedFeedId = 456
+
+		const result = getInitialRoute()
+		expect(result).toEqual({
+			name: ROUTES.FOLDER,
+			params: { folderId: 456 },
+		})
+	})
+
+	it('should return STARRED route with starredFeedId if lastViewedFeedType is 2 and lastViewedFeedId > 0', () => {
+		app.state.lastViewedFeedType = '2'
+		app.state.lastViewedFeedId = 789
+
+		const result = getInitialRoute()
+		expect(result).toEqual({
+			name: ROUTES.STARRED,
+			params: { starredFeedId: 789 },
+		})
+	})
+
+	it('should return STARRED route if lastViewedFeedType is 2', () => {
+		app.state.lastViewedFeedType = '2'
+		app.state.lastViewedFeedId = 0
+
+		const result = getInitialRoute()
+		expect(result).toEqual({
+			name: ROUTES.STARRED,
+			params: {},
+		})
+	})
+
+	it('should return ALL route if lastViewedFeedType is 3', () => {
+		app.state.lastViewedFeedType = '3'
+
+		const result = getInitialRoute()
+		expect(result).toEqual({
+			name: ROUTES.ALL,
+		})
+	})
+
+	it('should return EXPLORE route if lastViewedFeedType is 5', () => {
+		app.state.lastViewedFeedType = '5'
+
+		const result = getInitialRoute()
+		expect(result).toEqual({
+			name: ROUTES.EXPLORE,
+		})
+	})
+
+	it('should return UNREAD route for any other type', () => {
+		app.state.lastViewedFeedType = 'unknown'
+
+		const result = getInitialRoute()
+		expect(result).toEqual({
+			name: ROUTES.UNREAD,
+		})
+	})
+})


### PR DESCRIPTION
## Summary

This PR adds the last missing part for #3148, to also initially use the last viewed starred feed when opening the app.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
