### PR TITLE
Fix `Mark as unread on update` feed setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Fixed
 - Show a user-facing error when moving a feed fails (#3649)
 - `HTML Sanitizer` options adjusted to fix broken layouts
+- Feed setting `Mark as unread on update` had no effect
 
 # Releases
 ## [28.2.0-beta.1] - 2026-03-22

--- a/lib/Service/FeedServiceV2.php
+++ b/lib/Service/FeedServiceV2.php
@@ -398,8 +398,10 @@ class FeedServiceV2 extends Service
             $feed->setFaviconLink($fetchedFavicon);
         }
 
+        $feedId = $feed->getId();
+        $updateMode = $feed->getUpdateMode();
         foreach (array_reverse($items) as &$item) {
-            $item->setFeedId($feed->getId())
+            $item->setFeedId($feedId)
                 ->setBody($this->purifier->purify($item->getBody()));
 
             // Sanitize media description if present
@@ -408,12 +410,7 @@ class FeedServiceV2 extends Service
                 $item->setMediaDescription($this->purifier->purify($mediaDesc));
             }
 
-            // update modes: 0 nothing, 1 set unread
-            if ($feed->getUpdateMode() === Feed::UPDATE_MODE_NORMAL) {
-                $item->setUnread(true);
-            }
-
-            $item = $this->itemService->insertOrUpdate($item);
+            $item = $this->itemService->insertOrUpdate($item, $updateMode);
         }
 
 

--- a/lib/Service/ImportService.php
+++ b/lib/Service/ImportService.php
@@ -128,8 +128,14 @@ class ImportService
                 $item->setMediaDescription($this->purifier->purify($mediaDesc));
             }
             $item->generateSearchIndex();
-            if (!$this->itemService->insertOrUpdate($item)) {
+            try {
+                $this->itemService->insertOrUpdate($item, FEED::UPDATE_MODE_SILENT);
+            } catch (\Throwable $e) {
                 $error++;
+                $this->logger->error(
+                    'Failed to import item for feed {url}: ' . $e->getMessage(),
+                    ['url' => $feedLink]
+                );
             }
         }
 

--- a/lib/Service/ItemServiceV2.php
+++ b/lib/Service/ItemServiceV2.php
@@ -83,18 +83,22 @@ class ItemServiceV2 extends Service
      * Insert an item or update.
      *
      * @param Item $item
+     * @param int $updateMode
      *
      * @return Entity|Item The updated/inserted item
      */
