### PR TITLE
feat(MoveFeed): show status during move feed action

### DIFF
--- a/src/components/MoveFeed.vue
+++ b/src/components/MoveFeed.vue
@@ -18,8 +18,8 @@
 			<NcButton
 				:wide="true"
 				variant="primary"
-				:disabled="disableMoveFeed || moving"
-				@click="moveFeed()">
+				:disabled="disableMoveFeed || Boolean(movingToast)"
+				@click="moveFeeds()">
 				{{ t("news", "Move") }}
 			</NcButton>
 		</template>
@@ -30,7 +30,7 @@
 
 import type { Folder } from '../types/Folder.ts'
 
-import { showError } from '@nextcloud/dialogs'
+import { showError, showLoading } from '@nextcloud/dialogs'
 import { defineComponent } from 'vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcDialog from '@nextcloud/vue/components/NcDialog'
@@ -39,7 +39,7 @@ import { ACTIONS } from '../store/index.ts'
 
 type MoveFeedState = {
 	folder: Folder | null
-	moving: boolean
+	movingToast: ReturnType<typeof showLoading> | null
 	batchRequestDelay: number
 }
 
@@ -52,20 +52,11 @@ export default defineComponent({
 
 	props: {
 		/**
-		 * The feed to move
+		 * The feeds to move
 		 */
-		feed: {
-			type: Object,
-			required: false,
-			default: () => {
-				return { url: '' }
-			},
-		},
-
 		feeds: {
 			type: Array,
-			required: false,
-			default: () => [],
+			required: true,
 		},
 	},
 
@@ -76,7 +67,7 @@ export default defineComponent({
 	data: (): MoveFeedState => {
 		return {
 			folder: null,
-			moving: false,
+			movingToast: null,
 			batchRequestDelay: 150,
 		}
 	},
@@ -91,14 +82,18 @@ export default defineComponent({
 		},
 
 		isBatchMove(): boolean {
-			return Array.isArray(this.feeds) && this.feeds.length > 0
+			return Array.isArray(this.feeds) && this.feeds.length > 1
 		},
 
 		disableMoveFeed(): boolean {
 			if (this.isBatchMove) {
 				return false
 			}
-			return (this.folder && this.folder.id === this.feed.folderId)
+			const firstFeed = this.feeds?.[0]
+			if (!firstFeed) {
+				return true
+			}
+			return (this.folder && this.folder.id === firstFeed.folderId)
 		},
 	},
 
@@ -110,55 +105,39 @@ export default defineComponent({
 		/**
 		 * Move a Feed via the Vuex Store
 		 */
-		async moveFeed() {
-			this.moving = true
+		async moveFeeds() {
+			this.movingToast = showLoading(t('news', 'Moving feeds…'))
 			const folderId = this.folder ? this.folder.id : 0
 
-			if (this.isBatchMove) {
-				let failedMoves = 0
-				const feedsToMove = this.feeds.filter((feed) => (typeof feed.folderId === 'number' ? feed.folderId : 0) !== folderId)
-				try {
-					for (const [index, feed] of feedsToMove.entries()) {
-						try {
-							const response = await this.$store.dispatch(ACTIONS.MOVE_FEED, { feedId: feed.id, folderId })
-							if (!response?.status || response.status < 200 || response.status >= 300) {
-								failedMoves++
-							}
-						} catch {
+			let failedMoves = 0
+			const feedsToMove = this.feeds.filter((feed) => (typeof feed.folderId === 'number' ? feed.folderId : 0) !== folderId)
+			try {
+				for (const [index, feed] of feedsToMove.entries()) {
+					try {
+						const response = await this.$store.dispatch(ACTIONS.MOVE_FEED, { feedId: feed.id, folderId })
+						if (!response?.status || response.status < 200 || response.status >= 300) {
 							failedMoves++
 						}
-
-						if (index < feedsToMove.length - 1) {
-							await this.pauseBetweenBatchRequests()
-						}
+					} catch {
+						failedMoves++
 					}
-					await this.$store.dispatch(ACTIONS.FETCH_FEEDS)
-				} finally {
-					this.moving = false
+
+					if (index < feedsToMove.length - 1) {
+						await this.pauseBetweenBatchRequests()
+					}
 				}
-
-				if (failedMoves > 0) {
-					showError(t('news', 'Some selected feeds could not be moved. Please try again later or check your connection.'))
-					return
-				}
-
-				this.$emit('close')
-				return
-			}
-
-			const data = {
-				feedId: this.feed.id,
-				folderId,
-			}
-			let response
-			try {
-				response = await this.$store.dispatch(ACTIONS.MOVE_FEED, data)
 			} finally {
-				this.moving = false
+				this.movingToast?.hideToast()
+				this.movingToast = null
 			}
-			if (!response?.status || response.status < 200 || response.status >= 300) {
-				showError(t('news', 'Unable to move feed. Please try again later or check your connection.'))
-				return
+
+			if (failedMoves > 0) {
+				if (feedsToMove.length === 1) {
+					showError(t('news', 'Unable to move feed. Please try again later or check your connection.'))
+					return
+				} else {
+					showError(t('news', 'Some selected feeds could not be moved. Please try again later or check your connection.'))
+				}
 			}
 			await this.$store.dispatch(ACTIONS.FETCH_FEEDS)
 

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,7 +1,7 @@
 <template>
 	<NcAppNavigation>
 		<AddFeed v-if="showAddFeed" @close="closeAddFeed()" />
-		<MoveFeed v-if="showMoveFeed" :feed="feedToMove" @close="closeMoveFeed()" />
+		<MoveFeed v-if="showMoveFeed" :feeds="[feedToMove]" @close="closeMoveFeed()" />
 		<FeedInfoTable v-if="showFeedSettings" @close="closeFeedSettings()" />
 		<AppSettingsDialog v-if="showSettings" @close="closeSettings()" />
 		<NcAppNavigationNew

--- a/src/components/modals/FeedInfoTable.vue
+++ b/src/components/modals/FeedInfoTable.vue
@@ -5,7 +5,6 @@
 <template>
 	<MoveFeed
 		v-if="showMoveFeed"
-		:feed="feedToMove"
 		:feeds="feedsToMove"
 		@close="closeMoveFeed()" />
 	<NcModal
@@ -60,7 +59,7 @@
 				<tbody>
 					<tr>
 						<th colspan="4">
-							{{ t('news', 'Fetch options') }}
+							{{ t('news', 'Feed fetch options') }}
 						</th>
 					</tr>
 					<tr>
@@ -473,7 +472,6 @@ export default {
 
 	data() {
 		return {
-			feedToMove: undefined,
 			feedsToMove: [],
 			showMoveFeed: false,
 			selectedFeedIds: [],
@@ -640,8 +638,7 @@ export default {
 		},
 
 		openMoveFeed(feed) {
-			this.feedsToMove = []
-			this.feedToMove = feed
+			this.feedsToMove = [feed]
 			this.showMoveFeed = true
 		},
 
@@ -649,13 +646,11 @@ export default {
 			if (!this.canMoveSelected) {
 				return
 			}
-			this.feedToMove = undefined
 			this.feedsToMove = [...this.selectedFeeds]
 			this.showMoveFeed = true
 		},
 
 		closeMoveFeed() {
-			this.feedToMove = undefined
 			this.feedsToMove = []
 			this.showMoveFeed = false
 		},

--- a/tests/javascript/unit/components/MoveFeed.spec.ts
+++ b/tests/javascript/unit/components/MoveFeed.spec.ts
@@ -27,7 +27,7 @@ describe('MoveFeed.vue', () => {
 		vi.clearAllMocks()
 		wrapper = shallowMount(MoveFeed, {
 			props: {
-				feed: { id: 1, folderId: 1 },
+				feeds: [{ id: 1, folderId: 1 }],
 			},
 			global: {
 				mocks: {
@@ -38,12 +38,12 @@ describe('MoveFeed.vue', () => {
 		wrapper.vm.$data.folder = { id: 2, name: 'Folder 2' }
 	})
 
-	it('dispatches the move and refreshes feeds on success', async () => {
+	it('dispatches the single move and refreshes feeds on success', async () => {
 		mockDispatch
 			.mockResolvedValueOnce({ status: 204 })
 			.mockResolvedValueOnce(undefined)
 
-		await wrapper.vm.moveFeed()
+		await wrapper.vm.moveFeeds()
 
 		expect(mockDispatch).toHaveBeenNthCalledWith(1, FEED_ACTION_TYPES.MOVE_FEED, { feedId: 1, folderId: 2 })
 		expect(mockDispatch).toHaveBeenNthCalledWith(2, FEED_ACTION_TYPES.FETCH_FEEDS)
@@ -51,14 +51,76 @@ describe('MoveFeed.vue', () => {
 		expect(wrapper.emitted('close')).toHaveLength(1)
 	})
 
-	it('shows an error and keeps the dialog open when the move fails', async () => {
+	it('shows an error and keeps the dialog open when the single move fails', async () => {
 		mockDispatch.mockResolvedValueOnce({ status: 500 })
 
-		await wrapper.vm.moveFeed()
+		await wrapper.vm.moveFeeds()
 
 		expect(mockDispatch).toHaveBeenCalledTimes(1)
 		expect(mockDispatch).toHaveBeenCalledWith(FEED_ACTION_TYPES.MOVE_FEED, { feedId: 1, folderId: 2 })
 		expect(showError).toHaveBeenCalledWith('Unable to move feed. Please try again later or check your connection.')
 		expect(wrapper.emitted('close')).toBeUndefined()
+	})
+
+	it('dispatches the batched move and refreshes feeds on success', async () => {
+		mockDispatch
+			.mockResolvedValueOnce({ status: 204 })
+			.mockResolvedValueOnce({ status: 204 })
+			.mockResolvedValueOnce(undefined)
+
+		await wrapper.setProps({
+			feeds: [{ id: 1, folderId: 1 }, { id: 2 }],
+		})
+		await wrapper.vm.moveFeeds()
+
+		expect(mockDispatch).toHaveBeenNthCalledWith(1, FEED_ACTION_TYPES.MOVE_FEED, { feedId: 1, folderId: 2 })
+		expect(mockDispatch).toHaveBeenNthCalledWith(2, FEED_ACTION_TYPES.MOVE_FEED, { feedId: 2, folderId: 2 })
+		expect(mockDispatch).toHaveBeenNthCalledWith(3, FEED_ACTION_TYPES.FETCH_FEEDS)
+		expect(showError).not.toHaveBeenCalled()
+		expect(wrapper.emitted('close')).toHaveLength(1)
+	})
+
+	it('shows an error and closes the dialog when the batched move fails', async () => {
+		mockDispatch
+			.mockResolvedValueOnce({ status: 204 })
+			.mockResolvedValueOnce({ status: 500 })
+			.mockResolvedValueOnce(undefined)
+
+		await wrapper.setProps({
+			feeds: [{ id: 1, folderId: 1 }, { id: 2 }],
+		})
+		await wrapper.vm.moveFeeds()
+
+		expect(mockDispatch).toHaveBeenNthCalledWith(1, FEED_ACTION_TYPES.MOVE_FEED, { feedId: 1, folderId: 2 })
+		expect(mockDispatch).toHaveBeenNthCalledWith(2, FEED_ACTION_TYPES.MOVE_FEED, { feedId: 2, folderId: 2 })
+		expect(showError).toHaveBeenCalledWith('Some selected feeds could not be moved. Please try again later or check your connection.')
+		expect(wrapper.emitted('close')).toHaveLength(1)
+	})
+
+	it('should not disable move feed button when multiple feeds selected', async () => {
+		await wrapper.setProps({
+			feeds: [{ id: 1, folderId: 1 }, { id: 2 }],
+		})
+		const disableMove = wrapper.vm.$options.computed?.disableMoveFeed.call(wrapper.vm)
+
+		expect(disableMove).toBeFalsy()
+	})
+
+	it('should disable move feed button when selected folder is same than current feed folder', async () => {
+		await wrapper.setProps({
+			feeds: [{ id: 1, folderId: 2 }],
+		})
+		const disableMove = wrapper.vm.$options.computed?.disableMoveFeed.call(wrapper.vm)
+
+		expect(disableMove).toBeTruthy()
+	})
+
+	it('should disable move feed button when no feeds are selected', async () => {
+		await wrapper.setProps({
+			feeds: [],
+		})
+		const disableMove = wrapper.vm.$options.computed?.disableMoveFeed.call(wrapper.vm)
+
+		expect(disableMove).toBeTruthy()
 	})
 })

--- a/tests/javascript/unit/components/modals/FeedInfoTable.spec.ts
+++ b/tests/javascript/unit/components/modals/FeedInfoTable.spec.ts
@@ -89,11 +89,11 @@ describe('FeedInfoTable.vue', () => {
 		})
 
 		it('should set triggers to open and close move feed dialog', () => {
-			expect(wrapper.vm.feedToMove).toEqual(undefined)
+			expect(wrapper.vm.feedsToMove).toEqual([])
 			expect(wrapper.vm.showMoveFeed).toEqual(false)
 
 			wrapper.vm.openMoveFeed(feeds[0])
-			expect(wrapper.vm.feedToMove).toEqual(feeds[0])
+			expect(wrapper.vm.feedsToMove).toEqual([feeds[0]])
 			expect(wrapper.vm.showMoveFeed).toEqual(true)
 
 			wrapper.vm.closeMoveFeed(feeds[0])
@@ -185,7 +185,6 @@ describe('FeedInfoTable.vue', () => {
 
 			wrapper.vm.openMoveSelectedFeedsDialog()
 
-			expect(wrapper.vm.feedToMove).toEqual(undefined)
 			expect(wrapper.vm.feedsToMove).toEqual([feeds[0], feeds[1]])
 			expect(wrapper.vm.showMoveFeed).toEqual(true)
 		})


### PR DESCRIPTION
## Summary

This PR uses the showLoading toast to indicate the move action progress. It also remove redundant code by treating single move action as array with one element. Additionally two tests are added for the batch move action.  

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
