### PR TITLE
Automatically select item when using single item route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 
 ### Fixed
+- Automatically select item when using single item route
 
 # Releases
 ## [28.0.0-rc.2] - 2026-02-18

--- a/src/components/ContentTemplate.vue
+++ b/src/components/ContentTemplate.vue
@@ -200,7 +200,7 @@ const detailsView = computed(() => {
 function showItem(value) {
 	showDetails.value = value
 	// store show details value in local storage
-	if (noSplitMode.value) {
+	if (noSplitMode.value && props.fetchKey !== 'item') {
 		browserStorage.setItem('news.show-details', value)
 	}
 	// scroll to selected item when closing details in no-split mode
@@ -314,6 +314,8 @@ watch(displayMode, (newDisplayMode) => {
 	} else {
 		disablePageHotkeys()
 	}
+	showDetails.value = false
+	browserStorage.removeItem('news.show-details')
 })
 
 onBeforeMount(() => {
@@ -327,12 +329,14 @@ onMounted(() => {
 	if (displayMode.value === DISPLAY_MODE.SCREENREADER) {
 		enablePageHotkeys()
 	}
-	// get show-details flag from browser storage
-	if (noSplitMode.value) {
-		showItem(browserStorage.getItem('news.show-details') === 'true')
-		if (showDetails.value) {
-			initialSelection.value = true
-		}
+
+	const shouldShowItem = props.fetchKey === 'item'
+		|| (noSplitMode.value && browserStorage.getItem('news.show-details') === 'true')
+
+	showItem(shouldShowItem)
+
+	if (shouldShowItem && showDetails.value) {
+		initialSelection.value = true
 	}
 })
 
@@ -341,12 +345,13 @@ onBeforeUnmount(() => {
 })
 
 onUpdated(() => {
-	// auto-select first item when in details view and initialSelection is set
-	if (initialSelection.value && detailsView.value && !fetchingItems.value) {
-		if (props.items.length > 0) {
-			selectItem(props.items[0])
-			initialSelection.value = false
-		}
+	// auto-select first item when in details view and initialSelection is set or on item route
+	if (!fetchingItems.value
+		&& initialSelection.value
+		&& (detailsView.value || props.fetchKey === 'item')
+		&& props.items.length > 0) {
+		selectItem(props.items[0])
+		initialSelection.value = false
 	}
 })
 

--- a/tests/javascript/unit/components/ContentTemplate.spec.ts
+++ b/tests/javascript/unit/components/ContentTemplate.spec.ts
@@ -1,11 +1,31 @@
 import type { Store } from 'vuex'
 
-import { mount } from '@vue/test-utils'
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { shallowMount } from '@vue/test-utils'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
 import Vuex from 'vuex'
 import ContentTemplate from '../../../../src/components/ContentTemplate.vue'
+import { DISPLAY_MODE, SPLIT_MODE } from '../../../../src/enums/index.ts'
 import { ACTIONS, MUTATIONS } from '../../../../src/store/index.ts'
+
+vi.mock('@nextcloud/browser-storage', () => {
+	const builder = {
+		persist: vi.fn().mockReturnThis(),
+		build: vi.fn(() => ({
+			getItem: vi.fn(() => 'true'),
+			setItem: vi.fn(),
+			removeItem: vi.fn(),
+		})),
+	}
+
+	return {
+		getBuilder: vi.fn(() => builder),
+	}
+})
+
+vi.mock('@nextcloud/vue/composables/useIsMobile', () => ({
+	useIsMobile: () => false,
+}))
 
 describe('ContentTemplate.vue', () => {
 	'use strict'
@@ -65,6 +85,7 @@ describe('ContentTemplate.vue', () => {
 	})
 
 	beforeAll(() => {
+		HTMLElement.prototype.scrollTo = vi.fn()
 		HTMLElement.prototype.scrollIntoView = vi.fn()
 		HTMLElement.prototype.getBoundingClientRect = vi.fn(() => ({
 			width: 500,
@@ -77,6 +98,10 @@ describe('ContentTemplate.vue', () => {
 
 		store = new Vuex.Store({
 			state: {
+				app: {
+					displaymode: DISPLAY_MODE.DEFAULT,
+					splitmode: SPLIT_MODE.VERTICAL,
+				},
 				items: {
 					allItemsLoaded: {
 						unread: false,
@@ -95,60 +120,187 @@ describe('ContentTemplate.vue', () => {
 			getters: {
 				feeds: () => [mockFeed],
 				selected: () => store.state.items.allItems.find((item: FeedItem) => item.id === selectedId.value),
+				splitmode: (state) => state.app.splitmode,
+				displaymode: (state) => state.app.displaymode,
 			},
 		})
 		store.commit = commitStub
 		store.dispatch = dispatchStub
 	})
 
-	beforeEach(() => {
-		wrapper = mount(ContentTemplate, {
-			attachTo: document.body,
-			props: {
-				items: [mockItem1, mockItem2, mockItem3, mockItem4],
-				fetchKey: 'unread',
-			},
-			global: {
-				plugins: [store],
-			},
+	describe('item selection methods', () => {
+		beforeEach(() => {
+			wrapper = shallowMount(ContentTemplate, {
+				props: {
+					items: [mockItem1, mockItem2, mockItem3, mockItem4],
+					fetchKey: 'unread',
+				},
+				global: {
+					plugins: [store],
+				},
+			})
 		})
-		vi.clearAllMocks()
+
+		it('should set selected item id and call mark read if unread', async () => {
+			expect(wrapper.vm.selectedFeedItem).toEqual(undefined)
+			wrapper.vm.selectItem(mockItem1)
+			expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id, key: 'unread' })
+			expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem1 })
+			expect(wrapper.vm.selectedFeedItem).toEqual(mockItem1)
+		})
+
+		it('should set selected item id and do not call mark read if read', async () => {
+			mockItem1.unread = false
+			expect(wrapper.vm.selectedFeedItem).toEqual(undefined)
+			wrapper.vm.selectItem(mockItem1)
+			expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id, key: 'unread' })
+			expect(store.dispatch).not.toHaveBeenCalled()
+			expect(wrapper.vm.selectedFeedItem).toEqual(mockItem1)
+		})
+
+		it('should select previous item', () => {
+			wrapper.vm.selectItem(mockItem2)
+			expect(wrapper.vm.selectedFeedItem).toEqual(mockItem2)
+			wrapper.vm.previousItem()
+			expect(wrapper.vm.selectedFeedItem).toEqual(mockItem1)
+		})
+
+		it('should select next item', () => {
+			wrapper.vm.selectItem(mockItem2)
+			expect(wrapper.vm.selectedFeedItem).toEqual(mockItem2)
+			wrapper.vm.nextItem()
+			expect(wrapper.vm.selectedFeedItem).toEqual(mockItem3)
+		})
+
+		it('should select first item', () => {
+			expect(wrapper.vm.selectedFeedItem).toEqual(undefined)
+			wrapper.vm.nextItem()
+			expect(wrapper.vm.selectedFeedItem).toEqual(mockItem1)
+		})
+
+		afterEach(() => {
+			wrapper?.unmount()
+			vi.clearAllMocks()
+		})
 	})
 
-	it('should set selected item id and call mark read if unread', async () => {
-		expect(wrapper.vm.selectedFeedItem).toEqual(undefined)
-		wrapper.vm.selectItem(mockItem1)
-		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id, key: 'unread' })
-		expect(store.dispatch).toBeCalledWith(ACTIONS.MARK_READ, { item: mockItem1 })
-		expect(wrapper.vm.selectedFeedItem).toEqual(mockItem1)
+	describe('initial item auto-selection', () => {
+		beforeEach(() => {
+			vi.clearAllMocks()
+		})
+
+		it('should auto select first item with SPLIT_MODE.OFF and showDetails is set', async () => {
+			store.state.app.splitmode = SPLIT_MODE.OFF
+			store.state.items.fetchingItems.item = false
+			wrapper = shallowMount(ContentTemplate, {
+				props: {
+					items: [mockItem1, mockItem2, mockItem3, mockItem4],
+					fetchKey: 'unread',
+				},
+				global: {
+					plugins: [store],
+				},
+			})
+			wrapper.vm.showDetails = true
+			wrapper.vm.initialSelection = true
+
+			await nextTick()
+
+			expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id, key: 'unread' })
+			expect(wrapper.vm.initialSelection).toBe(false)
+		})
+
+		it('should not auto select when fetchingItems is true', async () => {
+			store.state.app.splitmode = SPLIT_MODE.OFF
+			store.state.items.fetchingItems.unread = true
+			wrapper = shallowMount(ContentTemplate, {
+				props: {
+					items: [mockItem1, mockItem2, mockItem3, mockItem4],
+					fetchKey: 'unread',
+				},
+				global: {
+					plugins: [store],
+				},
+			})
+
+			wrapper.vm.showDetails = true
+			wrapper.vm.initialSelection = true
+
+			await nextTick()
+
+			expect(store.commit).not.toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id, key: 'unread' })
+			expect(wrapper.vm.initialSelection).toBe(true)
+		})
+
+		it('should select first item when fetchKey is item', async () => {
+			store.state.app.splitmode = SPLIT_MODE.VERTICAL
+			store.state.items.fetchingItems.item = false
+			wrapper = shallowMount(ContentTemplate, {
+				props: {
+					items: [mockItem1],
+					fetchKey: 'item',
+				},
+				global: {
+					plugins: [store],
+				},
+			})
+
+			wrapper.vm.showDetails = false
+			wrapper.vm.initialSelection = true
+			store.state.items.fetchingItems.item = false
+
+			await wrapper.vm.$nextTick()
+
+			expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id, key: 'item' })
+		})
+
+		afterEach(() => {
+			wrapper?.unmount()
+			vi.clearAllMocks()
+		})
 	})
 
-	it('should set selected item id and do not call mark read if read', async () => {
-		mockItem1.unread = false
-		expect(wrapper.vm.selectedFeedItem).toEqual(undefined)
-		wrapper.vm.selectItem(mockItem1)
-		expect(store.commit).toBeCalledWith(MUTATIONS.SET_SELECTED_ITEM, { id: mockItem1.id, key: 'unread' })
-		expect(store.dispatch).not.toHaveBeenCalled()
-		expect(wrapper.vm.selectedFeedItem).toEqual(mockItem1)
-	})
+	describe('displayMode watcher', () => {
+		beforeEach(() => {
+			wrapper = shallowMount(ContentTemplate, {
+				props: {
+					items: [mockItem1, mockItem2, mockItem3, mockItem4],
+					fetchKey: 'unread',
+				},
+				global: {
+					plugins: [store],
+				},
+			})
+		})
 
-	it('should select previous item', () => {
-		wrapper.vm.selectItem(mockItem2)
-		expect(wrapper.vm.selectedFeedItem).toEqual(mockItem2)
-		wrapper.vm.previousItem()
-		expect(wrapper.vm.selectedFeedItem).toEqual(mockItem1)
-	})
+		it('should enable page hotkeys when display mode is SCREENREADER', async () => {
+			store.state.app.displaymode = DISPLAY_MODE.SCREENREADER
 
-	it('should select next item', () => {
-		wrapper.vm.selectItem(mockItem2)
-		expect(wrapper.vm.selectedFeedItem).toEqual(mockItem2)
-		wrapper.vm.nextItem()
-		expect(wrapper.vm.selectedFeedItem).toEqual(mockItem3)
-	})
+			await nextTick()
 
-	it('should select first item', () => {
-		expect(wrapper.vm.selectedFeedItem).toEqual(undefined)
-		wrapper.vm.nextItem()
-		expect(wrapper.vm.selectedFeedItem).toEqual(mockItem1)
+			expect(wrapper.vm.stopPageUpHotkey).not.toBe(null)
+			expect(wrapper.vm.stopPageDownHotkey).not.toBe(null)
+		})
+
+		it('should disable page hotkeys when display mode is not SCREENREADER', async () => {
+			store.state.app.displaymode = DISPLAY_MODE.DEFAULT
+			await nextTick()
+
+			expect(wrapper.vm.stopPageUpHotkey).toBe(null)
+			expect(wrapper.vm.stopPageDownHotkey).toBe(null)
+		})
+
+		it('should set showDetails to false when switching display mode', async () => {
+			wrapper.vm.showDetails = true
+			store.state.app.displaymode = DISPLAY_MODE.COMPACT
+			await nextTick()
+
+			expect(wrapper.vm.showDetails).toBe(false)
+		})
+
+		afterEach(() => {
+			wrapper?.unmount()
+			vi.clearAllMocks()
+		})
 	})
 })


### PR DESCRIPTION
## Summary

This PR adds automatically select the referenced item when using item route, for example from global search or from notification.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
