### PR TITLE
Fix wrong image referenced in notifaction code 

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -103,7 +103,7 @@ class Notifier implements INotifier
         );
 
         $notification->setLink(
-            $this->urlGenerator->linkToRouteAbsolute('news.page.index')
+            $this->urlGenerator->linkToRouteAbsolute('news.page.index') . 'item/' . $notification->getObjectId()
         );
 
         $notification->setIcon(

--- a/tests/Unit/Notification/NotifierTest.php
+++ b/tests/Unit/Notification/NotifierTest.php
@@ -119,7 +119,7 @@ class NotifierTest extends TestCase
 
         $this->urlGenerator->method('linkToRouteAbsolute')
             ->with('news.page.index')
-            ->willReturn('https://cloud.example.com/apps/news');
+            ->willReturn('https://cloud.example.com/apps/news/');
 
         $this->urlGenerator->method('imagePath')
             ->with(Application::NAME, 'app-dark.svg')
@@ -155,7 +155,7 @@ class NotifierTest extends TestCase
 
         $notification->expects($this->once())
             ->method('setLink')
-            ->with('https://cloud.example.com/apps/news')
+            ->with('https://cloud.example.com/apps/news/item/42')
             ->willReturnSelf();
 
         $notification->expects($this->once())
@@ -188,7 +188,7 @@ class NotifierTest extends TestCase
 
         $this->userManager->method('get')->with('deleted_user')->willReturn(null);
 
-        $this->urlGenerator->method('linkToRouteAbsolute')->willReturn('https://cloud.example.com/apps/news');
+        $this->urlGenerator->method('linkToRouteAbsolute')->willReturn('https://cloud.example.com/apps/news/');
         $this->urlGenerator->method('imagePath')->willReturn('/apps/news/img/app-dark.svg');
         $this->urlGenerator->method('getAbsoluteURL')->willReturn('https://cloud.example.com/apps/news/img/app-dark.svg');
 
@@ -246,7 +246,7 @@ class NotifierTest extends TestCase
         $user->method('getDisplayName')->willReturn('Alice');
         $this->userManager->method('get')->with('alice')->willReturn($user);
 
-        $this->urlGenerator->method('linkToRouteAbsolute')->willReturn('https://cloud.example.com/apps/news');
+        $this->urlGenerator->method('linkToRouteAbsolute')->willReturn('https://cloud.example.com/apps/news/');
         $this->urlGenerator->method('imagePath')->willReturn('/apps/news/img/app-dark.svg');
         $this->urlGenerator->method('getAbsoluteURL')->willReturn('https://cloud.example.com/apps/news/img/app-dark.svg');
 
@@ -293,7 +293,7 @@ class NotifierTest extends TestCase
         // Empty sharedBy falls back to ''
         $this->userManager->method('get')->with('')->willReturn(null);
 
-        $this->urlGenerator->method('linkToRouteAbsolute')->willReturn('https://cloud.example.com/apps/news');
+        $this->urlGenerator->method('linkToRouteAbsolute')->willReturn('https://cloud.example.com/apps/news/');
         $this->urlGenerator->method('imagePath')->willReturn('/apps/news/img/app-dark.svg');
         $this->urlGenerator->method('getAbsoluteURL')->willReturn('https://cloud.example.com/apps/news/img/app-dark.svg');
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

The image referenced in the code does not exist.

<img width="379" height="313" alt="image" src="https://github.com/user-attachments/assets/bf279ced-0ed0-4a74-8873-7cb43d20f5b7" />
<img width="379" height="313" alt="image" src="https://github.com/user-attachments/assets/878cc658-df44-4389-9fc3-235eb7220383" />


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
