### PR TITLE
Release 28.0.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 # Unreleased
 ### Changed
-- Notifications for shared articles - recipients now receive a notification when someone shares an article with them
+
+
+### Fixed
+
+
+# Releases
+## [28.0.0-beta.3] - 2026-02-08
+### Changed
+- Notifications for shared articles - recipients now receive a notification when someone shares an article with them (#3542)
 
 ### Fixed
 - global starred count not updated when deleting a feed with starred items (#3507)
@@ -14,7 +22,6 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - feed logo download and `fulltext` scraper don't use configured proxy (#3533)
 - Dependency scoping incompatible with auto-downloaded composer (#3418)
 
-# Releases
 ## [28.0.0-beta.2] - 2026-01-12
 ### Changed
 - Drop Support for Nextcloud 31 (#3485)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>28.0.0-beta.2</version>
+    <version>28.0.0-beta.3</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION



* Resolves: # <!-- related github issue -->

## Summary

### Changed
- Notifications for shared articles - recipients now receive a notification when someone shares an article with them (#3542)

### Fixed
- global starred count not updated when deleting a feed with starred items (#3507)
- feed fetcher requests may get stuck (#3528)
- feed logo download and `fulltext` scraper don't use configured proxy (#3533)
- Dependency scoping incompatible with auto-downloaded composer (#3418)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
