### PR TITLE
Limit full text scraper to download only new or updated articles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 # Unreleased
 ### Changed
 - Refactor full text scraper to use guzzle http client and its admin settings `Maximum redirects` and `Feed fetcher timeout`
+- Limit full text scraper to download only new or updated articles
 
 ### Fixed
 - Some feeds are no longer being updated because the job is terminating due to incorrect encoding handling in the full text scraper

--- a/lib/Db/FeedMapperV2.php
+++ b/lib/Db/FeedMapperV2.php
@@ -174,6 +174,30 @@ class FeedMapperV2 extends NewsMapperV2
     }
 
     /**
+     * @param int $id
+     *
+     * @return array
+     * @throws DBException
+     *
+     */
+    public function findItemGuidHashesByFeedId(int $id) : array
+    {
+        $guidHashBuilder = $this->db->getQueryBuilder();
+        $guidHashBuilder->select('items.guid_hash', 'items.pub_date')
+            ->from(ItemMapperV2::TABLE_NAME, 'items')
+            ->where('items.feed_id = :feedId')
+            ->setParameter('feedId', $id);
+
+        $guidHashList = [];
+        $rows = $this->db->executeQuery($guidHashBuilder->getSQL(), $guidHashBuilder->getParameters())->fetchAll();
+        foreach ($rows as $row) {
+            $guidHashList[$row['guid_hash']] = $row['pub_date'];
+        }
+
+        return $guidHashList;
+    }
+
+    /**
      * @param string   $userId
      * @param int      $id
      * @param int|null $maxItemID

--- a/lib/Fetcher/FeedFetcher.php
+++ b/lib/Fetcher/FeedFetcher.php
@@ -153,7 +153,8 @@ class FeedFetcher implements IFeedFetcher
         bool $fullTextEnabled,
         ?string $user,
         ?string $password,
-        ?string $httpLastModified
+        ?string $httpLastModified,
+        ?array $guidHashList
     ): array {
         $url2 = new Uri($url);
         if (!is_null($user) && trim($user) !== '') {
@@ -211,16 +212,48 @@ class FeedFetcher implements IFeedFetcher
             ]
         );
 
+        $feedTimestamp = $parsedFeed->getLastModified()?->getTimestamp();
         foreach ($parsedFeed as $item) {
             $body = null;
             $currRTL = $RTL;
 
-            // Scrape the content if full-text is enabled and if the feed provides a URL
-            if ($fullTextEnabled) {
+            // Scrape new content if full-text is enabled and if the feed provides a URL
+            if ($fullTextEnabled && isset($guidHashList)) {
+                $guidHash = md5($item->getPublicId());
+
+                // skip item if already exist and not updated
+                if (array_key_exists($guidHash, $guidHashList)) {
+                    // pubDate timestamp from DB/Item
+                    $oldPubDateTimestamp = $guidHashList[$guidHash];
+                    // pubDate/published timestamp from feed-io node/item interface
+                    $newPubDateTimestamp = $item->getLastModified()?->getTimestamp();
+
+                    // skip items with no valid pub date or when up to date
+                    if (is_null($newPubDateTimestamp) ||
+                        $newPubDateTimestamp === $feedTimestamp ||
+                        $oldPubDateTimestamp >= $newPubDateTimestamp) {
+                        $this->logger->debug(
+                            'Skipped fetching item {title} for feed {feed}, pub date not valid or item up to date',
+                            [
+                            'title' => $item->getTitle(),
+                            'feed'  => $feedName,
+                            ]
+                        );
+                        continue;
+                    }
+                }
                 $itemLink = $item->getLink();
                 if ($itemLink !== null && $this->scraper->scrape($itemLink)) {
                     $body = $this->scraper->getContent();
                     $currRTL = $this->scraper->getRTL($currRTL);
+                } else {
+                    $this->logger->debug(
+                        'Fetching full text item {title} for feed {feed} failed',
+                        [
+                        'title' => $item->getTitle(),
+                        'feed'  => $feedName,
+                        ]
+                    );
                 }
             }
 

--- a/lib/Fetcher/Fetcher.php
+++ b/lib/Fetcher/Fetcher.php
@@ -48,6 +48,7 @@ class Fetcher
      * @param  string|null $user              if given, basic auth is set for this feed
      * @param  string|null $password          if given, basic auth is set for this feed. Ignored if user is empty
      * @param  string|null $httpLastModified  if given, will be used when sending a request to servers
+     * @param  array|null  $guidHashList      if given, contains the list of known items for this feed
      *
      * @throws ReadErrorException if FeedIO fails
      * @return array an array containing the new feed and its items, first
@@ -58,7 +59,8 @@ class Fetcher
         bool $fullTextEnabled = false,
         ?string $user = null,
         ?string $password = null,
-        ?string $httpLastModified = null
+        ?string $httpLastModified = null,
+        ?array $guidHashList = null
     ): array {
         foreach ($this->fetchers as $fetcher) {
             if (!$fetcher->canHandle($url)) {
@@ -69,7 +71,8 @@ class Fetcher
                 $fullTextEnabled,
                 $user,
                 $password,
-                $httpLastModified
+                $httpLastModified,
+                $guidHashList
             );
         }
 

--- a/lib/Fetcher/IFeedFetcher.php
+++ b/lib/Fetcher/IFeedFetcher.php
@@ -28,6 +28,7 @@ interface IFeedFetcher
      * @param  string|null $user          if given, basic auth is set for this feed
      * @param  string|null $password      if given, basic auth is set for this feed. Ignored if user is empty
      * @param  string|null $httpLastModified if given, will be used when sending a request to servers
+     * @param  array|null  $guidHashList  if given, contains the list of known items for this feed
      *
      * @return array<Feed, Item[]> an array containing the new feed and its items, first
      * element being the Feed and second element being an array of Items
@@ -39,7 +40,8 @@ interface IFeedFetcher
         bool $fullTextEnabled,
         ?string $user,
         ?string $password,
-        ?string $httpLastModified
+        ?string $httpLastModified,
+        ?array $guidHashList
     ): array;
 
     /**

--- a/lib/Service/FeedServiceV2.php
+++ b/lib/Service/FeedServiceV2.php
@@ -224,7 +224,14 @@ class FeedServiceV2 extends Service
              * @var Feed   $feed
              * @var Item[] $items
              */
