### PR TITLE
Release 28.4.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,27 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 # Unreleased
 ### Added
-- Feed keyword filtering: hide articles matching keywords in title, body, or URL
-- Feed settings now support selecting multiple feeds and moving/deleting them in throttled, sequential requests.
 
 ### Changed
-- Replace `arthurhoaro/favicon` with `php-feed-io/favicon-io` for favicon discovery, using PSR-based HTTP interfaces and Symfony-backed discovery caching (#3710)
 
 ### Fixed
 
 # Releases
+## [28.4.0-beta.1] - 2026-05-10
+### Changed
+- Feed keyword filtering: hide articles matching keywords in title, body, or URL (#3711)
+
+  New occ commands:
+  ```bash
+  news:feed:filter:get
+  news:feed:filter:set
+  news:feed:filter:delete
+  ```
+  Added API v1-3 `GET|POST|DELETE /api/v1-3/feeds/{feedId}/filter` 
+
+- Feed settings now support selecting multiple feeds and moving/deleting them in throttled, sequential requests. (#3728)
+- Replace `arthurhoaro/favicon` with `php-feed-io/favicon-io` for favicon discovery, using PSR-based HTTP interfaces and Symfony-backed discovery caching (#3710)
+
 ## [28.3.0] - 2026-05-01
 ### Security
 - **Update recommended**: Replaces direct Guzzle HTTP client with Nextcloud's `IClientService`, adding SSRF protection. Security advisory pending. 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>28.3.0</version>
+    <version>28.4.0-beta.1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

### Changed
- Feed keyword filtering: hide articles matching keywords in title, body, or URL (#3711)

  New occ commands: ```bash news:feed:filter:get news:feed:filter:set news:feed:filter:delete ``` Added API v1-3 `GET|POST|DELETE /api/v1-3/feeds/{feedId}/filter`

- Feed settings now support selecting multiple feeds and moving/deleting them in throttled, sequential requests. (#3728)
- Replace `arthurhoaro/favicon` with `php-feed-io/favicon-io` for favicon discovery, using PSR-based HTTP interfaces and Symfony-backed discovery caching (#3710)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
