### PR TITLE
Add a feature to download the web version of an article on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 # Unreleased
 ### Changed
+- Added a feature to download the web version of an article on demand, to avoid downloading unnecessary content
 
 ### Fixed
 

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -52,6 +52,8 @@ return ['routes' => [
 
 // items
 ['name' => 'item#index', 'url' => '/items', 'verb' => 'GET'],
+['name' => 'item#body', 'url' => '/items/{itemId}/body', 'verb' => 'POST'],
+['name' => 'item#fulltext', 'url' => '/items/{itemId}/fulltext', 'verb' => 'GET'],
 ['name' => 'item#new_items', 'url' => '/items/new', 'verb' => 'GET'],
 ['name' => 'item#readAll', 'url' => '/items/read', 'verb' => 'POST'],
 ['name' => 'item#read', 'url' => '/items/{itemId}/read', 'verb' => 'POST'],

--- a/lib/Controller/ItemController.php
+++ b/lib/Controller/ItemController.php
@@ -332,4 +332,48 @@ class ItemController extends Controller
 
         return [];
     }
+
+    /**
+     * @param int $itemId              Item to fetch
+     *
+     * @return array|JSONResponse
+     */
+    #[NoAdminRequired]
+    public function fulltext(int $itemId)
+    {
+        $item = null;
+        try {
+            $item = $this->itemService->fetchFulltext($this->getUserId(), $itemId);
+        } catch (ServiceException $ex) {
+            return $this->error($ex, Http::STATUS_NOT_FOUND);
+        }
+
+        if ($item === null) {
+            return new JSONResponse([], Http::STATUS_NO_CONTENT);
+        }
+
+        return [$item];
+    }
+
+    /**
+     * @param int $itemId              Item to update
+     * @param string $body             New content
+     *
+     * @return array|JSONResponse
+     */
+    #[NoAdminRequired]
+    public function body(int $itemId, string $body)
+    {
+        try {
+            $this->itemService->updateBodyText(
+                $this->getUserId(),
+                $itemId,
+                $body
+            );
+        } catch (ServiceException $ex) {
+            return $this->error($ex, Http::STATUS_NOT_FOUND);
+        }
+
+        return [];
+    }
 }

--- a/lib/Service/ItemServiceV2.php
+++ b/lib/Service/ItemServiceV2.php
@@ -17,9 +17,11 @@ use OCA\News\Db\Feed;
 use OCA\News\Db\ListType;
 use OCA\News\Db\Item;
 use OCA\News\Db\ItemMapperV2;
+use OCA\News\Scraper\Scraper;
 use OCA\News\Service\Exceptions\ServiceConflictException;
 use OCA\News\Service\Exceptions\ServiceNotFoundException;
 use OCA\News\Service\Exceptions\ServiceValidationException;
+use OCA\News\Utility\HtmlSanitizer;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\Entity;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
@@ -40,11 +42,15 @@ class ItemServiceV2 extends Service
      * @param ItemMapperV2    $mapper
      * @param IAppConfig      $config
      * @param LoggerInterface $logger
+     * @param Scraper         $scraper
+     * @param HtmlSanitizer   $purifier
      */
     public function __construct(
         ItemMapperV2 $mapper,
         LoggerInterface $logger,
-        protected IAppConfig $config
+        protected IAppConfig $config,
+        protected Scraper $scraper,
+        protected HtmlSanitizer $purifier
     ) {
         parent::__construct($mapper, $logger);
     }
@@ -392,5 +398,54 @@ class ItemServiceV2 extends Service
         int $id = 0
     ): array {
         return $this->mapper->findAllItems($id, $userId, $type, $limit, $offset, $oldestFirst, $search);
+    }
+
+    /**
+     * Update item body with fetched content from item link
+     *
+     * @param string $userId
+     * @param int $id
+     *
+     * @return Entity|null
+     */
+    public function fetchFulltext(string $userId, int $id): Entity | null
+    {
+        /*
+         * limit execution time when fetching single item on demand
+         * to prevent a blocked request from running indefinitely
+         */
+        set_time_limit(6);
+
+        $body = null;
+        $item = $this->find($userId, $id);
+
+        $itemLink = $item->getUrl();
+        if ($itemLink !== null && $this->scraper->scrape($itemLink)) {
+            $body = $this->scraper->getContent();
+        }
+
+        if (is_null($body) || $body == '') {
+            return null;
+        }
+        $item->setBody($this->purifier->purify($body));
+
+        return $this->mapper->update($item);
+    }
+
+    /**
+     * Update item body with given content
+     *
+     * @param string $userId
+     * @param int $id
+     * @param string $body
+     *
+     * @return Entity
+     */
+    public function updateBodyText(string $userId, int $id, string $body): Entity
+    {
+        $item = $this->find($userId, $id);
+        $item->setBody($this->purifier->purify($body));
+
+        return $this->mapper->update($item);
     }
 }