-            list($feed, $items) = $this->feedFetcher->fetch($feedUrl, $full_text, $user, $password, $httpLastModified);
+            list($feed, $items) = $this->feedFetcher->fetch(
+                $feedUrl,
+                $full_text,
+                $user,
+                $password,
+                $httpLastModified,
+                null
+            );
         } catch (ReadErrorException $ex) {
             $this->logger->debug($ex->getMessage());
             if ($full_discover === false) {
@@ -245,7 +252,8 @@ class FeedServiceV2 extends Service
                     $full_text,
                     $user,
                     $password,
-                    $httpLastModified
+                    $httpLastModified,
+                    null,
                 );
             } catch (ReadErrorException $ex) {
                 throw new ServiceNotFoundException($ex->getMessage());
@@ -322,6 +330,11 @@ class FeedServiceV2 extends Service
         // yet, if so use the url
         $location = $feed->getLocation() ?? $feed->getUrl();
 
+        $guidHashList = null;
+        if ($feed->getFullTextEnabled()) {
+            $guidHashList = $this->mapper->findItemGuidHashesByFeedId($feed->getId());
+        }
+
         try {
             /**
              * @var Feed   $feed
@@ -332,7 +345,8 @@ class FeedServiceV2 extends Service
                 $feed->getFullTextEnabled(),
                 $feed->getBasicAuthUser(),
                 $feed->getBasicAuthPassword(),
-                $feed->getHttpLastModified()
+                $feed->getHttpLastModified(),
+                $guidHashList
             );
         } catch (ReadErrorException | NoAccurateParserException $ex) {
             $feed->setUpdateErrorCount($feed->getUpdateErrorCount() + 1);

--- a/tests/Unit/Fetcher/FeedFetcherTest.php
+++ b/tests/Unit/Fetcher/FeedFetcherTest.php
@@ -145,6 +145,7 @@ class FeedFetcherTest extends TestCase
     private $updated;
     private $body;
     private $parsed_body;
+    private $fulltext_body;
     /**
      * @var Author
      */
@@ -237,6 +238,8 @@ class FeedFetcherTest extends TestCase
             = '<![CDATA[let the bodies hit the floor <a href="test">test</a>]]>';
         $this->parsed_body
             = 'let the bodies hit the floor <a href="test">test</a>';
+        $this->fulltext_body
+            = 'let the bodies hit the floor with full speed <a href="test">test</a>';
         $this->pub = 23111;
         $this->updated = 23444;
         $this->author = new Author();
@@ -277,7 +280,7 @@ class FeedFetcherTest extends TestCase
         $item = $this->createItem();
         $feed = $this->createFeed();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        $result = $this->fetcher->fetch($this->url, '0', false, null, null);
+        $result = $this->fetcher->fetch($this->url, '0', false, null, null, []);
 
         $this->assertEquals([$feed, [$item]], $result);
     }
@@ -329,7 +332,7 @@ class FeedFetcherTest extends TestCase
         $item = $this->createItem();
         $feed = $this->createFeed();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        $result = $this->fetcher->fetch($this->url, '0', false, null, null);
+        $result = $this->fetcher->fetch($this->url, '0', false, null, null, []);
 
         $this->assertEquals([$feed, [$item]], $result);
 
@@ -346,7 +349,7 @@ class FeedFetcherTest extends TestCase
         $item = $this->createItem();
         $feed = $this->createFeed();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        $result = $this->fetcher->fetch($this->url, false, null, null, null);
+        $result = $this->fetcher->fetch($this->url, false, null, null, null, []);
 
         $this->assertEquals([$feed, [$item]], $result);
     }
