### PR TITLE
fix(eslint): use consistent type imports

### DIFF
--- a/src/components/ContentTemplate.vue
+++ b/src/components/ContentTemplate.vue
@@ -66,14 +66,13 @@
  * for more information, see https://vuejs.org/guide/extras/composition-api-faq.html
  */
 
+import type { PropType } from 'vue'
 import type { FeedItem } from '../types/FeedItem.ts'
 
 import { getBuilder } from '@nextcloud/browser-storage'
 import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import {
-	type PropType,
-
 	computed,
 	nextTick,
 	onBeforeMount,


### PR DESCRIPTION
## Summary

<!-- your text -->

Fix linting error introduced with #3831

> feat(import): enforce consistent types imports and ban usage of inline type specifiers

## Checklist

- Code is [properly formatted](https://nextcloud.github.io/news/developer/#coding-style-guidelines)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- Changelog entry added for all important changes.
