### PR TITLE
Release 28.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Fixed
 
 # Releases
+## [28.3.0] - 2026-05-01
+### Security
+- **Update recommended**: Replaces direct Guzzle HTTP client with Nextcloud's `IClientService`, adding SSRF protection. Security advisory pending. 
+
 ## [28.3.0-beta.1] - 2026-04-25
 ### Changed
 - Replace direct Guzzle HTTP client usage with Nextcloud's `IClientService` for SSRF protection and automatic system proxy support (#3672, #3671, #3679)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>28.3.0-beta.1</version>
+    <version>28.3.0</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

### Security
- **Update recommended**: Replaces direct Guzzle HTTP client with Nextcloud's `IClientService`, adding SSRF protection. Security advisory pending.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