@@ -365,7 +368,8 @@ class FeedFetcherTest extends TestCase
             false,
             'account@email.com',
             'F9sEU*Rt%:KFK8HMHT&',
-            null
+            null,
+            []
         );
 
         $this->assertEquals([$feed, [$item]], $result);
@@ -380,7 +384,7 @@ class FeedFetcherTest extends TestCase
         $item = $this->createItem('audio/ogg');
         $feed = $this->createFeed();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        $result = $this->fetcher->fetch($this->url, false, null, null, null);
+        $result = $this->fetcher->fetch($this->url, false, null, null, null, []);
 
         $this->assertEquals([$feed, [$item]], $result);
     }
@@ -394,7 +398,7 @@ class FeedFetcherTest extends TestCase
         $item = $this->createItem('video/ogg');
         $feed = $this->createFeed();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        $result = $this->fetcher->fetch($this->url, false, null, null, null);
+        $result = $this->fetcher->fetch($this->url, false, null, null, null, []);
 
         $this->assertEquals([$feed, [$item]], $result);
     }
@@ -409,7 +413,7 @@ class FeedFetcherTest extends TestCase
         $feed = $this->createFeed('de-DE');
         $item = $this->createItem();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        $result = $this->fetcher->fetch($this->url, false, null, null, null);
+        $result = $this->fetcher->fetch($this->url, false, null, null, null, []);
 
         $this->assertEquals([$feed, [$item]], $result);
     }
@@ -423,7 +427,7 @@ class FeedFetcherTest extends TestCase
         $this->createFeed('he-IL');
         $this->createItem();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        list($_, $items) = $this->fetcher->fetch($this->url, false, null, null, null);
+        list($_, $items) = $this->fetcher->fetch($this->url, false, null, null, null, []);
         $this->assertTrue($items[0]->getRtl());
     }
 
@@ -449,7 +453,7 @@ class FeedFetcherTest extends TestCase
 
 
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        list($feed, $items) = $this->fetcher->fetch($this->url, false, null, null, null);
+        list($feed, $items) = $this->fetcher->fetch($this->url, false, null, null, null, []);
         $this->assertSame($items[0]->getPubDate(), 1522180229);
     }
 
@@ -475,7 +479,7 @@ class FeedFetcherTest extends TestCase
 
 
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        list($feed, $items) = $this->fetcher->fetch($this->url, false, null, null, null);
+        list($feed, $items) = $this->fetcher->fetch($this->url, false, null, null, null, []);
         $this->assertSame($items[0]->getPubDate(), 1519761029);
     }
 
