### PR TITLE
Refactor full text scraper to use guzzle http client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 # Unreleased
 ### Changed
+- Refactor full text scraper to use guzzle http client and its admin settings `Maximum redirects` and `Feed fetcher timeout`
 
 ### Fixed
+- Some feeds are no longer being updated because the job is terminating due to incorrect encoding handling in the full text scraper
 
 
 # Releases

--- a/lib/Scraper/Scraper.php
+++ b/lib/Scraper/Scraper.php
@@ -23,8 +23,11 @@ class Scraper implements IScraper
     private $logger;
     private $config;
     private $readability;
-    private $curl_opts;
+    private $httpClient;
     private $fetcherConfig;
+
+    // Cached list of supported mbstring encodings
+    private static $supportedEncodingList = null;
 
     public function __construct(LoggerInterface $logger, FetcherConfig $fetcherConfig)
     {
@@ -35,70 +38,88 @@ class Scraper implements IScraper
             'SummonCthulhu' => true, // Remove <script>
         ]);
         $this->readability = null;
+        $httpClientConfig = [
+            'allow_redirects' => [
+                'referer'         => true,
+                'track_redirects' => true,
+            ],
+        ];
+        $this->httpClient = $this->fetcherConfig->getHttpClient($httpClientConfig);
 
-        $this->curl_opts = array(
-            CURLOPT_RETURNTRANSFER => true,     // return web page
-            CURLOPT_HEADER         => false,    // do not return headers
-            CURLOPT_FOLLOWLOCATION => true,     // follow redirects
-            CURLOPT_USERAGENT      => $this->fetcherConfig->getUserAgent(), // who am i
-            CURLOPT_AUTOREFERER    => true,     // set referer on redirect
-            CURLOPT_CONNECTTIMEOUT => 120,      // timeout on connect
-            CURLOPT_TIMEOUT        => 120,      // timeout on response
-            CURLOPT_MAXREDIRS      => 10,       // stop after 10 redirects
-        );
-
-        $proxy = $this->fetcherConfig->getProxy();
-        if (!is_null($proxy) && $proxy !== '') {
-            $this->curl_opts[CURLOPT_PROXY] = $proxy;
+        if (self::$supportedEncodingList === null) {
+            self::$supportedEncodingList = mb_list_encodings();
         }
     }
 
     private function getHTTPContent(string $url): array
     {
-        $handler = curl_init($url);
-        curl_setopt_array($handler, $this->curl_opts);
-        $content = curl_exec($handler);
-        $header  = curl_getinfo($handler);
-        curl_close($handler);
+        $effectiveUrl = $url;
+        try {
+            $response = $this->httpClient->request('GET', $url, [
+                'on_stats' => function ($stats) use (&$effectiveUrl) {
+                    $effectiveUrl = (string) $stats->getEffectiveUri();
+                }
+            ]);
 
-        $charset = null;
-        // check if charset is set in http header
-        if (isset($header['content_type']) &&
-            preg_match('/charset\s*=\s*"?([\w\-]+)"?/i', $header['content_type'], $m)) {
-            $charset = strtoupper($m[1]);
-        }
-        // search content for meta tag with charset
-        if ($charset === null &&
-            preg_match('/<meta[^>]+charset\s*=\s*["\']?([\w\-]+)["\']?[^>]+>/i', $content, $m)) {
-            $charset = strtoupper($m[1]);
-        }
-        // try to detect encoding
-        if ($charset === null) {
-            $encodingList = ['UTF-8', 'ISO-8859-1', 'Windows-1252', 'ASCII', 'UTF-16', 'UTF-16BE', 'UTF-16LE'];
-            $charset = mb_detect_encoding($content, $encodingList, true);
-        }
-        // convert to utf-8 if necessary
-        if ($charset !== null && $charset !== 'UTF-8') {
-            $convertedContent = mb_convert_encoding($content, 'UTF-8', $charset);
-            if ($convertedContent !== false) {
-                $content = $convertedContent;
-            } else {
-                $this->logger->warning(
-                    'Failed to convert encoding from {from} to UTF-8 for feed item',
-                    ['from' => $charset]
-                );
+            $content = $response->getBody()->getContents();
+            $contentType = $response->getHeaderLine('Content-Type');
+
+            $charset = null;
+            // check if charset is set in http header
+            if ($contentType &&
+                preg_match('/charset\s*=\s*"?([\w\-]+)"?/i', $contentType, $m)) {
+                $charset = strtoupper($m[1]);
             }
-        }
+            // search content for meta tag with charset
+            if ($charset === null &&
+                preg_match('/<meta[^>]+charset\s*=\s*["\']?([\w\-]+)["\']?[^>]+>/i', $content, $m)) {
+                $charset = strtoupper($m[1]);
+            }
+            // invalidate unsupported charsets to get the chance that a supported alias is detected
+            if ($charset !== null &&
+                !in_array($charset, self::$supportedEncodingList, true)) {
+                $this->logger->debug(
+                    'Ignoring unsupported charset {charset} from full text feed item',
+                    ['charset' => $charset]
+                );
+                $charset = null;
+            }
+            // try to detect encoding
+            if ($charset === null) {
+                $encodingList = ['UTF-8', 'ISO-8859-1', 'Windows-1252', 'ASCII', 'UTF-16', 'UTF-16BE', 'UTF-16LE'];
+                $charset = mb_detect_encoding($content, $encodingList, true);
+                if ($charset === false) {
+                    $charset = null;
+                }
+            }
+            // convert to utf-8 if necessary
+            if ($charset !== null && $charset !== 'UTF-8') {
+                $convertedContent = mb_convert_encoding($content, 'UTF-8', $charset);
+                if ($convertedContent !== false) {
+                    $content = $convertedContent;
+                } else {
+                    $this->logger->warning(
+                        'Failed to convert encoding from {from} to UTF-8 for full text feed item',
+                        ['from' => $charset]
+                    );
+                }
+            }
 
-        // Update the url after the redirects has been followed
-        $url = $header['url'];
-        return array($content, $header['url']);
+            // Update the url after the redirects has been followed
+            return array($content, $effectiveUrl);
+        } catch (\Throwable $e) {
+            $this->logger->debug('Error fetching {url} request returned {error}', [
+                'url' => $url,
+                'error' => $e->getMessage(),
+            ]);
+            return array(null, null);
+        }
     }
 
     public function scrape(string $url): bool
     {
         list($content, $redirected_url) = $this->getHTTPContent($url);
-        if ($content === false) {
+        if (is_null($content)) {
             $this->logger->error('Unable to receive content from {url}', [
                  'url' => $url,
             ]);

--- a/tests/Unit/Scraper/ScraperTest.php
+++ b/tests/Unit/Scraper/ScraperTest.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Nextcloud - News
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @copyright 2026 Nextcloud GmbH and Nextcloud contributors
+ */
+
+namespace OCA\News\Tests\Unit\Scraper;
+
+use PHPUnit\Framework\TestCase;
+use OCA\News\Scraper\Scraper;
+use OCA\News\Config\FetcherConfig;
+use Psr\Log\LoggerInterface;
+use Psr\Http\Message\ResponseInterface;
+use GuzzleHttp\Client;
+
+class ScraperTest extends TestCase
+{
+    private $logger;
+    private $fetcherConfig;
+    private $httpClient;
+    private $scraper;
+
+    protected function setUp(): void
+    {
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->httpClient = $this->getMockBuilder(Client::class)
+            ->getMock();
+
+        $this->fetcherConfig = $this->createMock(FetcherConfig::class);
+        $this->fetcherConfig->method('getHttpClient')
+            ->willReturn($this->httpClient);
+
+        $this->scraper = new Scraper($this->logger, $this->fetcherConfig);
+    }
+
+    public function testScrapeReturnsTrueAndSetsContent(): void
+    {
+        $body = $this->createMock(\Psr\Http\Message\StreamInterface::class);
+        $body->method('getContents')->willReturn('<html><body>Scrape full text content</body></html>');
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getBody')->willReturn($body);
+
+        $this->httpClient->method('request')
+            ->willReturn($response);
+
+        $result = $this->scraper->scrape('https://example.com');
+
+        $this->assertTrue($result);
+        $content = $this->scraper->getContent();
+        $this->assertStringContainsString('Scrape full text content', $content);
+    }
+
+    public function testHttpClientThrowsException(): void
+    {
+        $this->httpClient->method('request')
+            ->will($this->throwException(new \Exception('Network error')));
+
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->stringContains('Unable to receive content')
+            );
+
+        $result = $this->scraper->scrape('https://example.com');
+
+        $this->assertFalse($result);
+        $content = $this->scraper->getContent();
+        $this->assertNull($content);
+    }
+
+    public function testConvertEncodingFromIsoToUtf8(): void
+    {
+        $expectedUtf8 = "Scrape full text content: äöüß ÄÖÜ ñ µ";
+        $isoString = mb_convert_encoding($expectedUtf8, 'ISO-8859-1', 'UTF-8');
+
+        $body = $this->createMock(\Psr\Http\Message\StreamInterface::class);
+        $body->method('getContents')->willReturn('<html><body>'.$isoString.'</body></html>');
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getBody')->willReturn($body);
+        $response->method('getHeaderLine')->willReturn('text/html; charset="ISO-8859-1"');
+
+        $this->httpClient->method('request')
+            ->willReturn($response);
+
+        $result = $this->scraper->scrape('https://example.com');
+
+        $this->assertTrue($result);
+        $content = $this->scraper->getContent();
+        $this->assertEquals('<div>'.$expectedUtf8.'</div>', $content);
+    }
+
+    public function testUnsupportedCharsetIsIgnored(): void
+    {
+        $body = $this->createMock(\Psr\Http\Message\StreamInterface::class);
+        $body->method('getContents')->willReturn('<html><body>Scrape full text content</body></html>');
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getBody')->willReturn($body);
+        $response->method('getHeaderLine')->willReturn('text/html; charset="invalid"');
+
+        $this->logger->expects($this->once())
+            ->method('debug')
+            ->with(
+                $this->stringContains('Ignoring unsupported charset')
+            );
+
+        $this->httpClient->method('request')
+            ->willReturn($response);
+
+        $result = $this->scraper->scrape('https://example.com');
+
+        $this->assertTrue($result);
+        $content = $this->scraper->getContent();
+        $this->assertStringContainsString('Scrape full text content', $content);
+    }
+
+    public function testReadabilityParseThrowsException(): void
+    {
+        $body = $this->createMock(\Psr\Http\Message\StreamInterface::class);
+        $body->method('getContents')->willReturn('Scrape invalid html content');
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getBody')->willReturn($body);
+
+        $this->httpClient->method('request')
+            ->willReturn($response);
+
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->stringContains('Unable to parse content')
+            );
+
+        $result = $this->scraper->scrape('https://example.com');
+
+        $this->assertTrue($result);
+        $content = $this->scraper->getContent();
+        $this->assertNull($content);
+    }
+}


### PR DESCRIPTION
* Resolves: #3627 

## Summary

This is one of a series of three pull requests aimed at improving the full-text download feature.

This PR migrates the scraper to use also the guzzle client, as the other fetchers used by the app.
This means that the news admin settings “Feed fetcher timeout” and “Max redirects” are now also used for these requests.

To address the encoding issue that came up today, I’ve added a check to filter out unsupported encodings at an early stage, so that they can possibly be replaced by a similar supported one from our list during the encoding detection.
Which would be in that case `Windows-1250` -> `Windows-1252`.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
