### PR TITLE
Rework feed options menu and feed settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 # Unreleased
 ### Changed
+- Rework feed options menu and feed settings
 
 ### Fixed
 

--- a/src/components/SidebarFeedLinkActions.vue
+++ b/src/components/SidebarFeedLinkActions.vue
@@ -46,42 +46,6 @@
 			{{ t("news", "Default order") }}
 		</NcActionButton>
 		<NcActionButton
-			v-if="!feed.fullTextEnabled"
-			icon="icon-full-text-disabled"
-			@click="setFullText(true)">
-			<template #icon>
-				<TextShortIcon />
-			</template>
-			{{ t("news", "Enable full text") }}
-		</NcActionButton>
-		<NcActionButton
-			v-if="feed.fullTextEnabled"
-			icon="icon-full-text-enabled"
-			@click="setFullText(false)">
-			<template #icon>
-				<TextLongIcon />
-			</template>
-			{{ t("news", "Disable full text") }}
-		</NcActionButton>
-		<NcActionButton
-			v-if="feed.updateMode === FEED_UPDATE_MODE.UNREAD"
-			icon="file-document-refresh"
-			@click="setUpdateMode(FEED_UPDATE_MODE.IGNORE)">
-			<template #icon>
-				<FileDocumentRefresh />
-			</template>
-			{{ t("news", "Mark as unread on update") }}
-		</NcActionButton>
-		<NcActionButton
-			v-if="feed.updateMode === FEED_UPDATE_MODE.IGNORE"
-			icon="file-document-check"
-			@click="setUpdateMode(FEED_UPDATE_MODE.UNREAD)">
-			<template #icon>
-				<FileDocumentCheck />
-			</template>
-			{{ t("news", "Keep read status on update") }}
-		</NcActionButton>
-		<NcActionButton
 			icon="icon-rename"
 			:closeAfterClick="true"
 			@click="rename()">
@@ -102,24 +66,6 @@
 			@click="deleteFeed()">
 			{{ t("news", "Delete") }}
 		</NcActionButton>
-		<NcActionButton
-			v-if="feed.preventUpdate"
-			:closeAfterClick="true"
-			@click="setPreventUpdate(false)">
-			<template #icon>
-				<SyncOff />
-			</template>
-			{{ t("news", "Sync disabled") }}
-		</NcActionButton>
-		<NcActionButton
-			v-if="!feed.preventUpdate"
-			:closeAfterClick="true"
-			@click="setPreventUpdate(true)">
-			<template #icon>
-				<Sync />
-			</template>
-			{{ t("news", "Sync enabled") }}
-		</NcActionButton>
 		<NcAppNavigationItem
 			:name="t('news', 'Open Feed URL')"
 			:href="feed.location">
@@ -138,16 +84,10 @@ import { defineComponent } from 'vue'
 import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcAppNavigationItem from '@nextcloud/vue/components/NcAppNavigationItem'
 import ArrowRightIcon from 'vue-material-design-icons/ArrowRight.vue'
-import FileDocumentCheck from 'vue-material-design-icons/FileDocumentCheck.vue'
-import FileDocumentRefresh from 'vue-material-design-icons/FileDocumentRefresh.vue'
 import PinIcon from 'vue-material-design-icons/Pin.vue'
 import PinOffIcon from 'vue-material-design-icons/PinOff.vue'
 import RssIcon from 'vue-material-design-icons/Rss.vue'
