### PR TITLE
Fix #3587: Handle OPML files with leading blank lines

### DIFF
--- a/lib/Utility/OPMLImporter.php
+++ b/lib/Utility/OPMLImporter.php
@@ -40,6 +40,9 @@ class OPMLImporter
         $this->folders = [];
         $this->userId = $userId;
 
+        // Strip leading whitespace to handle OPML files with blank first lines
+        $data = ltrim($data);
+
         $document = new DOMDocument('1.0', 'UTF-8');
         $loaded = $document->loadXML($data);
         if ($loaded === false) {

--- a/tests/Unit/Utility/OPMLImporterTest.php
+++ b/tests/Unit/Utility/OPMLImporterTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace OCA\News\Tests\Unit\Utility;
+
+use OCA\News\Utility\OPMLImporter;
+
+use PHPUnit\Framework\TestCase;
+
+class OPMLImporterTest extends TestCase
+{
+    private OPMLImporter $importer;
+
+    protected function setUp(): void
+    {
+        $this->importer = new OPMLImporter();
+    }
+
+    public function testImportWithLeadingBlankLine(): void
+    {
+        $userId = 'test-user';
+
+        // OPML content with a leading blank line (from tt-rss)
+        $opmlWithBlankLine = '
+<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+  <head>
+    <title>Subscriptions</title>
+  </head>
+  <body>
+    <outline text="Test Folder" title="Test Folder">
+      <outline type="rss" text="Test Feed" title="Test Feed" htmlUrl="http://example.com/feed" xmlUrl="http://example.com/rss"/>
+    </outline>
+  </body>
+</opml>
+';
+
+        $result = $this->importer->import($userId, $opmlWithBlankLine);
+
+        // Should successfully parse the OPML despite leading whitespace
+        $this->assertNotNull($result);
+        $this->assertCount(1, $result[0], 'Should have 1 folder');
+        $this->assertCount(1, $result[1], 'Should have 1 feed');
+
+        $folder = $result[0][0];
+        $feed = $result[1][0];
+
+        $this->assertEquals('Test Folder', $folder['name']);
+        $this->assertEquals('Test Feed', $feed['title']);
+        $this->assertEquals('http://example.com/rss', $feed['url']);
+        $this->assertEquals('http://example.com/feed', $feed['link']);
+    }
+
+    public function testImportWithoutLeadingBlankLine(): void
+    {
+        $userId = 'test-user';
+
+        // Normal OPML content without leading whitespace
+        $opmlNormal = '<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+  <head>
+    <title>Subscriptions</title>
+  </head>
+  <body>
+    <outline type="rss" text="Normal Feed" title="Normal Feed" htmlUrl="http://example.org/feed" xmlUrl="http://example.org/rss"/>
+  </body>
+</opml>
+';
+
+        $result = $this->importer->import($userId, $opmlNormal);
+
+        $this->assertNotNull($result);
+        $this->assertCount(1, $result[1], 'Should have 1 feed');
+
+        $feed = $result[1][0];
+        $this->assertEquals('Normal Feed', $feed['title']);
+    }
+
+    public function testImportWithMultipleLeadingBlankLines(): void
+    {
+        $userId = 'test-user';
+
+        // OPML content with multiple leading blank lines and spaces
+        $opmlMultipleBlanks = '
+
+
+<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+  <head>
+    <title>Subscriptions</title>
+  </head>
+  <body>
+    <outline type="rss" text="Test Feed" title="Test Feed" htmlUrl="http://example.com/feed" xmlUrl="http://example.com/rss"/>
+  </body>
+</opml>
+';
+
+        $result = $this->importer->import($userId, $opmlMultipleBlanks);
+
+        $this->assertNotNull($result, 'Should handle multiple leading blank lines');
+        $this->assertCount(1, $result[1]);
+    }
+}


### PR DESCRIPTION
Fixes #3587

## Summary

Fixed OPML import failures when files contain leading blank lines or whitespace. This commonly occurs with OPML exports from tt-rss.

## Problem

tt-rss exports OPML files with a leading blank line before the XML declaration, which causes `DOMDocument::loadXML()` to fail with:

```
XML declaration allowed only at the start of the document in Entity, line: 2
```

## Solution

Strip leading whitespace from the OPML content before passing it to `DOMDocument::loadXML()` using PHP's `ltrim()` function.

## Changes

- Added `$data = ltrim($data);` in `OPMLImporter->import()` before XML parsing
- Added comprehensive test suite in `OPMLImporterTest.php` with 3 test cases:
  - OPML with single leading blank line
  - Normal OPML without leading blank lines (regression test)
  - OPML with multiple leading blank lines

## Testing

Created `tests/Unit/Utility/OPMLImporterTest.php` with full test coverage for the whitespace stripping functionality.
