### PR TITLE
fix docs of Explore Service

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -51,7 +51,7 @@ If you are using the News app in your company/community, it might be interesting
 
 The URL should be a path to a directory which contains a JSON file in the format of **feeds.LANG_CODE.json** where LANG_CODE is a two character language code (e.g. **en** or **de**).
 
-For example, entering the URL **<https://domain.com/directory>** as explore URL will produce the following request for German users:
+For example, entering the URL **<https://domain.com/directory/>** as explore URL will produce the following request for German users:
 
     GET https://domain.com/directory/feeds.de.json
 


### PR DESCRIPTION
* Resolves: no related issue

## Summary

If you look [at line 82 in Explore.vue 	](https://github.com/nextcloud/news/blob/f2868e2b681264078e9b41e5f0c724098b748a46/src/components/routes/Explore.vue#L82)
```js
const exploreUrl = loadState('news', 'exploreUrl') + 'feeds.en.json'
```
you see that the explore link just gets concatenated with the "feeds.en.json" string. If the URL doesn't end with a "/" it won't be able to request the file in the path, it will concatenate the pathname and the filename.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
