### PR TITLE
HTML Sanitizer options adjusted to fix broken layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 ### Fixed
 - Show a user-facing error when moving a feed fails (#3649)
+- Add more sanitize options to fix broken layouts
 
 # Releases
 ## [28.2.0-beta.1] - 2026-03-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 ### Fixed
 - Show a user-facing error when moving a feed fails (#3649)
-- Add more sanitize options to fix broken layouts
+- `HTML Sanitizer` options adjusted to fix broken layouts
 
 # Releases
 ## [28.2.0-beta.1] - 2026-03-22

--- a/lib/Utility/HtmlSanitizer.php
+++ b/lib/Utility/HtmlSanitizer.php
@@ -63,9 +63,14 @@ class HtmlSanitizer
             ->allowLinkSchemes(['http', 'https', 'mailto', 'ftp', 'nntp', 'news', 'tel'])
             // Configure allowed URI schemes for media (img, video, audio)
             ->allowMediaSchemes(['http', 'https', 'data'])
-            // Allow relative links and media
-            ->allowRelativeLinks(true)
-            ->allowRelativeMedias(true)
+            // Relative links are fixed by Readability and feed-io
+            // Disallow relative links and media just in case
+            ->allowRelativeLinks(false)
+            ->allowRelativeMedias(false)
+            // Remove dialog from articles
+            ->dropElement('dialog')
+            // Remove id attribute to not break CSS
+            ->dropAttribute('id', '*')
             // Disable input length limit
             ->withMaxInputLength(-1)
             // Add custom iframe src sanitizer to restrict to YouTube, Vimeo, VK

--- a/tests/Unit/Utility/HtmlSanitizerTest.php
+++ b/tests/Unit/Utility/HtmlSanitizerTest.php
@@ -194,14 +194,16 @@ class HtmlSanitizerTest extends TestCase
     {
         $input = '<a href="/relative/path">Relative Link</a>';
         $output = $this->sanitizer->purify($input);
-        $this->assertStringNotContainsString('/relative/path', $output);
+        $this->assertStringContainsString('<a>', $output);
+        $this->assertStringNotContainsString('href=', $output);
     }
 
     public function testPurifyDisallowsRelativeImages(): void
     {
         $input = '<img src="/images/photo.jpg" alt="Photo">';
         $output = $this->sanitizer->purify($input);
-        $this->assertStringNotContainsString('/images/photo.jpg', $output);
+        $this->assertStringContainsString('<img', $output);
+        $this->assertStringNotContainsString('src=', $output);
     }
 
     public function testPurifyPreservesTableStructure(): void
@@ -240,7 +242,7 @@ class HtmlSanitizerTest extends TestCase
     {
         $input = '<dialog><button>Click</button></dialog>';
         $output = $this->sanitizer->purify($input);
-        $this->assertEquals('', $output);
+        $this->assertEquals('', trim($output));
     }
 
     public function testPurifyRemovesIdAttribute(): void

--- a/tests/Unit/Utility/HtmlSanitizerTest.php
+++ b/tests/Unit/Utility/HtmlSanitizerTest.php
@@ -190,21 +190,18 @@ class HtmlSanitizerTest extends TestCase
         $this->assertStringContainsString('<strong>', $output);
     }
 
-    public function testPurifyAllowsRelativeLinks(): void
+    public function testPurifyDisallowsRelativeLinks(): void
     {
         $input = '<a href="/relative/path">Relative Link</a>';
         $output = $this->sanitizer->purify($input);
-        $this->assertStringContainsString('href=', $output);
-        $this->assertStringContainsString('/relative/path', $output);
+        $this->assertStringNotContainsString('/relative/path', $output);
     }
 
-    public function testPurifyAllowsRelativeImages(): void
+    public function testPurifyDisallowsRelativeImages(): void
     {
         $input = '<img src="/images/photo.jpg" alt="Photo">';
         $output = $this->sanitizer->purify($input);
-        $this->assertStringContainsString('<img', $output);
-        $this->assertStringContainsString('/images/photo.jpg', $output);
-        $this->assertStringContainsString('alt', $output);
+        $this->assertStringNotContainsString('/images/photo.jpg', $output);
     }
 
     public function testPurifyPreservesTableStructure(): void
@@ -237,5 +234,20 @@ class HtmlSanitizerTest extends TestCase
         $this->assertStringContainsString('inline code', $output);
         $this->assertStringContainsString('<pre>', $output);
         $this->assertStringContainsString('block code', $output);
+    }
+
+    public function testPurifyRemovesDialog(): void
+    {
+        $input = '<dialog><button>Click</button></dialog>';
+        $output = $this->sanitizer->purify($input);
+        $this->assertEquals('', $output);
+    }
+
+    public function testPurifyRemovesIdAttribute(): void
+    {
+        $input = '<section id="content"><article>Text</article></section>';
+        $output = $this->sanitizer->purify($input);
+        $this->assertStringNotContainsString('id="content"', $output);
+        $this->assertStringContainsString('<section>', $output);
     }
 }


### PR DESCRIPTION
## Summary

This PR adds options to the html sanitizer to fix broken layouts which mainly come from scraping but could also appear in the feed.

The changes are:
* disallow relative links and media
* remove dialog from articles
* remove id attribute to not break CSS

Relative links are already fixed by readability or feed-io and wouldn't work anyway.

If an article has an dialog which is normally hidden until a button is pressed it is currently shown completely out of place like this:
<img width="1411" height="494" alt="grafik" src="https://github.com/user-attachments/assets/f0bf89cf-ec9d-4dac-a266-98a77425daf5" />

Web articles can have id attributes that breaks the css, often like in this example `<section id="content">`, but also` <article id="content"> or <div id="content">`, which let the content write over the normal content boundaries.
<img width="1411" height="494" alt="grafik" src="https://github.com/user-attachments/assets/db3e8d2b-b904-4691-9392-3f9834d3f5f7" />

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