--- a/src/components/feed-display/FeedItemDisplay.vue
+++ b/src/components/feed-display/FeedItemDisplay.vue
@@ -30,7 +30,25 @@
 			</NcActionButton>
 		</NcActions>
 		<div class="action-bar">
-			<NcActions :inline="4">
+			<NcActions :inline="5">
+				<NcActionButton
+					v-if="canUndoFulltext"
+					:title="t('news', 'Undo article text replace')"
+					@click="toggleFulltext">
+					{{ t('news', 'Undo article text replace') }}
+					<template #icon>
+						<UndoIcon />
+					</template>
+				</NcActionButton>
+				<NcActionButton
+					v-else-if="!feed.fullTextEnabled && !screenReaderMode"
+					:title="t('news', 'Download web version of this article')"
+					@click="toggleFulltext">
+					{{ t('news', 'Download web version of this article') }}
+					<template #icon>
+						<TextLongIcon />
+					</template>
+				</NcActionButton>
 				<NcActionButton
 					:title="t('news', 'Share within Instance')"
 					@click="showShareMenu = true">
@@ -201,6 +219,7 @@
 import type { Feed } from '../../types/Feed.ts'
 import type { FeedItem } from '../../types/FeedItem.ts'
 
+import { showError, showLoading } from '@nextcloud/dialogs'
 import { generateUrl } from '@nextcloud/router'
 import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
@@ -215,6 +234,8 @@ import EyeIcon from 'vue-material-design-icons/Eye.vue'
 import EyeCheckIcon from 'vue-material-design-icons/EyeCheck.vue'
 import ShareVariant from 'vue-material-design-icons/ShareVariant.vue'
 import StarIcon from 'vue-material-design-icons/Star.vue'
+import TextLongIcon from 'vue-material-design-icons/TextLong.vue'
+import UndoIcon from 'vue-material-design-icons/UndoVariant.vue'
 import ShareItem from '../ShareItem.vue'
 import { DISPLAY_MODE, ITEM_HEIGHT, MEDIA_TYPE, SHOW_MEDIA, SPLIT_MODE } from '../../enums/index.ts'
 import { ACTIONS, MUTATIONS } from '../../store/index.ts'