-import Sync from 'vue-material-design-icons/Sync.vue'
-import SyncOff from 'vue-material-design-icons/SyncOff.vue'
-import TextLongIcon from 'vue-material-design-icons/TextLong.vue'
-import TextShortIcon from 'vue-material-design-icons/TextShort.vue'
-import { FEED_ORDER, FEED_UPDATE_MODE } from '../enums/index.ts'
+import { FEED_ORDER } from '../enums/index.ts'
 import { ACTIONS, MUTATIONS } from '../store/index.ts'
 
 export default defineComponent({
@@ -164,13 +104,7 @@ export default defineComponent({
 		RssIcon,
 		PinIcon,
 		PinOffIcon,
-		Sync,
-		SyncOff,
-		TextShortIcon,
-		TextLongIcon,
 		ArrowRightIcon,
-		FileDocumentRefresh,
-		FileDocumentCheck,
 	},
 
 	props: {
@@ -190,7 +124,6 @@ export default defineComponent({
 	data: () => {
 		return {
 			FEED_ORDER,
-			FEED_UPDATE_MODE,
 		}
 	},
 
@@ -207,10 +140,6 @@ export default defineComponent({
 			this.$store.dispatch(ACTIONS.FEED_MARK_READ, { feed: this.feed })
 		},
 
-		setPreventUpdate(preventUpdate: boolean) {
-			this.$store.dispatch(ACTIONS.FEED_SET_PREVENT_UPDATE, { feed: this.feed, preventUpdate })
-		},
-
 		setPinned(pinned: boolean) {
 			this.$store.dispatch(ACTIONS.FEED_SET_PINNED, { feed: this.feed, pinned })
 		},
@@ -218,14 +147,6 @@ export default defineComponent({
 		setOrdering(ordering: FEED_ORDER) {
 			this.$store.commit(MUTATIONS.SET_LAST_ITEM_LOADED, { key: 'feed-' + String(this.feedId), lastItem: undefined })
 			this.$store.dispatch(ACTIONS.FEED_SET_ORDERING, { feed: this.feed, ordering })
-		},
-
-		setFullText(fullTextEnabled: boolean) {
-			this.$store.dispatch(ACTIONS.FEED_SET_FULL_TEXT, { feed: this.feed, fullTextEnabled })
-		},
-
-		setUpdateMode(updateMode: FEED_UPDATE_MODE) {
-			this.$store.dispatch(ACTIONS.FEED_SET_UPDATE_MODE, { feed: this.feed, updateMode })
 		},
 
 		rename() {

--- a/src/components/modals/FeedInfoTable.vue
+++ b/src/components/modals/FeedInfoTable.vue
@@ -106,7 +106,7 @@
 			<NcNoteCard type="info">
 				{{ t('news', 'Please note that web scraping may be blocked by some providers and is generally discouraged.') }}
 			</NcNoteCard>
-			<NcNoteCard v-if="loading" type="info">
+			<NcNoteCard v-if="loading" type="info" data-test="loadingMessage">
 				<div class="loading-message">
 					<NcLoadingIcon size="24" />
 					<strong>{{ t('news', 'Loading feeds') }}...{{ t('news', 'Please wait') }}</strong>
@@ -202,10 +202,11 @@
 							</NcActions>
 						</td>
 						<td>
-							<NcActions :inline="3">
+							<NcActions :inline="3" :data-test="'feedOptions-' + feed.id">
 								<NcActionButton
 									v-if="feed.preventUpdate"
 									:title="t('news', 'Enable feed update')"
+									data-test="disableFeedUpdate"
 									@click="setPreventUpdate(feed, false)">
 									<template #icon>
 										<SyncOff />
@@ -214,6 +215,7 @@
 								<NcActionButton
 									v-if="!feed.preventUpdate"
 									:title="t('news', 'Disable feed update')"
+									data-test="enableFeedUpdate"
 									@click="setPreventUpdate(feed, true)">
 									<template #icon>
 										<Sync />
@@ -222,6 +224,7 @@
 								<NcActionButton
 									v-if="feed.updateMode === FEED_UPDATE_MODE.UNREAD"
 									:title="t('news', 'Disable marking items as unread on update')"
+									data-test="disableMarkUnread"
 									@click="setUpdateMode(feed, FEED_UPDATE_MODE.IGNORE)">
 									<template #icon>
 										<FileDocumentRefresh />
@@ -230,6 +233,7 @@
 								<NcActionButton
 									v-if="feed.updateMode === FEED_UPDATE_MODE.IGNORE"
 									:title="t('news', 'Enable marking items as unread on update')"
+									data-test="enableMarkUnread"
 									@click="setUpdateMode(feed, FEED_UPDATE_MODE.UNREAD)">
 									<template #icon>
 										<FileDocumentCheck />
@@ -238,6 +242,7 @@
 								<NcActionButton
 									v-if="!feed.fullTextEnabled"
 									:title="t('news', 'Enable web scraping')"
+									data-test="enableScraping"
 									@click="setFullText(feed, true)">
 									<template #icon>
 										<TextShortIcon />
@@ -246,6 +251,7 @@
 								<NcActionButton
 									v-if="feed.fullTextEnabled"
 									:title="t('news', 'Disable web scraping')"
+									data-test="disableScraping"
 									@click="setFullText(feed, false)">
 									<template #icon>
 										<TextLongIcon />

--- a/src/components/modals/FeedInfoTable.vue
+++ b/src/components/modals/FeedInfoTable.vue
@@ -206,7 +206,7 @@
 								<NcActionButton
 									v-if="feed.preventUpdate"
 									:title="t('news', 'Enable feed update')"
-									data-test="disableFeedUpdate"
+									data-test="enableFeedUpdate"
 									@click="setPreventUpdate(feed, false)">
 									<template #icon>
 										<SyncOff />
@@ -215,7 +215,7 @@
 								<NcActionButton
 									v-if="!feed.preventUpdate"
 									:title="t('news', 'Disable feed update')"
-									data-test="enableFeedUpdate"
+									data-test="disableFeedUpdate"
 									@click="setPreventUpdate(feed, true)">
 									<template #icon>
 										<Sync />

--- a/src/components/modals/FeedInfoTable.vue
+++ b/src/components/modals/FeedInfoTable.vue
@@ -6,11 +6,14 @@
 	<MoveFeed v-if="showMoveFeed" :feed="feedToMove" @close="closeMoveFeed()" />
 	<NcModal
 		size="large"
+		labelId="feed-settings-dialog"
 		:closeOnClickOutside="true"
 		@close="$emit('close')">
 		<div class="table-modal">
 			<div class="modal-header">
-				<h2>{{ t('news', 'Feed settings') }}</h2>
+				<h2 id="feed-settings-dialog">
+					{{ t('news', 'Feed settings') }}
+				</h2>
 			</div>
 			<table>
 				<tbody>
@@ -53,21 +56,21 @@
 				<tbody>
 					<tr>
 						<th colspan="4">
-							{{ t('news', 'Feed settings') }}
+							{{ t('news', 'Fetch options') }}
 						</th>
 					</tr>
 					<tr>
 						<td>
-							<TextShortIcon />
+							<Sync />
 						</td>
 						<td>
-							{{ t('news', 'Use article text provided by the feed') }}
+							{{ t('news', 'Feed update is enabled') }}
 						</td>
 						<td>
-							<TextLongIcon />
+							<SyncOff />
 						</td>
 						<td>
-							{{ t('news', 'Scrape web version of the article text') }}
+							{{ t('news', 'Feed update is disabled') }}
 						</td>
 					</tr>
 					<tr>
@@ -86,16 +89,16 @@
 					</tr>
 					<tr>
 						<td>
-							<Sync />
+							<TextShortIcon />
 						</td>
 						<td>
-							{{ t('news', 'Feed update is enabled') }}
+							{{ t('news', 'Use article text provided by the feed') }}
 						</td>
 						<td>
-							<SyncOff />
+							<TextLongIcon />
 						</td>
 						<td>
-							{{ t('news', 'Feed update is disabled') }}
+							{{ t('news', 'Scrape web version of the article text') }}
 						</td>
 					</tr>
 				</tbody>
@@ -202,8 +205,7 @@
 							<NcActions :inline="3">
 								<NcActionButton
 									v-if="feed.preventUpdate"
-									:closeAfterClick="true"
-									:title="t('news', 'Feed update is disabled')"
+									:title="t('news', 'Enable feed update')"
 									@click="setPreventUpdate(feed, false)">
 									<template #icon>
 										<SyncOff />
@@ -211,8 +213,7 @@
 								</NcActionButton>
 								<NcActionButton
 									v-if="!feed.preventUpdate"
-									:closeAfterClick="true"
-									:title="t('news', 'Feed update is enabled')"
+									:title="t('news', 'Disable feed update')"
 									@click="setPreventUpdate(feed, true)">
 									<template #icon>
 										<Sync />
@@ -220,8 +221,7 @@
 								</NcActionButton>
 								<NcActionButton
 									v-if="feed.updateMode === FEED_UPDATE_MODE.UNREAD"
-									icon="file-document-refresh"
-									:title="t('news', 'Mark as unread on update')"
+									:title="t('news', 'Disable marking items as unread on update')"
 									@click="setUpdateMode(feed, FEED_UPDATE_MODE.IGNORE)">
 									<template #icon>
 										<FileDocumentRefresh />
@@ -229,8 +229,7 @@
 								</NcActionButton>
 								<NcActionButton
 									v-if="feed.updateMode === FEED_UPDATE_MODE.IGNORE"
-									icon="file-document-check"
-									:title="t('news', 'Keep read status on update')"
+									:title="t('news', 'Enable marking items as unread on update')"
 									@click="setUpdateMode(feed, FEED_UPDATE_MODE.UNREAD)">
 									<template #icon>
 										<FileDocumentCheck />
@@ -238,8 +237,7 @@
 								</NcActionButton>
 								<NcActionButton
 									v-if="!feed.fullTextEnabled"
-									icon="icon-full-text-disabled"
-									:title="t('news', 'Use article text provided by the feed')"
+									:title="t('news', 'Enable web scraping')"
 									@click="setFullText(feed, true)">
 									<template #icon>
 										<TextShortIcon />
@@ -247,8 +245,7 @@
 								</NcActionButton>
 								<NcActionButton
 									v-if="feed.fullTextEnabled"
-									icon="icon-full-text-enabled"
-									:title="t('news', 'Scrape web version of the article text')"
+									:title="t('news', 'Disable web scraping')"
 									@click="setFullText(feed, false)">
 									<template #icon>
 										<TextLongIcon />

--- a/src/components/modals/FeedInfoTable.vue
+++ b/src/components/modals/FeedInfoTable.vue
@@ -6,15 +6,11 @@
 	<MoveFeed v-if="showMoveFeed" :feed="feedToMove" @close="closeMoveFeed()" />
 	<NcModal
 		size="large"
-		closeOnClickOutside="true"
+		:closeOnClickOutside="true"
 		@close="$emit('close')">
 		<div class="table-modal">
 			<div class="modal-header">
 				<h2>{{ t('news', 'Feed settings') }}</h2>
-				<div v-if="loading" class="loading-message">
-					<NcLoadingIcon size="36" />
-					<h1>{{ t('news', 'Importing feeds') }}...{{ t('news', 'Please wait') }}</h1>
-				</div>
 			</div>
 			<table>
 				<tbody>
@@ -23,7 +19,7 @@
 							{{ t('news', 'Last update') }}:
 						</td>
 						<td>
-							{{ t('news', 'Time when the feed was last downloaded') }}
+							{{ t('news', 'Time when the feed was last downloaded or modified') }}
 						</td>
 					</tr>
 					<tr>
@@ -54,6 +50,66 @@
 				</tbody>
 			</table>
 			<table>
+				<tbody>
+					<tr>
+						<th colspan="4">
+							{{ t('news', 'Feed settings') }}
+						</th>
+					</tr>
+					<tr>
+						<td>
+							<TextShortIcon />
+						</td>
+						<td>
+							{{ t('news', 'Use article text provided by the feed') }}
+						</td>
+						<td>
+							<TextLongIcon />
+						</td>
+						<td>
+							{{ t('news', 'Scrape web version of the article text') }}
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<FileDocumentRefresh />
+						</td>
+						<td>
+							{{ t('news', 'Mark as unread on update') }}
+						</td>
+						<td>
+							<FileDocumentCheck />
+						</td>
+						<td>
+							{{ t('news', 'Keep read status on update') }}
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<Sync />
+						</td>
+						<td>
+							{{ t('news', 'Feed update is enabled') }}
+						</td>
+						<td>
+							<SyncOff />
+						</td>
+						<td>
+							{{ t('news', 'Feed update is disabled') }}
+						</td>
+					</tr>
+				</tbody>
+			</table>
+			<NcNoteCard type="info">
+				{{ t('news', 'Please note that web scraping may be blocked by some providers and is generally discouraged.') }}
+			</NcNoteCard>
+			<NcNoteCard v-if="loading" type="info">
+				<div class="loading-message">
+					<NcLoadingIcon size="24" />
+					<strong>{{ t('news', 'Loading feeds') }}...{{ t('news', 'Please wait') }}</strong>
+				</div>
+			</NcNoteCard>
+			<table>
 				<thead>
 					<tr>
 						<th @click="sortBy('id')">
@@ -65,7 +121,11 @@
 								ID
 							</span>
 						</th>
-						<th />
+						<th colspan="2">
+							<span class="column-title">
+								{{ t('news', 'Options') }}
+							</span>
+						</th>
 						<th @click="sortBy('title')">
 							<span class="column-title">
 								<span class="sort-icon">
@@ -138,6 +198,64 @@
 									@openMoveDialog="openMoveFeed(feed)" />
 							</NcActions>
 						</td>
+						<td>
+							<NcActions :inline="3">
+								<NcActionButton
+									v-if="feed.preventUpdate"
+									:closeAfterClick="true"
+									:title="t('news', 'Feed update is disabled')"
+									@click="setPreventUpdate(feed, false)">
+									<template #icon>
+										<SyncOff />
+									</template>
+								</NcActionButton>
+								<NcActionButton
+									v-if="!feed.preventUpdate"
+									:closeAfterClick="true"
+									:title="t('news', 'Feed update is enabled')"
+									@click="setPreventUpdate(feed, true)">
+									<template #icon>
+										<Sync />
+									</template>
+								</NcActionButton>
+								<NcActionButton
+									v-if="feed.updateMode === FEED_UPDATE_MODE.UNREAD"
+									icon="file-document-refresh"
+									:title="t('news', 'Mark as unread on update')"
+									@click="setUpdateMode(feed, FEED_UPDATE_MODE.IGNORE)">
+									<template #icon>
+										<FileDocumentRefresh />
+									</template>
+								</NcActionButton>
+								<NcActionButton
+									v-if="feed.updateMode === FEED_UPDATE_MODE.IGNORE"
+									icon="file-document-check"
+									:title="t('news', 'Keep read status on update')"
+									@click="setUpdateMode(feed, FEED_UPDATE_MODE.UNREAD)">
+									<template #icon>
+										<FileDocumentCheck />
+									</template>
+								</NcActionButton>
+								<NcActionButton
+									v-if="!feed.fullTextEnabled"
+									icon="icon-full-text-disabled"
+									:title="t('news', 'Use article text provided by the feed')"
+									@click="setFullText(feed, true)">
+									<template #icon>
+										<TextShortIcon />
+									</template>
+								</NcActionButton>
+								<NcActionButton
+									v-if="feed.fullTextEnabled"
+									icon="icon-full-text-enabled"
+									:title="t('news', 'Scrape web version of the article text')"
+									@click="setFullText(feed, false)">
+									<template #icon>
+										<TextLongIcon />
+									</template>
+								</NcActionButton>
+							</NcActions>
+						</td>
 						<td class="text">
 							{{ feed.title }}
 						</td>
@@ -145,7 +263,7 @@
 							{{ folderName(feed) }}
 						</td>
 						<td class="date">
-							{{ feed.preventUpdate ? t('news', 'Sync disabled') : formatDate(feed.lastModified / 1000000) }}
+							{{ formatDate(feed.lastModified / 1000000) }}
 						</td>
 						<td class="date">
 							{{ feed.nextUpdateTime && !feed.preventUpdate ? formatDate(feed.nextUpdateTime) : t('news', 'Not available') }}
@@ -165,25 +283,43 @@
 
 <script>
 import { mapState } from 'vuex'
+import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActions from '@nextcloud/vue/components/NcActions'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcModal from '@nextcloud/vue/components/NcModal'
+import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
+import FileDocumentCheck from 'vue-material-design-icons/FileDocumentCheck.vue'
+import FileDocumentRefresh from 'vue-material-design-icons/FileDocumentRefresh.vue'
 import SortAscIcon from 'vue-material-design-icons/SortAscending.vue'
 import SortDescIcon from 'vue-material-design-icons/SortDescending.vue'
+import Sync from 'vue-material-design-icons/Sync.vue'
+import SyncOff from 'vue-material-design-icons/SyncOff.vue'
+import TextLongIcon from 'vue-material-design-icons/TextLong.vue'
+import TextShortIcon from 'vue-material-design-icons/TextShort.vue'
 import MoveFeed from '../MoveFeed.vue'
 import SidebarFeedLinkActions from '../SidebarFeedLinkActions.vue'
+import { FEED_UPDATE_MODE } from '../../enums/index.ts'
+import { ACTIONS } from '../../store/index.ts'
 import { formatDate } from '../../utils/dateUtils.ts'
 
 export default {
 	name: 'FeedInfoTable',
 	components: {
 		NcActions,
+		NcActionButton,
 		NcLoadingIcon,
 		NcModal,
+		NcNoteCard,
 		MoveFeed,
 		SidebarFeedLinkActions,
+		FileDocumentRefresh,
+		FileDocumentCheck,
 		SortAscIcon,
 		SortDescIcon,
+		Sync,
+		SyncOff,
+		TextShortIcon,
+		TextLongIcon,
 	},
 
 	emits: {
@@ -196,6 +332,7 @@ export default {
 			showMoveFeed: false,
 			sortKey: 'title',
 			sortOrder: 1,
+			FEED_UPDATE_MODE,
 		}
 	},
 
@@ -217,7 +354,7 @@ export default {
 		},
 
 		sortedFeeds() {
-			const sorted = [...this.feeds]
+			const sorted = Array.isArray(this.feeds) ? [...this.feeds] : []
 			if (this.sortKey) {
 				sorted.sort((a, b) => {
 					const valueA = a[this.sortKey]
@@ -255,6 +392,18 @@ export default {
 				this.sortKey = key
 				this.sortOrder = 1
 			}
+		},
+
+		setPreventUpdate(feed, preventUpdate) {
+			this.$store.dispatch(ACTIONS.FEED_SET_PREVENT_UPDATE, { feed, preventUpdate })
+		},
+
+		setUpdateMode(feed, updateMode) {
+			this.$store.dispatch(ACTIONS.FEED_SET_UPDATE_MODE, { feed, updateMode })
+		},
+
+		setFullText(feed, fullTextEnabled) {
+			this.$store.dispatch(ACTIONS.FEED_SET_FULL_TEXT, { feed, fullTextEnabled })
 		},
 	},
 }

--- a/tests/javascript/unit/components/SidebarFeedLinkActions.spec.ts
+++ b/tests/javascript/unit/components/SidebarFeedLinkActions.spec.ts
@@ -1,7 +1,7 @@
 import { shallowMount } from '@vue/test-utils'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import SidebarFeedLinkActions from '../../../../src/components/SidebarFeedLinkActions.vue'
-import { FEED_ORDER, FEED_UPDATE_MODE } from '../../../../src/enums/index.ts'
+import { FEED_ORDER } from '../../../../src/enums/index.ts'
 import { ACTIONS } from '../../../../src/store/index.ts'
 
 describe('SidebarFeedLinkActions.vue', () => {
@@ -58,22 +58,10 @@ describe('SidebarFeedLinkActions.vue', () => {
 			expect(wrapper.vm.$store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_PINNED, { feed: feeds[0], pinned: true })
 		})
 
-		it('should dispatch message to store with feed object and fullTextEnabled', () => {
+		it('should dispatch message to store with feed object and new ordering', () => {
 			wrapper.vm.setOrdering(FEED_ORDER.NEWEST)
 
 			expect(wrapper.vm.$store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_ORDERING, { feed: feeds[0], ordering: FEED_ORDER.NEWEST })
-		})
-
-		it('should dispatch message to store with feed object and fullTextEnabled', () => {
-			wrapper.vm.setFullText(true)
-
-			expect(wrapper.vm.$store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_FULL_TEXT, { feed: feeds[0], fullTextEnabled: true })
-		})
-
-		it('should dispatch message to store with feed object and new updateMode', () => {
-			wrapper.vm.setUpdateMode(FEED_UPDATE_MODE.IGNORE)
-
-			expect(wrapper.vm.$store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_UPDATE_MODE, { feed: feeds[0], updateMode: FEED_UPDATE_MODE.IGNORE })
 		})
 
 		it('should dispatch message to store with feed object on rename feed', () => {

--- a/tests/javascript/unit/components/modals/FeedInfoTable.spec.ts
+++ b/tests/javascript/unit/components/modals/FeedInfoTable.spec.ts
@@ -1,0 +1,246 @@
+import { shallowMount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import Vuex from 'vuex'
+import FeedInfoTable from '../../../../../src/components/modals/FeedInfoTable.vue'
+import { FEED_UPDATE_MODE } from '../../../../../src/enums/index.ts'
+import { ACTIONS } from '../../../../../src/store/index.ts'
+
+describe('FeedInfoTable.vue', () => {
+	'use strict'
+
+	let wrapper: any
+	let store: any
+
+	const feeds = [{
+		id: 1,
+		title: 'first',
+		folderId: 456,
+		lastModified: 9,
+		nextUpdateTime: 1,
+		articlesPerUpdate: 150,
+		updateErrorCount: 20,
+	}, {
+		id: 2,
+		title: 'second',
+		folderId: 789,
+		lastModified: 7,
+		nextUpdateTime: 4,
+		articlesPerUpdate: 50,
+		updateErrorCount: 40,
+	}, {
+		id: 3,
+		title: 'third',
+		folderId: 123,
+		lastModified: 8,
+		nextUpdateTime: 8,
+		articlesPerUpdate: 20,
+		updateErrorCount: 0,
+	}]
+
+	const folders = [{
+		id: 123,
+		name: 'second',
+	}, {
+		id: 456,
+		name: 'first',
+	}, {
+		id: 789,
+		name: 'third',
+	}]
+
+	beforeEach(() => {
+		store = new Vuex.Store({
+			state: {
+				feeds: { feeds },
+				folders: { folders },
+			},
+			getters: {
+				feeds: () => [feeds],
+				folders: () => [folders],
+			},
+		})
+		store.dispatch = vi.fn()
+		wrapper = shallowMount(FeedInfoTable, {
+			global: {
+				plugins: [store],
+			},
+		})
+	})
+
+	describe('Methods', () => {
+		it('should return folder name for a given feed', () => {
+			const folderName = wrapper.vm.folderName(feeds[0])
+			expect(folderName).toEqual('first')
+		})
+
+		it('should set triggers to open and close move feed dialog', () => {
+			expect(wrapper.vm.feedToMove).toEqual(undefined)
+			expect(wrapper.vm.showMoveFeed).toEqual(false)
+
+			wrapper.vm.openMoveFeed(feeds[0])
+			expect(wrapper.vm.feedToMove).toEqual(feeds[0])
+			expect(wrapper.vm.showMoveFeed).toEqual(true)
+
+			wrapper.vm.closeMoveFeed(feeds[0])
+			expect(wrapper.vm.showMoveFeed).toEqual(false)
+		})
+
+		it('should set key and ascending order when sort key differs', () => {
+			wrapper.vm.sortKey = 'title'
+			wrapper.vm.sortOrder = 1
+
+			wrapper.vm.sortBy('id')
+
+			expect(wrapper.vm.sortKey).toEqual('id')
+			expect(wrapper.vm.sortOrder).toEqual(1)
+		})
+
+		it('should set key and descending order when sort key is equal', () => {
+			wrapper.vm.sortKey = 'id'
+			wrapper.vm.sortOrder = 1
+
+			wrapper.vm.sortBy('id')
+
+			expect(wrapper.vm.sortKey).toEqual('id')
+			expect(wrapper.vm.sortOrder).toEqual(-1)
+		})
+	})
+
+	describe('Table Sorting', () => {
+		it('sort the feed table in ascending order by id', () => {
+			wrapper.vm.sortKey = 'id'
+			wrapper.vm.sortOrder = 1
+
+			const sortedFeeds = wrapper.vm.$options.computed?.sortedFeeds.call(wrapper.vm)
+			expect(sortedFeeds).toEqual([feeds[0], feeds[1], feeds[2]])
+		})
+
+		it('sort the feed table in descending order by id', () => {
+			wrapper.vm.sortKey = 'id'
+			wrapper.vm.sortOrder = -1
+
+			const sortedFeeds = wrapper.vm.$options.computed?.sortedFeeds.call(wrapper.vm)
+			expect(sortedFeeds).toEqual([feeds[2], feeds[1], feeds[0]])
+		})
+
+		it('sort the feed table in ascending order by title', () => {
+			wrapper.vm.sortKey = 'title'
+			wrapper.vm.sortOrder = 1
+
+			const sortedFeeds = wrapper.vm.$options.computed?.sortedFeeds.call(wrapper.vm)
+			expect(sortedFeeds).toEqual([feeds[0], feeds[1], feeds[2]])
+		})
+
+		it('sort the feed table in descending order by title', () => {
+			wrapper.vm.sortKey = 'title'
+			wrapper.vm.sortOrder = -1
+
+			const sortedFeeds = wrapper.vm.$options.computed?.sortedFeeds.call(wrapper.vm)
+			expect(sortedFeeds).toEqual([feeds[2], feeds[1], feeds[0]])
+		})
+
+		it('sort the feed table in ascending order by folderId', () => {
+			wrapper.vm.sortKey = 'folderId'
+			wrapper.vm.sortOrder = 1
+
+			const sortedFeeds = wrapper.vm.$options.computed?.sortedFeeds.call(wrapper.vm)
+			expect(sortedFeeds).toEqual([feeds[2], feeds[0], feeds[1]])
+		})
+
+		it('sort the feed table in descending order by folderId', () => {
+			wrapper.vm.sortKey = 'folderId'
+			wrapper.vm.sortOrder = -1
+
+			const sortedFeeds = wrapper.vm.$options.computed?.sortedFeeds.call(wrapper.vm)
+			expect(sortedFeeds).toEqual([feeds[1], feeds[0], feeds[2]])
+		})
+
+		it('sort the feed table in ascending order by lastModified', () => {
+			wrapper.vm.sortKey = 'lastModified'
+			wrapper.vm.sortOrder = 1
+
+			const sortedFeeds = wrapper.vm.$options.computed?.sortedFeeds.call(wrapper.vm)
+			expect(sortedFeeds).toEqual([feeds[1], feeds[2], feeds[0]])
+		})
+
+		it('sort the feed table in descending order by lastModified', () => {
+			wrapper.vm.sortKey = 'lastModified'
+			wrapper.vm.sortOrder = -1
+
+			const sortedFeeds = wrapper.vm.$options.computed?.sortedFeeds.call(wrapper.vm)
+			expect(sortedFeeds).toEqual([feeds[0], feeds[2], feeds[1]])
+		})
+
+		it('sort the feed table in ascending order by nextUpdateTime', () => {
+			wrapper.vm.sortKey = 'nextUpdateTime'
+			wrapper.vm.sortOrder = 1
+
+			const sortedFeeds = wrapper.vm.$options.computed?.sortedFeeds.call(wrapper.vm)
+			expect(sortedFeeds).toEqual([feeds[0], feeds[1], feeds[2]])
+		})
+
+		it('sort the feed table in descending order by nextUpdateTime', () => {
+			wrapper.vm.sortKey = 'nextUpdateTime'
+			wrapper.vm.sortOrder = -1
+
+			const sortedFeeds = wrapper.vm.$options.computed?.sortedFeeds.call(wrapper.vm)
+			expect(sortedFeeds).toEqual([feeds[2], feeds[1], feeds[0]])
+		})
+
+		it('sort the feed table in ascending order by articlesPerUpdate', () => {
+			wrapper.vm.sortKey = 'articlesPerUpdate'
+			wrapper.vm.sortOrder = 1
+
+			const sortedFeeds = wrapper.vm.$options.computed?.sortedFeeds.call(wrapper.vm)
+			expect(sortedFeeds).toEqual([feeds[2], feeds[1], feeds[0]])
+		})
+
+		it('sort the feed table in descending order by articlesPerUpdate', () => {
+			wrapper.vm.sortKey = 'articlesPerUpdate'
+			wrapper.vm.sortOrder = -1
+
+			const sortedFeeds = wrapper.vm.$options.computed?.sortedFeeds.call(wrapper.vm)
+			expect(sortedFeeds).toEqual([feeds[0], feeds[1], feeds[2]])
+		})
+
+		it('sort the feed table in ascending order by updateErrorCount', () => {
+			wrapper.vm.sortKey = 'updateErrorCount'
+			wrapper.vm.sortOrder = 1
+
+			const sortedFeeds = wrapper.vm.$options.computed?.sortedFeeds.call(wrapper.vm)
+			expect(sortedFeeds).toEqual([feeds[2], feeds[0], feeds[1]])
+		})
+
+		it('sort the feed table in descending order by updateErrorCount', () => {
+			wrapper.vm.sortKey = 'updateErrorCount'
+			wrapper.vm.sortOrder = -1
+
+			const sortedFeeds = wrapper.vm.$options.computed?.sortedFeeds.call(wrapper.vm)
+			expect(sortedFeeds).toEqual([feeds[1], feeds[0], feeds[2]])
+		})
+	})
+
+	describe('Feed Actions', () => {
+		it('should dispatch message to store with feed object and preventUpdate', () => {
+			wrapper.vm.setPreventUpdate(feeds[0], true)
+
+			expect(wrapper.vm.$store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_PREVENT_UPDATE, { feed: feeds[0], preventUpdate: true })
+		})
+
+		it('should dispatch message to store with feed object and new updateMode', () => {
+			wrapper.vm.setUpdateMode(feeds[0], FEED_UPDATE_MODE.IGNORE)
+
+			expect(wrapper.vm.$store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_UPDATE_MODE, { feed: feeds[0], updateMode: FEED_UPDATE_MODE.IGNORE })
+		})
+
+		it('should dispatch message to store with feed object and fullTextEnabled', () => {
+			wrapper.vm.setFullText(feeds[0], true)
+
+			expect(wrapper.vm.$store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_FULL_TEXT, { feed: feeds[0], fullTextEnabled: true })
+		})
+	})
+
+	afterEach(() => {
+		vi.clearAllMocks()
+	})
+})

--- a/tests/javascript/unit/components/modals/FeedInfoTable.spec.ts
+++ b/tests/javascript/unit/components/modals/FeedInfoTable.spec.ts
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils'
+import { mount, shallowMount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import Vuex from 'vuex'
 import FeedInfoTable from '../../../../../src/components/modals/FeedInfoTable.vue'
@@ -19,6 +19,9 @@ describe('FeedInfoTable.vue', () => {
 		nextUpdateTime: 1,
 		articlesPerUpdate: 150,
 		updateErrorCount: 20,
+		updateMode: FEED_UPDATE_MODE.UNREAD,
+		fullTextEnabled: false,
+		preventUpdate: true,
 	}, {
 		id: 2,
 		title: 'second',
@@ -27,6 +30,9 @@ describe('FeedInfoTable.vue', () => {
 		nextUpdateTime: 4,
 		articlesPerUpdate: 50,
 		updateErrorCount: 40,
+		updateMode: FEED_UPDATE_MODE.IGNORE,
+		fullTextEnabled: true,
+		preventUpdate: false,
 	}, {
 		id: 3,
 		title: 'third',
@@ -35,6 +41,9 @@ describe('FeedInfoTable.vue', () => {
 		nextUpdateTime: 8,
 		articlesPerUpdate: 20,
 		updateErrorCount: 0,
+		updateMode: FEED_UPDATE_MODE.UNREAD,
+		fullTextEnabled: true,
+		preventUpdate: true,
 	}]
 
 	const folders = [{
@@ -57,6 +66,7 @@ describe('FeedInfoTable.vue', () => {
 			getters: {
 				feeds: () => [feeds],
 				folders: () => [folders],
+				loading: () => false,
 			},
 		})
 		store.dispatch = vi.fn()
@@ -220,23 +230,121 @@ describe('FeedInfoTable.vue', () => {
 		})
 	})
 
-	describe('Feed Actions', () => {
-		it('should dispatch message to store with feed object and preventUpdate', () => {
-			wrapper.vm.setPreventUpdate(feeds[0], true)
-
-			expect(wrapper.vm.$store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_PREVENT_UPDATE, { feed: feeds[0], preventUpdate: true })
+	describe('Loading State', () => {
+		beforeEach(() => {
+			store = new Vuex.Store({
+				state: {
+					feeds: { feeds },
+					folders: { folders },
+				},
+				getters: {
+					feeds: () => [feeds],
+					folders: () => [folders],
+					loading: () => true,
+				},
+			})
+			store.dispatch = vi.fn()
+			wrapper = mount(FeedInfoTable, {
+				global: { plugins: [store] },
+			})
 		})
 
-		it('should dispatch message to store with feed object and new updateMode', () => {
-			wrapper.vm.setUpdateMode(feeds[0], FEED_UPDATE_MODE.IGNORE)
+		it('should show loading note card when loading is true', async () => {
+			const noteCard = wrapper.findAllComponents({ name: 'NcNoteCard' })
+				.find((ncnotecard) => ncnotecard.attributes('data-test') === 'loadingMessage')
+			expect(noteCard.text()).toContain('Loading feeds')
+		})
+	})
 
-			expect(wrapper.vm.$store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_UPDATE_MODE, { feed: feeds[0], updateMode: FEED_UPDATE_MODE.IGNORE })
+	describe('Action Buttons', () => {
+		beforeEach(() => {
+			store = new Vuex.Store({
+				state: {
+					feeds: { feeds },
+					folders: { folders },
+				},
+				getters: {
+					feeds: () => [feeds],
+					folders: () => [folders],
+					loading: () => false,
+				},
+			})
+			store.dispatch = vi.fn()
+			wrapper = mount(FeedInfoTable, {
+				global: { plugins: [store] },
+			})
 		})
 
-		it('should dispatch message to store with feed object and fullTextEnabled', () => {
-			wrapper.vm.setFullText(feeds[0], true)
+		it('should dispatch setPreventUpdate on click with preventUpdate false', async () => {
+			const actions = wrapper.findAllComponents({ name: 'NcActions' })
+				.find((ncactions) => ncactions.attributes('data-test') === 'feedOptions-1')
 
-			expect(wrapper.vm.$store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_FULL_TEXT, { feed: feeds[0], fullTextEnabled: true })
+			const button = actions.findAll('button')
+				.find((btn) => btn.attributes('data-test') === 'disableFeedUpdate')
+			expect(button).toBeTruthy()
+			await button.trigger('click')
+
+			expect(store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_PREVENT_UPDATE, { feed: feeds[0], preventUpdate: false })
+		})
+
+		it('should dispatch setPreventUpdate on click with preventUpdate true', async () => {
+			const actions = wrapper.findAllComponents({ name: 'NcActions' })
+				.find((ncactions) => ncactions.attributes('data-test') === 'feedOptions-2')
+
+			const button = actions.findAll('button')
+				.find((btn) => btn.attributes('data-test') === 'enableFeedUpdate')
+			expect(button).toBeTruthy()
+			await button.trigger('click')
+
+			expect(store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_PREVENT_UPDATE, { feed: feeds[1], preventUpdate: true })
+		})
+
+		it('should dispatch setUpdateMode on click with FEED_UPDATE_MODE.IGNORE', async () => {
+			const actions = wrapper.findAllComponents({ name: 'NcActions' })
+				.find((ncactions) => ncactions.attributes('data-test') === 'feedOptions-1')
+
+			const button = actions.findAll('button')
+				.find((btn) => btn.attributes('data-test') === 'disableMarkUnread')
+			expect(button).toBeTruthy()
+			await button.trigger('click')
+
+			expect(store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_UPDATE_MODE, { feed: feeds[0], updateMode: FEED_UPDATE_MODE.IGNORE })
+		})
+
+		it('should dispatch setUpdateMode on click with FEED_UPDATE_MODE.NORMAL', async () => {
+			const actions = wrapper.findAllComponents({ name: 'NcActions' })
+				.find((ncactions) => ncactions.attributes('data-test') === 'feedOptions-2')
+
+			const button = actions.findAll('button')
+				.find((btn) => btn.attributes('data-test') === 'enableMarkUnread')
+			expect(button).toBeTruthy()
+			await button.trigger('click')
+
+			expect(store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_UPDATE_MODE, { feed: feeds[1], updateMode: FEED_UPDATE_MODE.UNREAD })
+		})
+
+		it('should dispatch setFullText on click with fullTextEnabled true', async () => {
+			const actions = wrapper.findAllComponents({ name: 'NcActions' })
+				.find((ncactions) => ncactions.attributes('data-test') === 'feedOptions-1')
+
+			const button = actions.findAll('button')
+				.find((btn) => btn.attributes('data-test') === 'enableScraping')
+			expect(button).toBeTruthy()
+			await button.trigger('click')
+
+			expect(store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_FULL_TEXT, { feed: feeds[0], fullTextEnabled: true })
+		})
+
+		it('should dispatch setFullText on click with fullTextEnabled false', async () => {
+			const actions = wrapper.findAllComponents({ name: 'NcActions' })
+				.find((ncactions) => ncactions.attributes('data-test') === 'feedOptions-2')
+
+			const button = actions.findAll('button')
+				.find((btn) => btn.attributes('data-test') === 'disableScraping')
+			expect(button).toBeTruthy()
+			await button.trigger('click')
+
+			expect(store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_FULL_TEXT, { feed: feeds[1], fullTextEnabled: false })
 		})
 	})
 

--- a/tests/javascript/unit/components/modals/FeedInfoTable.spec.ts
+++ b/tests/javascript/unit/components/modals/FeedInfoTable.spec.ts
@@ -57,27 +57,27 @@ describe('FeedInfoTable.vue', () => {
 		name: 'third',
 	}]
 
-	beforeEach(() => {
-		store = new Vuex.Store({
-			state: {
-				feeds: { feeds },
-				folders: { folders },
-			},
-			getters: {
-				feeds: () => [feeds],
-				folders: () => [folders],
-				loading: () => false,
-			},
-		})
-		store.dispatch = vi.fn()
-		wrapper = shallowMount(FeedInfoTable, {
-			global: {
-				plugins: [store],
-			},
-		})
-	})
-
 	describe('Methods', () => {
+		beforeEach(() => {
+			store = new Vuex.Store({
+				state: {
+					feeds: { feeds },
+					folders: { folders },
+				},
+				getters: {
+					feeds: () => feeds,
+					folders: () => folders,
+					loading: () => false,
+				},
+			})
+			store.dispatch = vi.fn()
+			wrapper = shallowMount(FeedInfoTable, {
+				global: {
+					plugins: [store],
+				},
+			})
+		})
+
 		it('should return folder name for a given feed', () => {
 			const folderName = wrapper.vm.folderName(feeds[0])
 			expect(folderName).toEqual('first')
@@ -117,6 +117,26 @@ describe('FeedInfoTable.vue', () => {
 	})
 
 	describe('Table Sorting', () => {
+		beforeEach(() => {
+			store = new Vuex.Store({
+				state: {
+					feeds: { feeds },
+					folders: { folders },
+				},
+				getters: {
+					feeds: () => feeds,
+					folders: () => folders,
+					loading: () => false,
+				},
+			})
+			store.dispatch = vi.fn()
+			wrapper = shallowMount(FeedInfoTable, {
+				global: {
+					plugins: [store],
+				},
+			})
+		})
+
 		it('sort the feed table in ascending order by id', () => {
 			wrapper.vm.sortKey = 'id'
 			wrapper.vm.sortOrder = 1
@@ -238,14 +258,17 @@ describe('FeedInfoTable.vue', () => {
 					folders: { folders },
 				},
 				getters: {
-					feeds: () => [feeds],
-					folders: () => [folders],
+					feeds: () => feeds,
+					folders: () => folders,
 					loading: () => true,
 				},
 			})
 			store.dispatch = vi.fn()
 			wrapper = mount(FeedInfoTable, {
 				global: { plugins: [store] },
+				stubs: {
+					SidebarFeedLinkActions: true,
+				},
 			})
 		})
 
@@ -264,14 +287,17 @@ describe('FeedInfoTable.vue', () => {
 					folders: { folders },
 				},
 				getters: {
-					feeds: () => [feeds],
-					folders: () => [folders],
+					feeds: () => feeds,
+					folders: () => folders,
 					loading: () => false,
 				},
 			})
 			store.dispatch = vi.fn()
 			wrapper = mount(FeedInfoTable, {
 				global: { plugins: [store] },
+				stubs: {
+					SidebarFeedLinkActions: true,
+				},
 			})
 		})
 
@@ -280,7 +306,7 @@ describe('FeedInfoTable.vue', () => {
 				.find((ncactions) => ncactions.attributes('data-test') === 'feedOptions-1')
 
 			const button = actions.findAll('button')
-				.find((btn) => btn.attributes('data-test') === 'disableFeedUpdate')
+				.find((btn) => btn.attributes('data-test') === 'enableFeedUpdate')
 			expect(button).toBeTruthy()
 			await button.trigger('click')
 
@@ -292,7 +318,7 @@ describe('FeedInfoTable.vue', () => {
 				.find((ncactions) => ncactions.attributes('data-test') === 'feedOptions-2')
 
 			const button = actions.findAll('button')
-				.find((btn) => btn.attributes('data-test') === 'enableFeedUpdate')
+				.find((btn) => btn.attributes('data-test') === 'disableFeedUpdate')
 			expect(button).toBeTruthy()
 			await button.trigger('click')
 


### PR DESCRIPTION
## Summary

This PR reworks the Feed Options menu in the sidebar and the Feed Settings to provide a clearer distinction between actions that can be performed immediately and changes to the fetch behavior.

<img width="167" height="220" alt="grafik" src="https://github.com/user-attachments/assets/1391f8bf-235a-4762-935a-a03a188fc971" />
<img width="1242" height="656" alt="grafik" src="https://github.com/user-attachments/assets/d8542ff7-28ae-4f3c-bc40-8a623d69355b" />


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
