### PR TITLE
fix: use nextcloud style input fields for the new filter dialog and add some tests

### DIFF
--- a/src/components/modals/FeedInfoTable.vue
+++ b/src/components/modals/FeedInfoTable.vue
@@ -305,9 +305,15 @@
 				</tbody>
 			</table>
 		</div>
-		<NcModal v-if="filterFeed" size="small" @close="closeFilterDialog()">
+		<NcModal
+			v-if="filterFeed"
+			labelId="feed-filter-dialog"
+			size="small"
+			@close="closeFilterDialog()">
 			<div class="filter-dialog">
-				<h3>{{ t('news', 'Keyword Filters for {feed}', { feed: filterFeed.title }) }}</h3>
+				<h3 id="feed-filter-dialog">
+					{{ t('news', 'Keyword Filters for {feed}', { feed: filterFeed.title }) }}
+				</h3>
 				<p class="filter-help-text">
 					{{ t('news', 'Matching is case-insensitive. Title and body keywords match whole words, while URL keywords match URL fragments.') }}
 				</p>
@@ -315,14 +321,24 @@
 					{{ filterDialogError }}
 				</NcNoteCard>
 
-				<label for="filter-title-keywords">{{ t('news', 'Title keywords') }}</label>
-				<input id="filter-title-keywords" v-model="filterForm.titleKeywords" :placeholder="t('news', 'e.g. android, ios')">
+				<div class="filter-inputs">
+					<NcTextField
+						id="filter-title-keywords"
+						v-model:modelValue="filterForm.titleKeywords"
+						:label="t('news', 'Title keywords')"
+						:placeholder="t('news', 'e.g. android, ios')" />
+					<NcTextField
+						id="filter-body-keywords"
+						v-model:modelValue="filterForm.bodyKeywords"
+						:label="t('news', 'Body keywords')"
+						:placeholder="t('news', 'e.g. advertisement')" />
 
-				<label for="filter-body-keywords">{{ t('news', 'Body keywords') }}</label>
-				<input id="filter-body-keywords" v-model="filterForm.bodyKeywords" :placeholder="t('news', 'e.g. advertisement')">
-
-				<label for="filter-url-keywords">{{ t('news', 'URL keywords') }}</label>
-				<input id="filter-url-keywords" v-model="filterForm.urlKeywords" :placeholder="t('news', 'e.g. /sport/')">
+					<NcTextField
+						id="filter-url-keywords"
+						v-model:modelValue="filterForm.urlKeywords"
+						:label="t('news', 'URL keywords')"
+						:placeholder="t('news', 'e.g. /sport/')" />
+				</div>
 
 				<div class="filter-actions">
 					<NcButton :disabled="filterDialogSaving" @click="saveFilter()">
@@ -345,6 +361,7 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcModal from '@nextcloud/vue/components/NcModal'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
+import NcTextField from '@nextcloud/vue/components/NcTextField'
 import FileDocumentCheck from 'vue-material-design-icons/FileDocumentCheck.vue'
 import FileDocumentRefresh from 'vue-material-design-icons/FileDocumentRefresh.vue'
 import FilterIcon from 'vue-material-design-icons/Filter.vue'
@@ -368,6 +385,7 @@ export default {
 		NcLoadingIcon,
 		NcModal,
 		NcNoteCard,
+		NcTextField,
 		MoveFeed,
 		SidebarFeedLinkActions,
 		FileDocumentRefresh,
@@ -652,19 +670,10 @@ export default {
 			margin-bottom: 12px;
 		}
 
-		label {
-			display: block;
-			margin-bottom: 4px;
-			font-weight: bold;
-		}
-
-		input {
-			display: block;
-			width: 100%;
-			margin-bottom: 12px;
-			padding: 8px;
-			border: 1px solid var(--color-border);
-			border-radius: 4px;
+		.filter-inputs {
+			display: flex;
+			flex-direction: column;
+			gap: 8px;
 		}
 
 		.filter-actions {

--- a/tests/javascript/unit/components/modals/FeedInfoTable.spec.ts
+++ b/tests/javascript/unit/components/modals/FeedInfoTable.spec.ts
@@ -426,6 +426,64 @@ describe('FeedInfoTable.vue', () => {
 		})
 	})
 
+	describe('Feed Filter dialog', () => {
+		beforeEach(() => {
+			store = new Vuex.Store({
+				state: {
+					feeds: { feeds },
+					folders: { folders },
+				},
+				getters: {
+					feeds: () => feeds,
+					folders: () => folders,
+				},
+			})
+			store.dispatch = vi.fn()
+			wrapper = mount(FeedInfoTable, {
+				global: { plugins: [store] },
+				stubs: {
+					SidebarFeedLinkActions: true,
+				},
+			})
+		})
+		it('Should update title filter via v-model', async () => {
+			await wrapper.vm.openFilterDialog(feeds[0])
+
+			expect(store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_GET_FILTER, { feed: feeds[0] })
+
+			const textField = wrapper.findAllComponents({ name: 'NcTextField' })
+				.find((c) => c.props('id') === 'filter-title-keywords')
+			await textField.setValue('filter text')
+			await wrapper.vm.saveFilter()
+
+			expect(store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SAVE_FILTER, { feed: feeds[0], titleKeywords: 'filter text', bodyKeywords: '', urlKeywords: '' })
+		})
+		it('Should update body filter via v-model', async () => {
+			await wrapper.vm.openFilterDialog(feeds[0])
+
+			expect(store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_GET_FILTER, { feed: feeds[0] })
+
+			const textField = wrapper.findAllComponents({ name: 'NcTextField' })
+				.find((c) => c.props('id') === 'filter-body-keywords')
+			await textField.setValue('filter text')
+			await wrapper.vm.saveFilter()
+
+			expect(store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SAVE_FILTER, { feed: feeds[0], titleKeywords: '', bodyKeywords: 'filter text', urlKeywords: '' })
+		})
+		it('Should update url filter via v-model', async () => {
+			await wrapper.vm.openFilterDialog(feeds[0])
+
+			expect(store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_GET_FILTER, { feed: feeds[0] })
+
+			const textField = wrapper.findAllComponents({ name: 'NcTextField' })
+				.find((c) => c.props('id') === 'filter-url-keywords')
+			await textField.setValue('filter text')
+			await wrapper.vm.saveFilter()
+
+			expect(store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_SAVE_FILTER, { feed: feeds[0], titleKeywords: '', bodyKeywords: '', urlKeywords: 'filter text' })
+		})
+	})
+
 	afterEach(() => {
 		vi.clearAllMocks()
 	})


### PR DESCRIPTION
## Summary

This PR changes the input fields for the new filter feature to nextcloud components to keep the nextcloud styling.
It also adds a labelId to the filter dialog for accessibility and some tests.

<table>
<tr>
<td>
old:
<img width="409" height="479" alt="grafik" src="https://github.com/user-attachments/assets/cadeb485-4931-4dd4-a120-97a2b95dec8f" />
</td>
<td>
new:
<img width="409" height="406" alt="grafik" src="https://github.com/user-attachments/assets/57c63156-0c10-4f2a-b799-8c9b0179b0a6" />
</td>
</tr>
<tr>
<td>
old:
<img width="409" height="479" alt="grafik" src="https://github.com/user-attachments/assets/ed443ceb-e568-4850-9dc1-f537a5990375" />
</td>
<td>
new:
<img width="409" height="406" alt="grafik" src="https://github.com/user-attachments/assets/852eb1f7-676c-451d-a812-1ce7de9b9432" />
</td>
</tr>
</table>

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
