### PR TITLE
Release 28.0.0-rc.1

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -111,6 +111,7 @@
 * [Benedikt Geißler](mailto:benedikt@g5r.eu)
 * [Bernhard Posselt](mailto:bernhard@desktop.localdomain)
 * [Björn Bidar](mailto:bjorn.bidar@thaodan.de)
+* [Brian Schwartz](mailto:brian@wellvetted.co)
 * [Candid Dauth](mailto:cdauth@cdauth.eu)
 * [Carl Schwan](mailto:carl@carlschwan.eu)
 * [Carlos Silva](mailto:r3pek@r3pek.org)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,22 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 # Unreleased
 ### Changed
-- Replace deprecated PHPUnit `withConsecutive` method to prepare for PHPUnit 10 upgrade
-- Add CI security scanning with Zizmor (#3560)
-- Add user settings to control loading external content in the frontend
-- Add support for Media RSS images in the frontend
 
 ### Fixed
-- Article sharing throws 404 error due to incorrect URL path construction
-- Password managers auto-filling the share recipient field
-- Improved error handling in `news:updater:update-feed` command with fallback message (#3561)
 
 # Releases
+## [28.0.0-rc.1] - 2026-02-18
+### Changed
+- Replace deprecated PHPUnit `withConsecutive` method to prepare for PHPUnit 10 upgrade (#3434)
+- Add CI security scanning with Zizmor (#3560)
+- Add user settings to control loading external content in the frontend (#3566)
+- Add support for Media RSS images in the frontend (#3566)
+
+### Fixed
+- Article sharing throws 404 error due to incorrect URL path construction (#3551)
+- Password managers auto-filling the share recipient field (#3551)
+- Improved error handling in `news:updater:update-feed` command with fallback message (#3561)
+
 ## [28.0.0-beta.3] - 2026-02-08
 ### Changed
 - Notifications for shared articles - recipients now receive a notification when someone shares an article with them (#3542)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>28.0.0-beta.3</version>
+    <version>28.0.0-rc.1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

### Changed
- Replace deprecated PHPUnit `withConsecutive` method to prepare for PHPUnit 10 upgrade (#3434)
- Add CI security scanning with Zizmor (#3560)
- Add user settings to control loading external content in the frontend (#3566)
- Add support for Media RSS images in the frontend (#3566)

### Fixed
- Article sharing throws 404 error due to incorrect URL path construction (#3551)
- Password managers auto-filling the share recipient field (#3551)
- Improved error handling in `news:updater:update-feed` command with fallback message (#3561)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
