### PR TITLE
fix: update existing items when reloaded from backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 
 ### Fixed
+- Update items that have been reloaded from the backend
 
 # Releases
 ## [28.2.0-beta.2] - 2026-04-08

--- a/src/components/routes/All.vue
+++ b/src/components/routes/All.vue
@@ -43,11 +43,10 @@ export default defineComponent({
 
 	created() {
 		/*
-		 * When sorting newest to oldest lastItemLoaded needs to be reset to get new items for this route
+		 * Reset the offset so that updated items can be fetched again when changing the route
 		 */
-		if (this.oldestFirst === false) {
-			this.$store.commit(MUTATIONS.SET_LAST_ITEM_LOADED, { key: 'all', lastItem: undefined })
-		}
+		this.$store.commit(MUTATIONS.SET_LAST_ITEM_LOADED, { key: 'all', lastItem: undefined })
+		this.$store.commit(MUTATIONS.SET_ALL_LOADED, { key: 'all', loaded: false })
 	},
 
 	methods: {

--- a/src/components/routes/Feed.vue
+++ b/src/components/routes/Feed.vue
@@ -85,11 +85,10 @@ export default defineComponent({
 		feedId: {
 			handler() {
 				/*
-				 * When sorting newest to oldest lastItemLoaded needs to be reset to get new items for this route
+				 * Reset the offset so that updated items can be fetched again when changing the route
 				 */
-				if (this.oldestFirst === false) {
-					this.$store.commit(MUTATIONS.SET_LAST_ITEM_LOADED, { key: 'feed-' + this.feedId, lastItem: undefined })
-				}
+				this.$store.commit(MUTATIONS.SET_LAST_ITEM_LOADED, { key: 'feed-' + this.feedId, lastItem: undefined })
+				this.$store.commit(MUTATIONS.SET_ALL_LOADED, { key: 'feed-' + this.feedId, loaded: false })
 			},
 
 			immediate: true,

--- a/src/components/routes/Folder.vue
+++ b/src/components/routes/Folder.vue
@@ -96,11 +96,10 @@ export default defineComponent({
 		folderId: {
 			handler() {
 				/*
-				 * When sorting newest to oldest lastItemLoaded needs to reset to get new items for this route
+				 * Reset the offset so that updated items can be fetched again when changing the route
 				 */
-				if (this.oldestFirst === false) {
-					this.$store.commit(MUTATIONS.SET_LAST_ITEM_LOADED, { key: 'folder-' + this.folderId, lastItem: undefined })
-				}
+				this.$store.commit(MUTATIONS.SET_LAST_ITEM_LOADED, { key: 'folder-' + this.folderId, lastItem: undefined })
+				this.$store.commit(MUTATIONS.SET_ALL_LOADED, { key: 'folder-' + this.folderId, loaded: false })
 			},
 
 			immediate: true,

--- a/src/components/routes/Starred.vue
+++ b/src/components/routes/Starred.vue
@@ -81,11 +81,10 @@ export default defineComponent({
 
 	created() {
 		/*
-		 * When sorting newest to oldest lastItemLoaded needs to be reset to get new items for this route
+		 * Reset the offset so that updated items can be fetched again when changing the route
 		 */
-		if (this.oldestFirst === false) {
-			this.$store.commit(MUTATIONS.SET_LAST_ITEM_LOADED, { key: this.fetchKey, lastItem: undefined })
-		}
+		this.$store.commit(MUTATIONS.SET_LAST_ITEM_LOADED, { key: this.fetchKey, lastItem: undefined })
+		this.$store.commit(MUTATIONS.SET_ALL_LOADED, { key: this.fetchKey, loaded: false })
 	},
 
 	methods: {

--- a/src/components/routes/Unread.vue
+++ b/src/components/routes/Unread.vue
@@ -78,11 +78,10 @@ export default defineComponent({
 
 	created() {
 		/*
-		 * When sorting newest to oldest lastItemLoaded needs to be reset to get new items for this route
+		 * Reset the offset so that updated items can be fetched again when changing the route
 		 */
-		if (this.oldestFirst === false) {
-			this.$store.commit(MUTATIONS.SET_LAST_ITEM_LOADED, { key: 'unread', lastItem: undefined })
-		}
+		this.$store.commit(MUTATIONS.SET_LAST_ITEM_LOADED, { key: 'unread', lastItem: undefined })
+		this.$store.commit(MUTATIONS.SET_ALL_LOADED, { key: 'unread', loaded: false })
 	},
 
 	methods: {

--- a/src/store/item.ts
+++ b/src/store/item.ts
@@ -439,31 +439,55 @@ export const mutations = {
 
 	[FEED_ITEM_MUTATION_TYPES.SET_ITEMS](
 		state: ItemState,
-		items: FeedItem[],
+		items?: FeedItem[],
 	) {
-		if (items) {
-			let newestFetchedItemId = 0
-			const newItems: FeedItem[] = []
+		if (!items) {
+			return
+		}
 
-			items.forEach((it) => {
-				if (state.allItems.find((existing: FeedItem) => existing.id === it.id) === undefined) {
-					if (!it.title) {
-						it.title = it.url
-					}
-					newItems.push(it)
-					if (state.newestItemId < Number(it.id)) {
-						newestFetchedItemId = Number(it.id)
-					}
+		let newestFetchedItemId = state.newestItemId
+
+		const itemIndexMap = new Map<number, number>()
+		state.allItems.forEach((item, index) => {
+			itemIndexMap.set(Number(item.id), index)
+		})
+
+		const updatedMap = new Map<number, FeedItem>()
+		const newItems: FeedItem[] = []
+
+		for (const it of items) {
+			const id = Number(it.id)
+			const itemIndex = itemIndexMap.get(id)
+
+			if (!it.title) {
+				it.title = it.url
+			}
+
+			if (itemIndex === undefined) {
+				newItems.push(it)
+
+				if (id > newestFetchedItemId) {
+					newestFetchedItemId = id
 				}
-			})
-
-			if (newItems.length > 0) {
-				state.allItems = [...state.allItems, ...newItems]
+			} else {
+				const item = state.allItems[itemIndex]
+				updatedMap.set(Number(item.id), {
+					...item,
+					...it,
+				})
 			}
+		}
 
-			if (newestFetchedItemId > state.newestItemId) {
-				state.syncNeeded = true
-			}
+		const mergedItems = state.allItems.map((item) => {
+			const id = Number(item.id)
+			const updated = updatedMap.get(id)
+			return updated ?? item
+		})
+
+		state.allItems = [...mergedItems, ...newItems]
+
+		if (newestFetchedItemId > state.newestItemId) {
+			state.syncNeeded = true
 		}
 	},
 

--- a/tests/javascript/unit/components/routes/Feed.spec.ts
+++ b/tests/javascript/unit/components/routes/Feed.spec.ts
@@ -85,6 +85,9 @@ describe('Feed.vue', () => {
 				SET_LAST_ITEM_LOADED(state, { key, lastItem }) {
 					state.items.lastItemLoaded[key] = lastItem
 				},
+				SET_ALL_LOADED(state, { key, loaded }) {
+					state.items.allItemsLoaded[key] = loaded
+				},
 			},
 			getters: {
 				feeds: () => [mockFeed],

--- a/tests/javascript/unit/store/item.spec.ts
+++ b/tests/javascript/unit/store/item.spec.ts
@@ -278,7 +278,7 @@ describe('item.ts', () => {
 		})
 
 		describe('SET_ITEMS', () => {
-			it('should add feeds to state', () => {
+			it('should add items to state', () => {
 				const state = { allItems: [] }
 				let items = []
 
@@ -294,6 +294,24 @@ describe('item.ts', () => {
 				items = [{ title: 'test2', id: 234 }]
 				mutations[FEED_ITEM_MUTATION_TYPES.SET_ITEMS](state, items)
 				expect(state.allItems.length).toEqual(2)
+			})
+
+			it('should update items in state', () => {
+				const state = { allItems: [
+					{ id: 1, feedId: 123, title: 'item1', unread: false },
+					{ id: 2, feedId: 345, title: 'item2', unread: true },
+					{ id: 3, feedId: 678, title: 'item3', unread: false },
+				] }
+				const items = [
+					{ id: 1, feedId: 123, title: 'item1', unread: true },
+					{ id: 2, feedId: 345, title: 'item2 updated', unread: true },
+				]
+
+				mutations[FEED_ITEM_MUTATION_TYPES.SET_ITEMS](state, items)
+				expect(state.allItems.length).toEqual(3)
+				expect(state.allItems[0].unread).toBeTruthy()
+				expect(state.allItems[1].title).toEqual('item2 updated')
+				expect(state.allItems[2].title).toEqual('item3')
 			})
 
 			it('should not add duplicates', () => {
@@ -327,6 +345,19 @@ describe('item.ts', () => {
 
 				mutations[FEED_ITEM_MUTATION_TYPES.SET_ITEMS](state, items)
 				expect(state.allItems[0].title).toEqual('https://feedurl')
+			})
+
+			it('should not change state when items undefined', () => {
+				const state = { allItems: [{ id: 1, title: 'abc' }] } as AppState
+				const originalAllItems = state.allItems
+				const originalState = {
+					...state,
+					allItems: state.allItems.map((item) => ({ ...item })),
+				}
+
+				mutations[FEED_ITEM_MUTATION_TYPES.SET_ITEMS](state, undefined)
+				expect(state).toEqual(originalState)
+				expect(state.allItems).toBe(originalAllItems)
 			})
 		})
 


### PR DESCRIPTION
## Summary

A side effect of the unread fix (#3668) is that the offset must now also be reset when sorting in reverse order so that older items are retrieved, just as already required for new items and normal sorting.
The frontend currently ignores also updates to items that have already been loaded and only reloads them if the list is manually refreshed using the reload button or the “r” shortcut.

This PR changes that, so that when you switch between routes, older updated items are displayed immediately.

The only thing that remains is that if you stay on a route for a while and the backend updates older items, you now also need to manually refresh when using reverse sorting if you want to stay on the current route and read the updated items.
Until now, this was only necessary when using the standard sort order to view new items without changing the route.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
