### PR TITLE
fix: respect the proxy configuration and use the correct user agent for all http fetcher clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Fixed
 - global starred count not updated when deleting a feed with starred items
 - feed fetcher requests may get stuck
+- feed logo download and `fulltext` scraper don't use configured proxy
 
 # Releases
 ## [28.0.0-beta.2] - 2026-01-12

--- a/lib/Scraper/Scraper.php
+++ b/lib/Scraper/Scraper.php
@@ -46,6 +46,11 @@ class Scraper implements IScraper
             CURLOPT_TIMEOUT        => 120,      // timeout on response
             CURLOPT_MAXREDIRS      => 10,       // stop after 10 redirects
         );
+
+        $proxy = $this->fetcherConfig->getProxy();
+        if (!is_null($proxy) && $proxy !== '') {
+            $this->curl_opts[CURLOPT_PROXY] = $proxy;
+        }
     }
 
     private function getHTTPContent(string $url): array


### PR DESCRIPTION
* Resolves: #3488
* Resolves: #3525

## Summary

This PR is a follow up to #3528 that fixes the real problem that the different http clients uses wrong user agents and don't respect the proxy confguration.
That is why the client requests can stuck (propably blocked by CDN).

Therefore, the configuration is now standardised via getHttpClient in the FetcherConfig.
Different timeout values or optional parameters can be set via $config parameter.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