-    public function insertOrUpdate(Item $item): Entity
+    public function insertOrUpdate(Item $item, int $updateMode): Entity
     {
         try {
             /** @var Item $db_item */
             $db_item = $this->findByGuidHash($item->getFeedId(), $item->getGuidHash());
 
+            // Keep unread state when configured in feed settings
+            if ($updateMode === FEED::UPDATE_MODE_SILENT) {
+                $item->setUnread($db_item->isUnread());
+            }
             // Transfer user modifications
-            $item->setUnread($db_item->isUnread())
-                 ->setStarred($db_item->isStarred())
+            $item->setStarred($db_item->isStarred())
                  ->setId($db_item->getId());
 
             $item->generateSearchIndex();//generates fingerprint

--- a/lib/Service/ShareService.php
+++ b/lib/Service/ShareService.php
@@ -145,7 +145,7 @@ class ShareService
 
         $sharedItem->setFeedId($feed->getId());
 
-        $result = $this->itemService->insertOrUpdate($sharedItem);
+        $result = $this->itemService->insertOrUpdate($sharedItem, FEED::UPDATE_MODE_SILENT);
 
         // Send notification to recipient
         $this->sendShareNotification($userId, $shareRecipientId, $result);

--- a/src/components/modals/FeedInfoTable.vue
+++ b/src/components/modals/FeedInfoTable.vue
@@ -75,16 +75,16 @@
 					</tr>
 					<tr>
 						<td>
-							<FileDocumentRefresh />
-						</td>
-						<td>
-							{{ t('news', 'Mark as unread on update') }}
-						</td>
-						<td>
 							<FileDocumentCheck />
 						</td>
 						<td>
 							{{ t('news', 'Keep read status on update') }}
+						</td>
+						<td>
+							<FileDocumentRefresh />
+						</td>
+						<td>
+							{{ t('news', 'Mark as unread on update') }}
 						</td>
 					</tr>
 					<tr>
@@ -222,19 +222,19 @@
 									</template>
 								</NcActionButton>
 								<NcActionButton
-									v-if="feed.updateMode === FEED_UPDATE_MODE.UNREAD"
+									v-if="feed.updateMode === FEED_UPDATE_MODE.NORMAL"
 									:title="t('news', 'Disable marking items as unread on update')"
 									data-test="disableMarkUnread"
-									@click="setUpdateMode(feed, FEED_UPDATE_MODE.IGNORE)">
+									@click="setUpdateMode(feed, FEED_UPDATE_MODE.SILENT)">
 									<template #icon>
 										<FileDocumentRefresh />
 									</template>
 								</NcActionButton>
 								<NcActionButton
-									v-if="feed.updateMode === FEED_UPDATE_MODE.IGNORE"
+									v-if="feed.updateMode === FEED_UPDATE_MODE.SILENT"
 									:title="t('news', 'Enable marking items as unread on update')"
 									data-test="enableMarkUnread"
-									@click="setUpdateMode(feed, FEED_UPDATE_MODE.UNREAD)">
+									@click="setUpdateMode(feed, FEED_UPDATE_MODE.NORMAL)">
 									<template #icon>
 										<FileDocumentCheck />
 									</template>

--- a/src/dataservices/feed.service.ts
+++ b/src/dataservices/feed.service.ts
@@ -59,7 +59,7 @@ export class FeedService {
 	 * @param param0.pinned {Boolean} should be pinned (true) or not pinned (flse)
 	 * @param param0.ordering {FEED_ORDER} sets feed order (0 = NEWEST, 1 = OLDEST, 2 = DEFAULT)
 	 * @param param0.fullTextEnabled {Boolean} should be full text be enabled (true) or not (flse)
-	 * @param param0.updateMode {FEED_UPDATE_MODE} sets updateMode (0 = UNREAD, 1 = IGNORE)
+	 * @param param0.updateMode {FEED_UPDATE_MODE} sets updateMode (0 = SILENT, 1 = NORMAL)
 	 * @param param0.preventUpdate {boolean} enable/disable feed sync
 	 * @param param0.title {String} title of feed to display
 	 * @return Null value is returned on success

--- a/src/enums/index.ts
+++ b/src/enums/index.ts
@@ -11,8 +11,8 @@ export enum FEED_ORDER {
 }
 
 export enum FEED_UPDATE_MODE {
-	UNREAD = 0,
-	IGNORE = 1,
+	SILENT = 0,
+	NORMAL = 1,
 }
 
 export enum SPLIT_MODE {

--- a/tests/Unit/Service/FeedServiceTest.php
+++ b/tests/Unit/Service/FeedServiceTest.php
@@ -604,15 +604,15 @@ class FeedServiceTest extends TestCase
         $feed = Feed::fromParams([
             'id'         => 1,
             'location'   => 'url.com',
-            'updateMode' => 1,
+            'updateMode' => FEED::UPDATE_MODE_NORMAL,
         ]);
 
         $new_feed = $this->getMockBuilder(Feed::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $item1 = Item::fromParams(['id' => 1, 'body' => '1']);
-        $item2 = Item::fromParams(['id' => 2, 'body' => '2']);
+        $item1 = Item::fromParams(['id' => 1, 'body' => '1', 'unread' => true]);
+        $item2 = Item::fromParams(['id' => 2, 'body' => '2', 'unread' => true]);
         $this->fetcher->expects($this->once())
                       ->method('fetch')
                       ->will($this->returnValue([$new_feed, [$item1, $item2]]));
@@ -633,7 +633,7 @@ class FeedServiceTest extends TestCase
                 return $args[0]; // returnArgument(0)
             });
 
-        $insertOrUpdateCalls = [[$item2], [$item1]];
+        $insertOrUpdateCalls = [[$item2, FEED::UPDATE_MODE_NORMAL], [$item1, FEED::UPDATE_MODE_NORMAL]];
         $insertOrUpdateIndex = 0;
 
         $this->itemService->expects($this->exactly(2))
@@ -663,6 +663,7 @@ class FeedServiceTest extends TestCase
         $item1 = Item::fromParams([
             'id' => 1, 
             'body' => '<p>body content</p>',
+            'unread' => true,
             'mediaDescription' => '<p>media desc with <script>alert("xss")</script></p>'
         ]);
         

--- a/tests/Unit/Service/ImportServiceTest.php
+++ b/tests/Unit/Service/ImportServiceTest.php
@@ -128,7 +128,7 @@ class ImportServiceTest extends TestCase
 
         $this->itemService->expects($this->once())
             ->method('insertOrUpdate')
-            ->with($item);
+            ->with($item, FEED::UPDATE_MODE_SILENT);
 
         $this->purifier->expects($this->once())
             ->method('purify')
@@ -204,7 +204,7 @@ class ImportServiceTest extends TestCase
 
         $this->itemService->expects($this->exactly(2))
             ->method('insertOrUpdate')
-            ->with($item);
+            ->with($item, FEED::UPDATE_MODE_SILENT);
         $this->purifier->expects($this->exactly(2))
             ->method('purify')
             ->with($this->equalTo($item->getBody()))
@@ -261,7 +261,7 @@ class ImportServiceTest extends TestCase
 
         $this->itemService->expects($this->once())
             ->method('insertOrUpdate')
-            ->with($item);
+            ->with($item, FEED::UPDATE_MODE_SILENT);
 
         // Purifier should be called twice: once for body, once for media description
         $purifyCallIndex = 0;

--- a/tests/Unit/Service/ItemServiceTest.php
+++ b/tests/Unit/Service/ItemServiceTest.php
@@ -22,6 +22,7 @@ use OCA\News\Service\Exceptions\ServiceNotFoundException;
 use OCA\News\Service\ItemServiceV2;
 use \OCP\AppFramework\Db\DoesNotExistException;
 
+use \OCA\News\Db\Feed;
 use \OCA\News\Db\Item;
 use \OCA\News\Db\ListType;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
@@ -452,7 +453,7 @@ class ItemServiceTest extends TestCase
             ->with($item)
             ->will($this->returnValue($item));
 
-        $result = $this->class->insertOrUpdate($item);
+        $result = $this->class->insertOrUpdate($item, FEED::UPDATE_MODE_SILENT);
 
         $this->assertEquals($item, $result);
     }
@@ -515,7 +516,7 @@ class ItemServiceTest extends TestCase
             ->with($item)
             ->will($this->returnValue($item));
 
-        $result = $this->class->insertOrUpdate($item);
+        $result = $this->class->insertOrUpdate($item, FEED::UPDATE_MODE_SILENT);
 
         $this->assertEquals($item, $result);
     }
@@ -578,9 +579,49 @@ class ItemServiceTest extends TestCase
             ->with($item)
             ->will($this->returnValue($item));
 
-        $result = $this->class->insertOrUpdate($item);
+        $result = $this->class->insertOrUpdate($item, FEED::UPDATE_MODE_SILENT);
 
         $this->assertEquals($item, $result);
+    }
+
+    public function testInsertOrUpdatePreservesUnread()
+    {
+        $item = Item::fromParams(['id' => 1, 'feedId' => '1', 'guidHash' => 'hash', 'unread' => true]);
+        $db_item = Item::fromParams(['id' => 1, 'feedId' => '1', 'guidHash' => 'hash', 'unread' => false]);
+
+        $this->mapper->expects($this->once())
+            ->method('findByGuidHash')
+            ->with(1, 'hash')
+            ->will($this->returnValue($db_item));
+
+        $this->mapper->expects($this->once())
+            ->method('update')
+            ->with($item)
+            ->will($this->returnValue($item));
+
+        $result = $this->class->insertOrUpdate($item, FEED::UPDATE_MODE_SILENT);
+
+        $this->assertFalse($result->isUnread());
+    }
+
+    public function testInsertOrUpdateUpdatesUnread()
+    {
+        $item = Item::fromParams(['id' => 1, 'feedId' => '1', 'guidHash' => 'hash', 'unread' => true]);
+        $db_item = Item::fromParams(['id' => 1, 'feedId' => '1', 'guidHash' => 'hash', 'unread' => false]);
+
+        $this->mapper->expects($this->once())
+            ->method('findByGuidHash')
+            ->with(1, 'hash')
+            ->will($this->returnValue($db_item));
+
+        $this->mapper->expects($this->once())
+            ->method('update')
+            ->with($item)
+            ->will($this->returnValue($item));
+
+        $result = $this->class->insertOrUpdate($item, FEED::UPDATE_MODE_NORMAL);
+
+        $this->assertTrue($result->isUnread());
     }
 
     public function testFindByGuidHash()

