### PR TITLE
Check for null before logging download status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Fixed
 - Article sharing throws 404 error due to incorrect URL path construction
 - Password managers auto-filling the share recipient field
+- Improved error handling in `news:updater:update-feed` command with fallback message (#3561)
 
 # Releases
 ## [28.0.0-beta.3] - 2026-02-08

--- a/lib/Command/Updater/UpdateFeed.php
+++ b/lib/Command/Updater/UpdateFeed.php
@@ -66,7 +66,10 @@ class UpdateFeed extends Command
         }
 
         if ($updated_feed->getUpdateErrorCount() !== 0) {
-            $output->writeln($updated_feed->getLastUpdateError());
+            $message = $updated_feed->getLastUpdateError();
+            $message ??= 'Could not update feed with id ' . $feedId . ' for user ' . $userId;
+
+            $output->writeln($message);
             return 255;
         }
 

--- a/tests/Unit/Command/UpdateFeedTest.php
+++ b/tests/Unit/Command/UpdateFeedTest.php
@@ -126,6 +126,44 @@ class UpdateFeedTest extends TestCase
     }
 
     /**
+     * Test feed error with null last error message uses fallback
+     */
+    public function testValidFeedErrorWithNullMessage()
+    {
+        $this->consoleInput->expects($this->exactly(2))
+                           ->method('getArgument')
+                           ->will($this->returnValueMap([
+                               ['feed-id', '1'],
+                               ['user-id', 'admin'],
+                           ]));
+
+        $feed = $this->createMock(Feed::class);
+        $feed->expects($this->exactly(1))
+             ->method('getUpdateErrorCount')
+             ->willReturn(10);
+        $feed->expects($this->exactly(1))
+             ->method('getLastUpdateError')
+             ->willReturn(null);
+
+        $this->service->expects($this->exactly(1))
+                           ->method('find')
+                           ->with('admin', '1')
+                           ->willReturn($feed);
+
+        $this->service->expects($this->exactly(1))
+                           ->method('fetch')
+                           ->with($feed)
+                           ->willReturn($feed);
+
+        $this->consoleOutput->expects($this->exactly(1))
+                           ->method('writeln')
+                           ->with('Could not update feed with id 1 for user admin');
+
+        $result = $this->command->run($this->consoleInput, $this->consoleOutput);
+        $this->assertSame(255, $result);
+    }
+
+    /**
      * Test a valid call will work
      */
     public function testInValid()


### PR DESCRIPTION
* Resolves: #3556

## Summary

A very modest check to ensure no crashing on nulls.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
