### PR TITLE
Release 28.4.1

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,6 +27,22 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Validate release tag matches app version
+        run: |
+          APP_VERSION="$(sed -n 's:.*<version>\(.*\)</version>.*:\1:p' appinfo/info.xml | head -n 1)"
+
+          if [[ -z "$APP_VERSION" ]]; then
+            echo "::error title=Unable to read app version::Could not find a <version> value in appinfo/info.xml."
+            exit 1
+          fi
+
+          if [[ "$GITHUB_REF_NAME" != "$APP_VERSION" ]]; then
+            echo "::error title=Release tag/version mismatch::Release tag '$GITHUB_REF_NAME' does not match appinfo/info.xml version '$APP_VERSION'. Update appinfo/info.xml before publishing this release."
+            exit 1
+          fi
+
+          echo "Release tag matches appinfo/info.xml version: $APP_VERSION"
+
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Fixed
 
 # Releases
+## [28.4.1] - 2026-05-22
+Added safety check for release process.
+
 ## [28.4.0] - 2026-05-15
 No notable changes since the beta release.
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,11 +21,10 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>28.4.0-beta.1</version>
+    <version>28.4.1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>
-    <author>Eryk J.</author>
     <author>Bernhard Posselt (former)</author>
     <author>Alessandro Cosentino (former)</author>
     <author>Jan-Christoph Borchardt (former)</author>


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

With the last release, the info.xml was not updated, due to the way how the release process works, this caused the new code to be released under the old version. Not that dramatic since the last version was a beta and functions the same as the stable release, but in other cases this could have negative consequences.

So I added a step that will fail the process, to create a release.

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
