### PR TITLE
Reload on token-expired app error

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -55,6 +55,8 @@ import NcContent from '@nextcloud/vue/components/NcContent'
 import Sidebar from './components/Sidebar.vue'
 import { ACTIONS, MUTATIONS } from './store/index.ts'
 
+const TOKEN_EXPIRED_ERROR = 'Token expired or app not enabled! Reload the page!'
+
 export default defineComponent({
 	components: {
 		NcContent,
@@ -69,6 +71,17 @@ export default defineComponent({
 		...mapState(['app']),
 	},
 
+	watch: {
+		'app.error': {
+			immediate: true,
+			handler(error) {
+				if (typeof error?.message === 'string' && error.message.includes(TOKEN_EXPIRED_ERROR)) {
+					this.reloadPage()
+				}
+			},
+		},
+	},
+
 	async created() {
 		// fetch folders and feeds to build side bar
 		await this.$store.dispatch(ACTIONS.FETCH_FOLDERS)
@@ -78,6 +91,10 @@ export default defineComponent({
 	},
 
 	methods: {
+		reloadPage() {
+			window.location.reload()
+		},
+
 		stopPlaying() {
 			this.$store.commit(MUTATIONS.SET_PLAYING_ITEM, undefined)
 		},

--- a/tests/javascript/unit/components/App.spec.ts
+++ b/tests/javascript/unit/components/App.spec.ts
@@ -58,4 +58,13 @@ describe('FeedItemDisplay.vue', () => {
 
 		expect(commitStub).toBeCalledWith(MUTATIONS.SET_ERROR, undefined)
 	})
+
+	it('should reload when token error is shown', () => {
+		const reloadSpy = vi.spyOn(wrapper.vm, 'reloadPage').mockImplementation(() => {})
+		const error = new Error('Token expired or app not enabled! Reload the page!')
+
+		wrapper.vm.$options.watch['app.error'].handler.call(wrapper.vm, error)
+
+		expect(reloadSpy).toHaveBeenCalled()
+	})
 })


### PR DESCRIPTION
This adds a small App.vue watcher that reloads the page when the news app reports the "Token expired or app not enabled! Reload the page!" error, plus a unit test.

Refs #638.