@@ -235,6 +256,8 @@ export default defineComponent({
 		ShareItem,
 		ChevronLeftIcon,
 		ChevronRightIcon,
+		TextLongIcon,
+		UndoIcon,
 	},
 
 	props: {
@@ -287,6 +310,9 @@ export default defineComponent({
 			showShareMenu: false,
 			allowEnclosureImage: false,
 			allowEnclosureThumbnail: false,
+			originalBody: null,
+			originalIntro: null,
+			isDownloading: null,
 		}
 	},
 
@@ -341,6 +367,10 @@ export default defineComponent({
 
 		mediaOptions() {
 			return this.$store.getters.mediaOptions
+		},
+
+		canUndoFulltext() {
+			return this.originalBody !== null
 		},
 
 		sanitizedBody() {
@@ -407,8 +437,11 @@ export default defineComponent({
 
 	created() {
 		// create shortcuts
-		if (this.splitModeOff && !this.screenReaderMode) {
-			useHotKey('Escape', this.closeDetails)
+		if (!this.screenReaderMode) {
+			useHotKey('x', this.toggleFulltext)
+			if (this.splitModeOff) {
+				useHotKey('Escape', this.closeDetails)
+			}
 		}
 	},
 
@@ -443,6 +476,40 @@ export default defineComponent({
 				this.$store.dispatch(ACTIONS.MARK_READ, { item: this.item })
 			} else {
 				this.$store.dispatch(ACTIONS.MARK_UNREAD, { item: this.item })
+			}
+		},
+
+		async fetchFulltext(): void {
+			this.isDownloading = showLoading(t('news', 'Downloading article text'))
+			try {
+				this.originalBody = this.item.body
+				this.originalIntro = this.item.intro
+				await this.$store.dispatch(ACTIONS.FETCH_FULLTEXT, { item: this.item })
+			} catch (error) {
+				// axios errors are handled global
+				showError(t('news', 'Downloading of the article text has failed: {errorMessage}', { errorMessage: error.message }))
+				this.originalBody = null
+				this.originalIntro = null
+			} finally {
+				this.isDownloading.hideToast()
+				this.isDownloading = null
+			}
+		},
+
+		async undoFulltext(): void {
+			await this.$store.dispatch(ACTIONS.UPDATE_BODY, { item: this.item, body: this.originalBody, intro: this.originalIntro })
+			this.originalBody = null
+			this.originalIntro = null
+		},
+
+		toggleFulltext() {
+			if (this.feed.fullTextEnabled || this.isDownloading) {
+				return
+			}
+			if (this.originalBody === null) {
+				this.fetchFulltext()
+			} else {
+				this.undoFulltext()
 			}
 		},
 

--- a/src/components/modals/AppSettingsDialog.vue
+++ b/src/components/modals/AppSettingsDialog.vue
@@ -204,6 +204,7 @@
 					</template>
 				</NcHotkey>
 				<NcHotkey :label="t('news', 'Toggle keep current article unread')" hotkey="U" />
+				<NcHotkey :label="t('news', 'Download web version of the selected article')" hotkey="X" />
 			</NcHotkeyList>
 			<NcHotkeyList :label="t('news', 'Feed/Folder navigation and control')">
 				<NcHotkey :label="t('news', 'Jump to previous feed')" hotkey="D" />

--- a/src/dataservices/item.service.ts
+++ b/src/dataservices/item.service.ts
@@ -154,4 +154,29 @@ export class ItemService {
 			isStarred: read,
 		})
 	}
+
+	/**
+	 * Makes backend call to fetch full-text content for item
+	 *
+	 * @param item FeedItem (containing id) for which the content is to be fetched
+	 * @return response object containing backend request response
+	 */
+	static async fetchFulltext(item: FeedItem): Promise<AxiosResponse> {
+		return await axios.get(API_ROUTES.ITEMS + `/${item.id}/fulltext`, {
+			timeout: 5000,
+		})
+	}
+
+	/**
+	 * Makes backend call to update item content
+	 *
+	 * @param itemId for which the content is to be updated
+	 * @param body content used for the update
+	 * @return response object containing backend request response
+	 */
+	static async updateBodyText(itemId: string, body: string): Promise<void> {
+		await axios.post(API_ROUTES.ITEMS + `/${itemId}/body`, {
+			body,
+		})
+	}
 }

--- a/src/store/item.ts
+++ b/src/store/item.ts
@@ -16,7 +16,9 @@ export const FEED_ITEM_ACTION_TYPES = {
 	UNSTAR_ITEM: 'UNSTAR_ITEM',
 	FETCH_FEED_ITEMS: 'FETCH_FEED_ITEMS',
 	FETCH_FOLDER_FEED_ITEMS: 'FETCH_FOLDER_FEED_ITEMS',
+	FETCH_FULLTEXT: 'FETCH_FULLTEXT',
 	FETCH_ITEMS: 'FETCH_ITEMS',
+	UPDATE_BODY: 'UPDATE_BODY',
 }
 
 export type ItemState = {
@@ -291,6 +293,35 @@ export const actions = {
 			commit(FEED_ITEM_MUTATION_TYPES.SET_LAST_ITEM_LOADED, { key: 'folder-' + folderId, lastItem })
 		}
 		commit(FEED_ITEM_MUTATION_TYPES.SET_FETCHING, { key: 'folder-' + folderId, fetching: false })
+	},
+
+	async [FEED_ITEM_ACTION_TYPES.FETCH_FULLTEXT](
+		{ commit }: ActionParams<ItemState>,
+		{ item }: { item: FeedItem },
+	) {
+		const response = await ItemService.fetchFulltext(item)
+		if (response?.status === 200) {
+			const newItem = response?.data[0]
+			if (newItem) {
+				commit(FEED_ITEM_MUTATION_TYPES.UPDATE_ITEM, { item: newItem })
+			} else {
+				throw new Error(t('news', 'Empty Response'))
+			}
+		} else {
+			const errorMessage = response.statusText
+			throw new Error(errorMessage)
+		}
+	},
+
+	async [FEED_ITEM_ACTION_TYPES.UPDATE_BODY](
+		{ commit }: ActionParams<ItemState>,
+		{ item, body, intro }: { item: FeedItem, body: string, intro: string },
+	) {
+		ItemService.updateBodyText(item.id, body)
+		item.body = body
+		item.intro = intro
+
+		commit(FEED_ITEM_MUTATION_TYPES.UPDATE_ITEM, { item })
 	},
 
 	/**

--- a/src/types/FeedItem.ts
+++ b/src/types/FeedItem.ts
@@ -8,4 +8,6 @@ export type FeedItem = {
 	pubDate: number
 	url: string
 	keepUnread: boolean
+	body: string
+	intro: string
 }

--- a/tests/Unit/Controller/ItemControllerTest.php
+++ b/tests/Unit/Controller/ItemControllerTest.php
@@ -653,4 +653,62 @@ class ItemControllerTest extends TestCase
         $response = $this->controller->newItems(ListType::FEED, 2, 3);
         $this->assertEquals([], $response);
     }
+
+
+    public function testFulltextSuccess()
+    {
+        $item = new Item();
+        $this->itemService->expects($this->once())
+            ->method('fetchFulltext')
+            ->with('user', 10)
+            ->willReturn($item);
+
+        $response = $this->controller->fulltext(10);
+        $this->assertEquals([$item], $response);
+    }
+
+
+    public function testFulltextNotFound()
+    {
+        $msg = 'not found';
+        $this->itemService->expects($this->once())
+            ->method('fetchFulltext')
+            ->with('user', 10)
+            ->will($this->throwException(new ServiceNotFoundException($msg)));
+
+        $response = $this->controller->fulltext(10);
+        $params = json_decode($response->render(), true);
+
+        $this->assertEquals(Http::STATUS_NOT_FOUND, $response->getStatus());
+        $this->assertEquals($msg, $params['message']);
+    }
+
+
+    public function testUpdateBodySuccess()
+    {
+        $item = new Item();
+        $this->itemService->expects($this->once())
+            ->method('updateBodyText')
+            ->with('user', 10, 'content')
+            ->willReturn($item);
+
+        $response = $this->controller->body(10, 'content');
+        $this->assertEquals([], $response);
+    }
+
+
+    public function testUpdateBodyNotFound()
+    {
+        $msg = 'not found';
+        $this->itemService->expects($this->once())
+            ->method('updateBodyText')
+            ->with('user', 10, 'content')
+            ->will($this->throwException(new ServiceNotFoundException($msg)));
+
+        $response = $this->controller->body(10, 'content');
+        $params = json_decode($response->render(), true);
+
+        $this->assertEquals(Http::STATUS_NOT_FOUND, $response->getStatus());
+        $this->assertEquals($msg, $params['message']);
+    }
 }

--- a/tests/Unit/Service/ItemServiceTest.php
+++ b/tests/Unit/Service/ItemServiceTest.php
@@ -14,6 +14,8 @@
 namespace OCA\News\Tests\Unit\Service;
 
 use OCA\News\Db\ItemMapperV2;
+use OCA\News\Scraper\Scraper;
+use OCA\News\Utility\HtmlSanitizer;
 use OCA\News\Service\Exceptions\ServiceConflictException;
 use OCA\News\Service\Exceptions\ServiceValidationException;
 use OCA\News\Service\Exceptions\ServiceNotFoundException;
@@ -55,6 +57,17 @@ class ItemServiceTest extends TestCase
      * @var MockObject|LoggerInterface
      */
     private $logger;
+
+    /**
+     * @var MockObject|Scraper
+     */
+    private $scraper;
+
+    /**
+     * @var MockObject|HtmlSanitizer
+     */
+    private $purifier;
+
     /**
      * @var int
      */
@@ -86,10 +99,20 @@ class ItemServiceTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->scraper = $this->getMockBuilder(Scraper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->purifier = $this->getMockBuilder(HtmlSanitizer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->class = new ItemServiceV2(
             $this->mapper,
             $this->logger,
-            $this->config
+            $this->config,
+            $this->scraper,
+            $this->purifier
         );
         $this->user = 'jack';
         $this->id = 3;
@@ -642,5 +665,140 @@ class ItemServiceTest extends TestCase
              ->with(5);
 
         $this->class->purgeOverThreshold(5);
+    }
+
+    public function testFetchFulltextSuccess()
+    {
+        $item = $this->getMockBuilder(Item::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $item->expects($this->once())
+             ->method('getUrl')
+             ->willReturn('http://example.com');
+
+        $this->mapper->expects($this->once())
+            ->method('findFromUser')
+            ->with('jack', 3)
+            ->willReturn($item);
+
+        $this->scraper->expects($this->once())
+            ->method('scrape')
+            ->with('http://example.com')
+            ->willReturn(true);
+
+        $htmlBody = '<p>content</p>';
+        $this->scraper->expects($this->once())
+            ->method('getContent')
+            ->willReturn($htmlBody);
+
+        $purifiedBody = 'content';
+        $this->purifier->expects($this->once())
+            ->method('purify')
+            ->with($htmlBody)
+            ->willReturn($purifiedBody);
+
+        $item->expects($this->once())
+            ->method('setBody')
+            ->with($purifiedBody);
+
+        $this->mapper->expects($this->once())
+            ->method('update')
+            ->with($item)
+            ->willReturn($item);
+
+        $result = $this->class->fetchFulltext('jack', 3);
+
+        $this->assertNotNull($result);
+    }
+
+    public function testFetchFulltextScrapeFails()
+    {
+        $item = $this->getMockBuilder(Item::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $item->expects($this->once())
+             ->method('getUrl')
+             ->will($this->returnValue('http://example.com'));
+
+        $this->mapper->expects($this->once())
+            ->method('findFromUser')
+            ->with('jack', 3)
+            ->will($this->returnValue($item));
+
+        $this->scraper->expects($this->once())
+            ->method('scrape')
+            ->with('http://example.com')
+            ->willReturn(false);
+
+        $this->mapper->expects($this->never())
+            ->method('update');
+
+        $result = $this->class->fetchFulltext('jack', 3);
+
+        $this->assertNull($result);
+    }
+
+    public function testFetchFulltextEmptyContent()
+    {
+        $item = $this->getMockBuilder(Item::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $item->expects($this->once())
+             ->method('getUrl')
+             ->will($this->returnValue('http://example.com'));
+
+        $this->mapper->expects($this->once())
+            ->method('findFromUser')
+            ->with('jack', 3)
+            ->will($this->returnValue($item));
+
+        $this->scraper->expects($this->once())
+            ->method('scrape')
+            ->with('http://example.com')
+            ->willReturn(true);
+
+        $this->scraper->expects($this->once())
+            ->method('getContent')
+            ->willReturn('');
+
+        $this->mapper->expects($this->never())
+            ->method('update');
+
+        $result = $this->class->fetchFulltext('jack', 3);
+
+        $this->assertNull($result);
+    }
+
+    public function testUpdateBody()
+    {
+        $item = $this->getMockBuilder(Item::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mapper->expects($this->once())
+            ->method('findFromUser')
+            ->with('jack', 3)
+            ->will($this->returnValue($item));
+
+        $body = 'content';
+        $this->purifier->expects($this->once())
+            ->method('purify')
+            ->with($body)
+            ->willReturn($body);
+
+        $item->expects($this->once())
+            ->method('setBody')
+            ->with($body);
+
+        $this->mapper->expects($this->once())
+            ->method('update')
+            ->willReturn($item);
+
+        $result = $this->class->updateBodyText('jack', 3, 'content');
+
+        $this->assertNotNull($result);
     }
 }

--- a/tests/javascript/unit/components/feed-display/FeedItemDisplay.spec.ts
+++ b/tests/javascript/unit/components/feed-display/FeedItemDisplay.spec.ts
@@ -1,9 +1,17 @@
+import { showError } from '@nextcloud/dialogs'
 import { shallowMount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, reactive } from 'vue'
 import FeedItemDisplay from '../../../../../src/components/feed-display/FeedItemDisplay.vue'
 import { MEDIA_TYPE, SHOW_MEDIA } from '../../../../../src/enums/index.ts'
 import { ACTIONS, MUTATIONS } from '../../../../../src/store/index.ts'
+
+vi.mock('@nextcloud/dialogs', () => ({
+	showError: vi.fn(),
+	showLoading: vi.fn(() => ({
+		hideToast: vi.fn(),
+	})),
+}))
 
 describe('FeedItemDisplay.vue', () => {
 	'use strict'
@@ -14,6 +22,8 @@ describe('FeedItemDisplay.vue', () => {
 		feedId: 1,
 		title: 'feed item',
 		pubDate: Date.now() / 1000,
+		body: '<p>content</p>',
+		intro: 'content',
 	}
 	const mockFeeds = [
 		{
@@ -387,6 +397,85 @@ describe('FeedItemDisplay.vue', () => {
 
 		expect(wrapper.find('.enclosure.thumbnail').exists()).toBe(false)
 		expect(wrapper.find('.consent-button').exists()).toBe(false)
+	})
+
+	it('fetchFulltext successfully scraped website content', async () => {
+		await wrapper.vm.fetchFulltext()
+
+		expect(dispatchStub).toHaveBeenCalledWith(ACTIONS.FETCH_FULLTEXT, {
+			item: wrapper.vm.item,
+		})
+
+		expect(wrapper.vm.originalBody).toBe('<p>content</p>')
+		expect(wrapper.vm.originalIntro).toBe('content')
+		expect(wrapper.vm.isDownloading).toBeNull()
+	})
+
+	it('fetchFulltext shows error toast', async () => {
+		const error = new Error('Download error')
+		dispatchStub.mockRejectedValue(error)
+
+		await wrapper.vm.fetchFulltext()
+
+		expect(showError).toHaveBeenCalled()
+		expect(wrapper.vm.originalBody).toBeNull()
+		expect(wrapper.vm.originalIntro).toBeNull()
+		expect(wrapper.vm.isDownloading).toBeNull()
+	})
+
+	it('canUndoFulltext returns true if originalBody is set', async () => {
+		wrapper.vm.originalBody = 'original body'
+
+		const canUndo = wrapper.vm.$options.computed?.canUndoFulltext.call(wrapper.vm)
+		expect(canUndo).toBeTruthy()
+	})
+
+	it('undoFulltext restores original values', async () => {
+		wrapper.vm.originalBody = 'original body'
+		wrapper.vm.originalIntro = 'original intro'
+
+		await wrapper.vm.undoFulltext()
+
+		expect(dispatchStub).toHaveBeenCalledWith(ACTIONS.UPDATE_BODY, {
+			item: wrapper.vm.item,
+			body: 'original body',
+			intro: 'original intro',
+		})
+
+		expect(wrapper.vm.originalBody).toBeNull()
+		expect(wrapper.vm.originalIntro).toBeNull()
+	})
+
+	it('toggleFulltext calls fetchFulltext when originalBody is not set', async () => {
+		const spy = vi.spyOn(wrapper.vm, 'fetchFulltext')
+
+		wrapper.vm.originalBody = null
+		wrapper.vm.isDownloading = null
+
+		wrapper.vm.toggleFulltext()
+
+		expect(spy).toHaveBeenCalled()
+	})
+
+	it('toggleFulltext calls undoFulltext when originalBody exists', async () => {
+		const spy = vi.spyOn(wrapper.vm, 'undoFulltext')
+
+		wrapper.vm.originalBody = 'original body'
+		wrapper.vm.isDownloading = null
+
+		wrapper.vm.toggleFulltext()
+
+		expect(spy).toHaveBeenCalled()
+	})
+
+	it('toggleFulltext does nothing if downloading', () => {
+		const fetchSpy = vi.spyOn(wrapper.vm, 'fetchFulltext')
+
+		wrapper.vm.isDownloading = {}
+
+		wrapper.vm.toggleFulltext()
+
+		expect(fetchSpy).not.toHaveBeenCalled()
 	})
 
 	describe('sanitizedBody', () => {

--- a/tests/javascript/unit/services/item.service.spec.ts
+++ b/tests/javascript/unit/services/item.service.spec.ts
@@ -131,4 +131,27 @@ describe('item.service.ts', () => {
 			expect(args[1].isStarred).toEqual(false)
 		})
 	})
+
+	describe('fetchFulltext', () => {
+		it('should call GET with item id', async () => {
+			await ItemService.fetchFulltext({ id: 1 })
+
+			expect(axios.get).toBeCalled()
+			const args = axios.get.mock.calls[0]
+
+			expect(args[0]).toContain('1')
+		})
+	})
+
+	describe('updateBodyText', () => {
+		it('should call POST with item id and body param ', async () => {
+			await ItemService.updateBodyText(1, 'content')
+
+			expect(axios.post).toBeCalled()
+			const args = axios.post.mock.calls[0]
+
+			expect(args[0]).toContain('1')
+			expect(args[1]).toEqual({ body: 'content' })
+		})
+	})
 })

--- a/tests/javascript/unit/store/item.spec.ts
+++ b/tests/javascript/unit/store/item.spec.ts
@@ -152,6 +152,59 @@ describe('item.ts', () => {
 			})
 		})
 
+		describe('FETCH_FULLTEXT', () => {
+			it('commits updated item when fulltext exists', async () => {
+				const item = { id: 123, body: 'old body', intro: 'old intro' }
+				const response = { status: 200, data: [{ id: 123, body: 'full text', intro: 'intro' }] }
+				const commit = vi.fn()
+				vi.spyOn(ItemService, 'fetchFulltext').mockResolvedValue(response)
+
+				await actions[FEED_ITEM_ACTION_TYPES.FETCH_FULLTEXT]({ commit }, { item })
+
+				expect(ItemService.fetchFulltext).toHaveBeenCalledWith(item)
+				expect(commit).toHaveBeenCalledWith(FEED_ITEM_MUTATION_TYPES.UPDATE_ITEM, { item: response.data[0] })
+			})
+
+			it('throws error when response data is empty', async () => {
+				const item = { id: 123, body: 'old body', intro: 'new body' }
+				const response = { status: 200, data: [] }
+				const commit = vi.fn()
+				vi.spyOn(ItemService, 'fetchFulltext').mockResolvedValue(response)
+
+				await expect(actions[FEED_ITEM_ACTION_TYPES.FETCH_FULLTEXT]({ commit }, { item }))
+					.rejects
+					.toThrow('Empty Response')
+			})
+
+			it('throws error when full text scraper fails', async () => {
+				const item = { id: 123, body: 'old body', intro: 'new body' }
+				const response = { status: 204, statusText: 'No Content', data: [] }
+				const commit = vi.fn()
+				vi.spyOn(ItemService, 'fetchFulltext').mockResolvedValue(response)
+
+				await expect(actions[FEED_ITEM_ACTION_TYPES.FETCH_FULLTEXT]({ commit }, { item }))
+					.rejects
+					.toThrow('No Content')
+			})
+		})
+
+		describe('UPDATE_BODY', () => {
+			it('updates body and intro and commits', async () => {
+				const item = { id: 123, body: 'full text', intro: 'intro' }
+				const body = 'old body'
+				const intro = 'old intro'
+				const commit = vi.fn()
+				vi.spyOn(ItemService, 'updateBodyText').mockResolvedValue(undefined)
+
+				await actions[FEED_ITEM_ACTION_TYPES.UPDATE_BODY]({ commit }, { item, body, intro })
+
+				expect(ItemService.updateBodyText).toHaveBeenCalledWith(item.id, body)
+				expect(item.body).toBe(body)
+				expect(item.intro).toBe(intro)
+				expect(commit).toHaveBeenCalledWith(FEED_ITEM_MUTATION_TYPES.UPDATE_ITEM, { item })
+			})
+		})
+
 		it('MARK_READ should call GET and commit returned feeds to state', async () => {
 			const item = { id: 1, feedId: 123, unread: true }
 			const commit = vi.fn()


### PR DESCRIPTION
## Summary

This PR adds a button to the article view that allows you to download the web version of an article and replace it directly. If the result is not satisfying, because of cookie banner or paywall,  you can revert the change as long as you view this article.
This can also done with the shotcut key 'x'.

The download is handled in exactly the same way as with the global ‘full text’ feed option and is processed by `Readability` and `HTMLSanitzier`.
This should make it unnecessary to download the web version for every article in a feed.

Here is an example of how it works:

[Bildschirmaufnahme_20260325_204209.webm](https://github.com/user-attachments/assets/fb79b43b-4b74-4e1a-b191-1031d9a29190)



## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
