### PR TITLE
Handle invalid JSON in feed fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - global starred count not updated when deleting a feed with starred items
 - feed fetcher requests may get stuck
 - feed logo download and `fulltext` scraper don't use configured proxy
+- handle invalid JSON feed responses without crashing updater job
 
 # Releases
 ## [28.0.0-beta.2] - 2026-01-12

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -169,7 +169,11 @@ class FeedFetcher implements IFeedFetcher
             $lastModified = null;
         }
         $url = (string) $url2;
-        $resource = $this->reader->read($url, null, $lastModified);
+        try {
+            $resource = $this->reader->read($url, null, $lastModified);
+        } catch (\TypeError $e) {
+            throw new ReadErrorException($e->getMessage(), $e->getCode(), $e);
+        }
 
         $location     = $resource->getUrl();
         $parsedFeed   = $resource->getFeed();

--- a/tests/Unit/Fetcher/FeedFetcherTest.php
+++ b/tests/Unit/Fetcher/FeedFetcherTest.php
@@ -22,6 +22,7 @@ use OCA\News\Vendor\FeedIo\Feed\Node\Category;
 use OCA\News\Vendor\FeedIo\Feed\ItemInterface;
 use OCA\News\Vendor\FeedIo\FeedInterface;
 use OCA\News\Vendor\FeedIo\FeedIo;
+use OCA\News\Vendor\FeedIo\Reader\ReadErrorException;
 use OCA\News\Vendor\FeedIo\Reader\Result;
 use OC\L10N\L10N;
 use \OCA\News\Db\Feed;
@@ -349,6 +350,17 @@ class FeedFetcherTest extends TestCase
         $result = $this->fetcher->fetch($this->url, false, null, null, null);
 
         $this->assertEquals([$feed, [$item]], $result);
+    }
+
+    public function testFetchWrapsTypeError(): void
+    {
+        $this->reader->expects($this->once())
+            ->method('read')
+            ->with($this->url)
+            ->will($this->throwException(new \TypeError('Invalid JSON')));
+
+        $this->expectException(ReadErrorException::class);
+        $this->fetcher->fetch($this->url, false, null, null, null);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Convert Feed-IO TypeError to ReadErrorException to avoid crashing UpdaterJob
- Add unit test for invalid JSON handling
- Update changelog

## Related issue
- Fixes #3129