@@ -488,7 +492,7 @@ class FeedFetcherTest extends TestCase
         $this->createItem();
         $feed = $this->createFeed();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        $result = $this->fetcher->fetch($this->url, false, null, null. null, null);
+        $result = $this->fetcher->fetch($this->url, false, null, null, null, []);
         //Explicitly assert GUID value
         $this->assertEquals(2, count($result));
         $this->assertEquals(1, count($result[1]));
@@ -506,13 +510,112 @@ class FeedFetcherTest extends TestCase
         $this->createItem();
         $feed = $this->createFeed();
         $this->mockIterator($this->feed_mock, [$this->item_mock]);
-        $result = $this->fetcher->fetch($this->url, false, null, null, null);
+        $result = $this->fetcher->fetch($this->url, false, null, null, null, []);
         //Explicitly assert GUID value
         $this->assertEquals(2, count($result));
         $this->assertEquals(1, count($result[1]));
         $resultItem = $result[1][0];
         $this->assertEquals($this->permalink, $resultItem->getGuid());
     }
+
+    /**
+     * Test if the fetch function don't scrape the fulltext body if item does exist.
+     */
+    public function testFetchFulltextWhenItemExists()
+    {
+        $this->setUpReader($this->url);
+        $this->scraper->expects($this->never())
+            ->method('scrape')
+            ->with($this->permalink);
+        $this->scraper->expects($this->never())
+            ->method('getContent');
+
+        $guidHashList = [];
+        $guidHashList[$this->guid_hash] = $this->modified->getTimestamp();
+
+        $item = $this->createFulltextItem(true, false);
+        $feed = $this->createFeed();
+
+        $this->mockIterator($this->feed_mock, [$this->item_mock]);
+
+        $result = $this->fetcher->fetch($this->url, true, null, null, null, $guidHashList);
+
+        $this->assertEquals([$feed, []], $result);
+    }
+
+    /**
+     * Test if the fetch function scrape the fulltext body if item does exist but has newer pub date.
+     */
+    public function testFetchFulltextWhenExistingItemIsUpdated()
+    {
+        $this->setUpReader($this->url);
+        $this->scraper->expects($this->once())
+            ->method('scrape')
+            ->with($this->permalink)
+            ->will($this->returnValue(true));
+        $this->scraper->expects($this->once())
+            ->method('getContent')
+            ->will($this->returnValue($this->fulltext_body));
+
+        $guidHashList[$this->guid_hash] = $this->modified->getTimestamp() - 1;
+
+        $item = $this->createFulltextItem(false, false);
+        $feed = $this->createFeed();
+
+        $this->mockIterator($this->feed_mock, [$this->item_mock]);
+
+        $result = $this->fetcher->fetch($this->url, true, null, null, null, $guidHashList);
+
+        $this->assertEquals([$feed, [$item]], $result);
+    }
+
+    /**
+     * Test if the fetch function scrape the fulltext body if item does not exist.
+     */
+    public function testFetchFulltextWhenItemIsNew()
+    {
+        $this->setUpReader($this->url);
+        $this->scraper->expects($this->once())
+            ->method('scrape')
+            ->with($this->permalink)
+            ->will($this->returnValue(true));
+        $this->scraper->expects($this->once())
+            ->method('getContent')
+            ->will($this->returnValue($this->fulltext_body));
+
+        $item = $this->createFulltextItem(false, false);
+        $feed = $this->createFeed();
+
+        $this->mockIterator($this->feed_mock, [$this->item_mock]);
+
+        $result = $this->fetcher->fetch($this->url, true, null, null, null, []);
+
+        $this->assertEquals([$feed, [$item]], $result);
+    }
+
+    /**
+     * Test if the fetch function returns the feed item if the fulltext body is invalid
+     */
+    public function testFetchWhenFetchedFulltextBodyIsInvalid()
+    {
+        $this->setUpReader($this->url);
+        $this->scraper->expects($this->once())
+            ->method('scrape')
+            ->with($this->permalink)
+            ->will($this->returnValue(false));
+        $this->scraper->expects($this->never())
+            ->method('getContent');
+
+        $item = $this->createFulltextItem(false, true);
+        $feed = $this->createFeed();
+
+        $this->mockIterator($this->feed_mock, [$this->item_mock]);
+
+        $result = $this->fetcher->fetch($this->url, true, null, null, null, []);
+
+        $this->assertEquals([$feed, [$item]], $result);
+    }
+
     /**
      * Mock an iteration option on an existing mock
      *
@@ -736,5 +839,56 @@ class FeedFetcherTest extends TestCase
 
 
         return $feed;
+    }
+
+    /**
+     * Create an fulltext item mock.
+     *
+     * @param bool   $itemExist
+     * @param bool   $itemInvalid
+     *
+     * @return Item
+     */
+    private function createFulltextItem(bool $itemExist, bool $itemInvalid)
+    {
+        $this->item_mock->expects($this->exactly($itemExist ? 0 : 2))
+            ->method('getLink')
+            ->will($this->returnValue($this->permalink));
+        $this->item_mock->expects($this->any())
+            ->method('getTitle')
+            ->will($this->returnValue($this->title));
+        $this->item_mock->expects($this->any())
+            ->method('getPublicId')
+            ->will($this->returnValue($this->guid));
+        $this->item_mock->expects($this->exactly($itemInvalid ? 1 : 0))
+            ->method('getContent')
+            ->will($this->returnValue($this->body));
+        $this->item_mock->expects($this->any())
+            ->method('getLastModified')
+            ->will($this->returnValue($this->modified));
+        $this->item_mock->expects($this->exactly($itemExist ? 0 : 1))
+            ->method('getAuthor')
+            ->will($this->returnValue($this->author));
+        $this->item_mock->expects($this->exactly($itemExist ? 0 : 1))
+            ->method('getCategories')
+            ->will($this->returnValue($this->categories));
+
+        $item = new Item();
+
+        $item->setUnread(true)
+            ->setUrl($this->permalink)
+            ->setTitle('my<\' title')
+            ->setGuid($this->guid)
+            ->setGuidHash($this->guid_hash)
+            ->setBody($itemInvalid ? $this->parsed_body : $this->fulltext_body)
+            ->setRtl(false)
+            ->setLastModified(3)
+            ->setPubDate(3)
+            ->setAuthor(html_entity_decode($this->author->getName()))
+            ->setCategoriesJson($this->categoriesJson);
+
+        $item->generateSearchIndex();
+
+        return $item;
     }
 }

