### PR TITLE
Release 28.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,19 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 
 # Unreleased
 ### Added
-- Support for Nextcloud Server 34 (Hub 26 spring) (#3786)
 
 ### Changed
 
 ### Fixed
-- Focus article view when item selected via keyboard navigation
 
 # Releases
+## [28.6.0] - 2026-06-08
+### Added
+- Added support for Nextcloud Server 34 "Hub 26 spring" (#3786)
+
+### Fixed
+- Focus article view when item selected via keyboard navigation (#3791)
+
 ## [28.5.1] - 2026-06-04
 No notable changes since the beta release.
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>28.6.0-beta.1</version>
+    <version>28.6.0</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION



* Resolves: # <!-- related github issue -->

## Summary
### Added
- Added support for Nextcloud Server 34 "Hub 26 spring" (#3786)

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