--- a/tests/javascript/unit/components/modals/FeedInfoTable.spec.ts
+++ b/tests/javascript/unit/components/modals/FeedInfoTable.spec.ts
@@ -19,7 +19,7 @@ describe('FeedInfoTable.vue', () => {
 		nextUpdateTime: 1,
 		articlesPerUpdate: 150,
 		updateErrorCount: 20,
-		updateMode: FEED_UPDATE_MODE.UNREAD,
+		updateMode: FEED_UPDATE_MODE.NORMAL,
 		fullTextEnabled: false,
 		preventUpdate: true,
 	}, {
@@ -30,7 +30,7 @@ describe('FeedInfoTable.vue', () => {
 		nextUpdateTime: 4,
 		articlesPerUpdate: 50,
 		updateErrorCount: 40,
-		updateMode: FEED_UPDATE_MODE.IGNORE,
+		updateMode: FEED_UPDATE_MODE.SILENT,
 		fullTextEnabled: true,
 		preventUpdate: false,
 	}, {
@@ -41,7 +41,7 @@ describe('FeedInfoTable.vue', () => {
 		nextUpdateTime: 8,
 		articlesPerUpdate: 20,
 		updateErrorCount: 0,
-		updateMode: FEED_UPDATE_MODE.UNREAD,
+		updateMode: FEED_UPDATE_MODE.NORMAL,
 		fullTextEnabled: true,
 		preventUpdate: true,
 	}]
@@ -325,7 +325,7 @@ describe('FeedInfoTable.vue', () => {
 			expect(store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_PREVENT_UPDATE, { feed: feeds[1], preventUpdate: true })
 		})
 
-		it('should dispatch setUpdateMode on click with FEED_UPDATE_MODE.IGNORE', async () => {
+		it('should dispatch setUpdateMode on click with FEED_UPDATE_MODE.SILENT', async () => {
 			const actions = wrapper.findAllComponents({ name: 'NcActions' })
 				.find((ncactions) => ncactions.attributes('data-test') === 'feedOptions-1')
 
@@ -334,7 +334,7 @@ describe('FeedInfoTable.vue', () => {
 			expect(button).toBeTruthy()
 			await button.trigger('click')
 
-			expect(store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_UPDATE_MODE, { feed: feeds[0], updateMode: FEED_UPDATE_MODE.IGNORE })
+			expect(store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_UPDATE_MODE, { feed: feeds[0], updateMode: FEED_UPDATE_MODE.SILENT })
 		})
 
 		it('should dispatch setUpdateMode on click with FEED_UPDATE_MODE.NORMAL', async () => {
@@ -346,7 +346,7 @@ describe('FeedInfoTable.vue', () => {
 			expect(button).toBeTruthy()
 			await button.trigger('click')
 
-			expect(store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_UPDATE_MODE, { feed: feeds[1], updateMode: FEED_UPDATE_MODE.UNREAD })
+			expect(store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SET_UPDATE_MODE, { feed: feeds[1], updateMode: FEED_UPDATE_MODE.NORMAL })
 		})
 
 		it('should dispatch setFullText on click with fullTextEnabled true', async () => {

--- a/tests/javascript/unit/store/feed.spec.ts
+++ b/tests/javascript/unit/store/feed.spec.ts
@@ -162,9 +162,9 @@ describe('feed.ts', () => {
 			it('should call FeedService.updateFeed and commit updated `updateMode` property to state', async () => {
 				FeedService.updateFeed = vi.fn()
 				const commit = vi.fn()
-				await actions[FEED_ACTION_TYPES.FEED_SET_UPDATE_MODE]({ commit }, { feed: { id: 1 }, updateMode: FEED_UPDATE_MODE.IGNORE })
-				expect(FeedService.updateFeed).toBeCalledWith({ feedId: 1, updateMode: FEED_UPDATE_MODE.IGNORE })
-				expect(commit).toBeCalledWith(FEED_MUTATION_TYPES.UPDATE_FEED, { id: 1, updateMode: FEED_UPDATE_MODE.IGNORE })
+				await actions[FEED_ACTION_TYPES.FEED_SET_UPDATE_MODE]({ commit }, { feed: { id: 1 }, updateMode: FEED_UPDATE_MODE.SILENT })
+				expect(FeedService.updateFeed).toBeCalledWith({ feedId: 1, updateMode: FEED_UPDATE_MODE.SILENT })
+				expect(commit).toBeCalledWith(FEED_MUTATION_TYPES.UPDATE_FEED, { id: 1, updateMode: FEED_UPDATE_MODE.SILENT })
 			})
 		})
 


### PR DESCRIPTION
## Summary
This PR fixes the feed update mode to set updated items to unread when updated.

The feature is broken since the change in bfcf38a480, which always uses the unread state from the db item. 
In the frontend, the options have been swapped since at least fe034782f7.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