--- a/tests/Unit/Service/FeedServiceTest.php
+++ b/tests/Unit/Service/FeedServiceTest.php
@@ -338,8 +338,8 @@ class FeedServiceTest extends TestCase
                        ->will($this->returnValue(['http://discover.test']));
 
         $expectedCalls = [
-            ['http://test', false, 'user', 'pass', null],
-            ['http://discover.test', false, 'user', 'pass', null]
+            ['http://test', false, 'user', 'pass', null, null],
+            ['http://discover.test', false, 'user', 'pass', null, null]
         ];
         $callIndex = 0;
 


### PR DESCRIPTION
* Resolves: #3319

## Summary

This is the second of a series of three pull requests to improve the full-text download feature.

The current implementation is unfair to content providers and gives the app a bad reputation as aggressive crawler.

Although the feed is only downloaded when necessary, depending on the settings, all referenced web pages are then downloaded again and again.

To prevent this, I have implemented a mechanism that ensures only new or updated content is downloaded, which also saves memory during the fetch.

This involves creating a list of known GUID hashes and their corresponding publication dates, which is used for comparison during the update job.
As some feeds do not have publication dates for the items and the current date is used in this case, these feed items are not updated  and only downloaded once.

Here some example debug output showing one hourly fetch during my tests, the heise feed would currently fetch 160 websites per hour

> heise online News added: 3, skipped: 157, error: 0
> Items: 3 Memory used: 4 MB

> tagesschau.de - Die Nachrichten der ARD added: 3, skipped: 37, error: 0                             
> Items: 3 Memory used: 1 MB

> taz.de - Artikel aus der Onlineausgabe added: 10, skipped: 10, error: 0
> Items: 10 Memory used: 1 MB

Another way to avoid downloading unnecessary articles is coming with the third PR, which I am currently still testing. It allows individual articles to be updated on demand from the frontend via the backend controller and it advantages (readability, sanitize, etc)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
