### PR TITLE
fix(db): use correlated subqueries for feed unread/starred counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Added
 
 ### Changed
+- Optimize the feed listing query to use correlated subqueries for unread/starred counts instead of double LEFT JOINs with COUNT(DISTINCT), avoiding row multiplication and improving performance for feeds with many items.
 
 ### Fixed
 

--- a/lib/Db/FeedMapperV2.php
+++ b/lib/Db/FeedMapperV2.php
@@ -52,32 +52,34 @@ class FeedMapperV2 extends NewsMapperV2
     public function findAllFromUser(string $userId, array $params = []): array
     {
         $builder = $this->db->getQueryBuilder();
+
+        $unreadCount = $this->db->getQueryBuilder();
+        $unreadCount->select($unreadCount->createFunction('COUNT(*)'))
+            ->from(ItemMapperV2::TABLE_NAME, 'items_unread')
+            ->where('items_unread.feed_id = feeds.id')
+            ->andWhere('items_unread.unread = :unread');
+        $unreadSQL = $unreadCount->getSQL();
+
+        $starredCount = $this->db->getQueryBuilder();
+        $starredCount->select($starredCount->createFunction('COUNT(*)'))
+            ->from(ItemMapperV2::TABLE_NAME, 'items_starred')
+            ->where('items_starred.feed_id = feeds.id')
+            ->andWhere('items_starred.starred = :starred');
+        $starredSQL = $starredCount->getSQL();
+
         $builder
             ->select('feeds.*')
             ->selectAlias(
-                $builder->createFunction('COUNT(DISTINCT items_unread.id)'),
+                $builder->createFunction('(' . $unreadSQL . ')'),
                 'unreadCount'
             )
             ->selectAlias(
-                $builder->createFunction('COUNT(DISTINCT items_starred.id)'),
+                $builder->createFunction('(' . $starredSQL . ')'),
                 'starredCount'
             )
             ->from(static::TABLE_NAME, 'feeds')
-            ->leftJoin(
-                'feeds',
-                ItemMapperV2::TABLE_NAME,
-                'items_unread',
-                'items_unread.feed_id = feeds.id AND items_unread.unread = :unread'
-            )
-            ->leftJoin(
-                'feeds',
-                ItemMapperV2::TABLE_NAME,
-                'items_starred',
-                'items_starred.feed_id = feeds.id AND items_starred.starred = :starred'
-            )
             ->where('feeds.user_id = :user_id')
             ->andWhere('feeds.deleted_at = 0')
-            ->groupBy('feeds.id')
             ->setParameter('unread', true, IQueryBuilder::PARAM_BOOL)
             ->setParameter('starred', true, IQueryBuilder::PARAM_BOOL)
             ->setParameter('user_id', $userId)

--- a/tests/Unit/Db/FeedMapperTest.php
+++ b/tests/Unit/Db/FeedMapperTest.php
@@ -63,18 +63,75 @@ class FeedMapperTest extends MapperTestUtility
      */
     public function testFindAllFromUser()
     {
-        $this->db->expects($this->once())
+        $unreadBuilder = $this->getMockBuilder(IQueryBuilder::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $starredBuilder = $this->getMockBuilder(IQueryBuilder::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $funcCount = $this->getMockBuilder(IQueryFunction::class)->getMock();
+        $funcUnread = $this->getMockBuilder(IQueryFunction::class)->getMock();
+        $funcStarred = $this->getMockBuilder(IQueryFunction::class)->getMock();
+
+        $this->db->expects($this->exactly(3))
                  ->method('getQueryBuilder')
-                 ->willReturn($this->builder);
+                 ->willReturnOnConsecutiveCalls($this->builder, $unreadBuilder, $starredBuilder);
 
-        $funcUnread = $this->getMockBuilder(IQueryFunction::class)
-                      ->getMock();
-        $funcStarred = $this->getMockBuilder(IQueryFunction::class)
-                      ->getMock();
+        // Unread count subquery
+        $unreadBuilder->expects($this->once())
+            ->method('createFunction')
+            ->with('COUNT(*)')
+            ->willReturn($funcCount);
+        $unreadBuilder->expects($this->once())
+            ->method('select')
+            ->with($funcCount)
+            ->will($this->returnSelf());
+        $unreadBuilder->expects($this->once())
+            ->method('from')
+            ->with('news_items', 'items_unread')
+            ->will($this->returnSelf());
+        $unreadBuilder->expects($this->once())
+            ->method('where')
+            ->with('items_unread.feed_id = feeds.id')
+            ->will($this->returnSelf());
+        $unreadBuilder->expects($this->once())
+            ->method('andWhere')
+            ->with('items_unread.unread = :unread')
+            ->will($this->returnSelf());
+        $unreadBuilder->expects($this->once())
+            ->method('getSQL')
+            ->willReturn('UNREAD_SQL');
 
+        // Starred count subquery
+        $starredBuilder->expects($this->once())
+            ->method('createFunction')
+            ->with('COUNT(*)')
+            ->willReturn($funcCount);
+        $starredBuilder->expects($this->once())
+            ->method('select')
+            ->with($funcCount)
+            ->will($this->returnSelf());
+        $starredBuilder->expects($this->once())
+            ->method('from')
+            ->with('news_items', 'items_starred')
+            ->will($this->returnSelf());
+        $starredBuilder->expects($this->once())
+            ->method('where')
+            ->with('items_starred.feed_id = feeds.id')
+            ->will($this->returnSelf());
+        $starredBuilder->expects($this->once())
+            ->method('andWhere')
+            ->with('items_starred.starred = :starred')
+            ->will($this->returnSelf());
+        $starredBuilder->expects($this->once())
+            ->method('getSQL')
+            ->willReturn('STARRED_SQL');
+
+        // Main query
         $createFunctionCalls = [
-            ['COUNT(DISTINCT items_unread.id)'],
-            ['COUNT(DISTINCT items_starred.id)']
+            ['(UNREAD_SQL)'],
+            ['(STARRED_SQL)']
         ];
         $createFunctionReturns = [$funcUnread, $funcStarred];
         $createFunctionIndex = 0;
@@ -109,19 +166,6 @@ class FeedMapperTest extends MapperTestUtility
                       ->with('news_feeds', 'feeds')
                       ->will($this->returnSelf());
 
-        $leftJoinCalls = [
-            ['feeds', 'news_items', 'items_unread', 'items_unread.feed_id = feeds.id AND items_unread.unread = :unread'],
-            ['feeds', 'news_items', 'items_starred', 'items_starred.feed_id = feeds.id AND items_starred.starred = :starred']
-        ];
-        $leftJoinIndex = 0;
-
-        $this->builder->expects($this->exactly(2))
-                      ->method('leftJoin')
-                      ->willReturnCallback(function (...$args) use (&$leftJoinCalls, &$leftJoinIndex) {
-                          $this->assertEquals($leftJoinCalls[$leftJoinIndex++], $args);
-                          return $this->builder;
-                      });
-
         $this->builder->expects($this->once())
                       ->method('where')
                       ->with('feeds.user_id = :user_id')
@@ -130,11 +174,6 @@ class FeedMapperTest extends MapperTestUtility
         $this->builder->expects($this->once())
                       ->method('andWhere')
                       ->with('feeds.deleted_at = 0')
-                      ->will($this->returnSelf());
-
-        $this->builder->expects($this->once())
-                      ->method('groupby')
-                      ->with('feeds.id')
                       ->will($this->returnSelf());
 
         $setParameterCalls = [
@@ -150,6 +189,11 @@ class FeedMapperTest extends MapperTestUtility
                           $this->assertEquals($setParameterCalls[$setParameterIndex++], $args);
                           return $this->builder;
                       });
+
+        $this->builder->expects($this->once())
+                      ->method('addOrderBy')
+                      ->with('feeds.title')
+                      ->will($this->returnSelf());
 
         $this->builder->expects($this->once())
                       ->method('executeQuery')


### PR DESCRIPTION
* Resolves: #3826

Note: AI assisted with Opencode using Qwen 3.6 27b q6 and GLM 5.2

## Summary

`FeedMapperV2::findAllFromUser` (the per-user feed list, used to render the sidebar and feed list) joined `news_items` onto `news_feeds` twice — once for unread items and once for starred items — and relied on `COUNT(DISTINCT ...)` to undo the row multiplication those two joins introduce.

For a feed with **U** unread and **S** starred items, the join produced **U × S** intermediate rows *before* the `GROUP BY`; `COUNT(DISTINCT ...)` then had to deduplicate that whole set. This is wasted work and gets materially worse as items accumulate, since both counts are computed for every feed on every request regardless of how few items actually match.

This replaces the double `LEFT JOIN` + `GROUP BY` + `COUNT(DISTINCT ...)` with two correlated scalar subqueries in the `SELECT` list. Each count is now a single index range scan per feed against the existing indexes (`news_items_unread_feed_id`, `news_items_starred_feed_id`), with no row multiplication, no `GROUP BY`, and no `DISTINCT`. The returned columns and result set are unchanged.

Before:
```sql
SELECT feeds.*,
       COUNT(DISTINCT items_unread.id)   AS unreadCount,
       COUNT(DISTINCT items_starred.id) AS starredCount
FROM oc_news_feeds feeds
LEFT JOIN oc_news_items items_unread   ON items_unread.feed_id  = feeds.id AND items_unread.unread  = 1
LEFT JOIN oc_news_items items_starred  ON items_starred.feed_id = feeds.id AND items_starred.starred = 1
WHERE feeds.user_id = ? AND feeds.deleted_at = 0
GROUP BY feeds.id
ORDER BY feeds.title ASC;
```

After:
```sql
SELECT feeds.*,
       (SELECT COUNT(*) FROM oc_news_items i WHERE i.feed_id = feeds.id AND i.unread   = 1) AS unreadCount,
       (SELECT COUNT(*) FROM oc_news_items i WHERE i.feed_id = feeds.id AND i.starred  = 1) AS starredCount
FROM oc_news_feeds feeds
WHERE feeds.user_id = ? AND feeds.deleted_at = 0
ORDER BY feeds.title ASC;
```

The unit test `FeedMapperTest::testFindAllFromUser` is updated to assert the new query-builder calls (subquery builders + scalar `selectAlias` instead of `leftJoin`/`groupBy`).

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
