### PR TITLE
Release 28.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 
 ### Fixed
-- Handle OPML files with leading blank lines (#3587)
-- Sanitize media descriptions to prevent potentially malicious HTML from untrusted feed content (#3588)
+
 
 # Releases
+## [28.0.1] - 2026-03-11
+### Fixed
+- Handle OPML files with leading blank lines (#3596)
+- Sanitize media descriptions to prevent potentially malicious HTML from untrusted feed content (#3606)
+
 ## [28.0.0] - 2026-03-03
 ### Fixed
 - Automatically select item when using single item route (#3577)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>28.0.0</version>
+    <version>28.0.1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION



* Resolves: # <!-- related github issue -->

## Summary

### Fixed
- Handle OPML files with leading blank lines (#3596)
- Sanitize media descriptions to prevent potentially malicious HTML from untrusted feed content (#3606)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
