### PR TITLE
Release 28.7.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Added
 
 ### Changed
-- Optimize the feed listing query to use correlated subqueries for unread/starred counts instead of double LEFT JOINs with COUNT(DISTINCT), avoiding row multiplication and improving performance for feeds with many items.
 
 ### Fixed
-- Preserve the RSS-provided lead image when web content scraping (full text) is enabled by injecting it into the scraped article body if missing — keeps the lead image visible in the web app and in third-party clients (iOS, etc.) that render only the body
+
 
 # Releases
+## [28.7.0-beta.1] - 2026-07-19
+### Changed
+- Optimize the feed listing query to use correlated subqueries for unread/starred counts instead of double LEFT JOINs with COUNT(DISTINCT), avoiding row multiplication and improving performance for feeds with many items. (#3827)
+- Preserve the RSS-provided lead image when web content scraping (full text) is enabled by injecting it into the scraped article body if missing — keeps the lead image visible in the web app and in third-party clients (iOS, etc.) that render only the body (#3738)
+
 ## [28.6.0] - 2026-06-08
 ### Added
 - Added support for Nextcloud Server 34 "Hub 26 spring" (#3786)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ Create a [feature request](https://github.com/nextcloud/news/discussions/new)
 
 Report a [feed issue](https://github.com/nextcloud/news/discussions/new)
     ]]></description>
-    <version>28.6.0</version>
+    <version>28.7.0-beta.1</version>
     <licence>agpl</licence>
     <author>Benjamin Brahmer</author>
     <author>Sean Molenaar</author>


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

### Changed

- Optimize the feed listing query to use correlated subqueries for unread/starred counts instead of double LEFT JOINs with COUNT(DISTINCT), avoiding row multiplication and improving performance for feeds with many items. (#3827)
- Preserve the RSS-provided lead image when web content scraping (full text) is enabled by injecting it into the scraped article body if missing — keeps the lead image visible in the web app and in third-party clients (iOS, etc.) that render only the body (#3738)


## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
