### PR TITLE
Allow OPML import with .xml file extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ You can also check [on GitHub](https://github.com/nextcloud/news/releases), the 
 ### Changed
 
 ### Fixed
+- Allow OPML import with `.xml` file extension (#3888)
 
 
 # Releases

--- a/src/components/modals/AppSettingsDialog.vue
+++ b/src/components/modals/AppSettingsDialog.vue
@@ -100,7 +100,7 @@
 						ref="fileSelect"
 						type="file"
 						class="hidden"
-						accept=".opml"
+						accept=".opml,.xml"
 						@change="importOpml">
 
 					<NcButton
@@ -510,7 +510,7 @@ export default defineComponent({
 		async importOpml(event) {
 			let result
 			const file = event.target.files[0]
-			if (!file || !file.name.endsWith('.opml')) {
+			if (!file || !(file.name.endsWith('.opml') || file.name.endsWith('.xml'))) {
 				result = { type: 'error', message: t('news', 'Please select a valid OPML file') }
 				this.$store.commit(MUTATIONS.SET_OPML_IMPORT_MESSAGE, { value: result })
 				return


### PR DESCRIPTION
## Summary
- Allow OPML import file picker / client-side check to accept `.xml` as well as `.opml`.
- Backend already validates by content; this unblocks FreshRSS/Inoreader `.xml` exports.

Fixes #3866

## Test plan
- [ ] Import a FreshRSS/Inoreader `.xml` OPML export via settings — file is accepted.
- [ ] Import a classic `.opml` file — still works.
