### PR TITLE
[master] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7716,9 +7716,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {


### PR DESCRIPTION
# Audit report

This audit fix resolves 1 of the total 8 vulnerabilities found in your project.

## Updated dependencies
* [lodash](#user-content-lodash)
## Fixed vulnerabilities

### `lodash` <a href="#user-content-lodash" id="lodash">#</a>
* Lodash has Prototype Pollution Vulnerability in `_.unset` and `_.omit` functions
* Severity: **moderate** (CVSS 6.5)
* Reference: [https://github.com/advisories/GHSA-xxjr-mmjv-4gpg](https://github.com/advisories/GHSA-xxjr-mmjv-4gpg)
* Affected versions: 4.0.0 - 4.17.21
* Package usage:
  * `node_modules/lodash`