### PR TITLE
Release 28.5.1-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 - Fixed News not starting since 28.5.0 due to php class loading issues (#3780)
 
 # Releases
+## [28.5.1-beta.1] - 2026-06-04
+### Fixed
+- Fixed News not starting since 28.5.0 due to php class loading issues (#3780)
+
 ## [28.5.0] - 2026-06-03
 ### Security
 - **Update recommended**: This version fixes a gap in the SSRF protection that occurs when the remote host redirects to a local address.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>28.5.0</version>
+    <version>28.5.1-beta.1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

### Fixed
- Fixed News not starting since 28.5.0 due to php class loading issues (#3780)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
