### PR TITLE
workflows: use mariadb service instead of outdated getong/mariadb-action

### DIFF
--- a/.github/workflows/api-integration-tests.yml
+++ b/.github/workflows/api-integration-tests.yml
@@ -7,7 +7,7 @@ env:
   MYSQL_USER: nc_test
   MYSQL_PASSWORD: nc_test_db
   MYSQL_DATABASE: nc_test
-  MYSQL_PORT: 3800
+  MYSQL_PORT: 3800 # hardcoded at services:mariadb:ports
 
 jobs:
   integration:
@@ -26,6 +26,16 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432 # Maps tcp port 5432 on service container to the host
+      mariadb:
+        image: mariadb:10.5
+        env:
+          MYSQL_ROOT_PASSWORD: ${{ env.MYSQL_PASSWORD }}
+          MYSQL_USER: ${{ env.MYSQL_USER }}
+          MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
+          MYSQL_DATABASE: ${{ env.MYSQL_DATABASE }}
+        options: --health-cmd="mariadb-admin ping" --health-interval 5s --health-timeout 2s --health-retries 5
+        ports:
+          - 3800:3306/tcp
     strategy:
       matrix:
         php-versions: ['8.2', '8.3']
@@ -60,17 +70,6 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y httpie && sudo npm install -g bats@1.11.0
 
       ### MySQL specific setup
-      - name: Setup mysql
-        if: matrix.database == 'mysql'
-        uses: getong/mariadb-action@d6d2ec41fd5588f369be4c9398ce77ee725ca9ea # v1.11
-        with:
-          mariadb version: '10.5'
-          host port: ${{ env.MYSQL_PORT }}
-          mysql database: ${{ env.MYSQL_DATABASE }}
-          mysql root password: ${{ env.MYSQL_PASSWORD }}
-          mysql user: ${{ env.MYSQL_USER }}
-          mysql password: ${{ env.MYSQL_PASSWORD }}
-
       - name: Set up server MySQL
         if: matrix.database == 'mysql'
         uses: SMillerDev/nextcloud-actions/setup-nextcloud@7665802e389e40d21b49877c3728bacca324d6e0 #latest


### PR DESCRIPTION
## Summary
This PR replaces the outdated mariadb-action with the github mariadb service.

**Note**: the mysql port is hardcoded, because you can't use env for the services ports, but we can use vars.MYSQL_PORT which has than to be configured in the action settings.

Currently the api integration test for mysql sporadically fails because of an outdated docker version that the maridb-action use.
Like currently for #3564 (https://github.com/nextcloud/news/actions/runs/22074097029)

`docker: Error response from daemon: client version 1.40 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.`

> Current runner version: '2.331.0'
> Runner Image Provisioner
>   Hosted Compute Agent

> Checking docker version
>   /usr/bin/docker version --format '{{.Server.APIVersion}}'
>   '1.52'
>   Docker daemon API version: '1.52'
>   /usr/bin/docker version --format '{{.Client.APIVersion}}'
>   '1.52'
> 

They ran fine on the other hosts (nextcloud self-hosted?) which has an older version installed.

> Current runner version: '2.331.0'
> Runner name: 'garm-24-ttsepx4xepsm'

> Checking docker version
>   /usr/bin/docker version --format '{{.Server.APIVersion}}'
>   '1.48'
>   Docker daemon API version: '1.48'
>   /usr/bin/docker version --format '{{.Client.APIVersion}}'
>   '1.48'

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
