### PR TITLE
Release 28.3.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 # Unreleased
 ### Changed
+
+### Fixed
+
+# Releases
+## [28.3.0-beta.1] - 2026-04-25
+### Changed
 - Replace direct Guzzle HTTP client usage with Nextcloud's `IClientService` for SSRF protection and automatic system proxy support (#3672, #3671, #3679)
 
 ### Fixed
 - Starred view fired an endless stream of requests due to a `fetchKey` mismatch between the component and the store (#3682)
 
-# Releases
 ## [28.2.0] - 2026-04-20
 ### Fixed
 - Update items that have been reloaded from the backend (#3677)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>28.2.0</version>
+    <version>28.3.0-beta.1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
## Summary

Changed
- Replace direct Guzzle HTTP client usage with Nextcloud's `IClientService` for SSRF protection and automatic system proxy support (#3672, #3671, #3679)

Fixed
- Starred view fired an endless stream of requests due to a `fetchKey` mismatch between the component and the store (#3682)


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
