### PR TITLE
fix: NcCheckBoxRadioSwitch requires value as string

### DIFF
--- a/src/components/modals/FeedInfoTable.vue
+++ b/src/components/modals/FeedInfoTable.vue
@@ -266,7 +266,7 @@
 						<td class="select-column">
 							<NcCheckboxRadioSwitch
 								v-model="selectedFeedIds"
-								:value="feed.id"
+								:value="String(feed.id)"
 								:disabled="processingBatch"
 								:aria-label="t('news', 'Select feed {feed}', { feed: feed.title || String(feed.id) })"
 								:data-test="'selectFeed-' + feed.id"
@@ -543,7 +543,7 @@ export default {
 
 		selectedFeeds() {
 			const selectedFeedIdSet = new Set(this.selectedFeedIds)
-			return this.feeds.filter((feed) => selectedFeedIdSet.has(feed.id))
+			return this.feeds.filter((feed) => selectedFeedIdSet.has(String(feed.id)))
 		},
 
 		sortedFeeds() {
@@ -633,7 +633,7 @@ export default {
 
 		toggleSelectAllByValue(checked) {
 			if (checked) {
-				this.selectedFeedIds = this.sortedFeeds.map((feed) => feed.id)
+				this.selectedFeedIds = this.sortedFeeds.map((feed) => String(feed.id))
 				return
 			}
 			this.selectedFeedIds = []

--- a/tests/javascript/unit/components/modals/FeedInfoTable.spec.ts
+++ b/tests/javascript/unit/components/modals/FeedInfoTable.spec.ts
@@ -174,14 +174,14 @@ describe('FeedInfoTable.vue', () => {
 
 		it('should toggle selecting all feeds', () => {
 			wrapper.vm.toggleSelectAllByValue(true)
-			expect(wrapper.vm.selectedFeedIds).toEqual([1, 2, 3])
+			expect(wrapper.vm.selectedFeedIds).toEqual(['1', '2', '3'])
 
 			wrapper.vm.toggleSelectAllByValue(false)
 			expect(wrapper.vm.selectedFeedIds).toEqual([])
 		})
 
 		it('should open move selected feeds dialog with selected feeds', () => {
-			wrapper.vm.selectedFeedIds = [1, 2]
+			wrapper.vm.selectedFeedIds = ['1', '2']
 
 			wrapper.vm.openMoveSelectedFeedsDialog()
 
@@ -204,7 +204,7 @@ describe('FeedInfoTable.vue', () => {
 			store.dispatch = vi.fn().mockResolvedValue(undefined)
 			const pauseSpy = vi.spyOn(wrapper.vm, 'pauseBetweenBatchRequests').mockResolvedValue(undefined)
 
-			wrapper.vm.selectedFeedIds = [1, 2]
+			wrapper.vm.selectedFeedIds = ['1', '2']
 			await wrapper.vm.deleteSelectedFeeds()
 
 			expect(store.dispatch).toHaveBeenNthCalledWith(1, ACTIONS.FEED_DELETE, { feed: feeds[0] })
@@ -216,9 +216,10 @@ describe('FeedInfoTable.vue', () => {
 
 		it('should show an error if deleting selected feeds fails', async () => {
 			vi.spyOn(window, 'confirm').mockReturnValue(true)
+			vi.spyOn(console, 'error').mockImplementation(() => {})
 			store.dispatch = vi.fn().mockRejectedValue(new Error('delete failed'))
 
-			wrapper.vm.selectedFeedIds = [1]
+			wrapper.vm.selectedFeedIds = ['1']
 			await wrapper.vm.deleteSelectedFeeds()
 
 			expect(store.dispatch).toHaveBeenCalledWith(ACTIONS.FEED_DELETE, { feed: feeds[0] })


### PR DESCRIPTION
## Summary

This PR fixes a type mismatch for the value prop in NcCheckboxRadioSwitch which should be a string.

```
stderr | tests/javascript/unit/components/modals/FeedInfoTable.spec.ts > FeedInfoTable.vue > Loading State > should show loading note card when loading is true
[Vue warn]: Invalid prop: type check failed for prop "value". Expected String with value "1", got Number with value 1.
  at <NcCheckboxRadioSwitch modelValue= [] onUpdate:modelValue=fn value=1  ... >
  at <Transition name="modal-in" appear="" >
  at <Transition name="fade" appear="" onAfterEnter=fn<useFocusTrap>  ... >
  at <NcModal size="large" labelId="feed-settings-dialog" closeOnClickOutside=true  ... >
  at <FeedInfoTable ref="VTU_COMPONENT" >
  at <VTUROOT>
```

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
